### PR TITLE
Use indexed wallet for config lookup - (alt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ coverage
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+
+.nyc_output/

--- a/packages/0xsequence/tests/browser/mock-wallet/mock-wallet.test.ts
+++ b/packages/0xsequence/tests/browser/mock-wallet/mock-wallet.test.ts
@@ -46,7 +46,7 @@ const main = async () => {
   const relayer2 = new LocalRelayer(getEOAWallet(testAccounts[5].privateKey, provider2))
   
 
-  // wallet account address: 0x24E78922FE5eCD765101276A422B8431d7151259 based on the chainId
+  // wallet account address: 0xfbbabe29b5ec5fcd0beead9fa1c7f367bb985e9d based on the chainId
   const wallet = (await Wallet.singleOwner(owner, deployedWalletContext)).connect(provider, relayer)
 
   // Network available list

--- a/packages/0xsequence/tests/browser/mux-transport/mux.test.ts
+++ b/packages/0xsequence/tests/browser/mux-transport/mux.test.ts
@@ -52,7 +52,7 @@ export const tests = async () => {
   const relayer2 = new LocalRelayer(getEOAWallet(testAccounts[5].privateKey, provider2))
 
 
-  // wallet account address: 0x24E78922FE5eCD765101276A422B8431d7151259 based on the chainId
+  // wallet account address: 0xfbbabe29b5ec5fcd0beead9fa1c7f367bb985e9d based on the chainId
   const swallet = (await SequenceWallet.singleOwner(owner, deployedWalletContext)).connect(provider1, relayer1)
 
   // Network available list

--- a/packages/0xsequence/tests/browser/proxy-transport/channel.test.ts
+++ b/packages/0xsequence/tests/browser/proxy-transport/channel.test.ts
@@ -37,7 +37,7 @@ export const tests = async () => {
   // relayer account is same as owner here
   const relayer = new LocalRelayer(owner)
 
-  // wallet account address: 0x24E78922FE5eCD765101276A422B8431d7151259 based on the chainId
+  // wallet account address: 0xfbbabe29b5ec5fcd0beead9fa1c7f367bb985e9d based on the chainId
   const rpcProvider = new JsonRpcProvider('http://localhost:8545')
   const wallet = (await Wallet.singleOwner(owner)).connect(rpcProvider, relayer)
 
@@ -64,7 +64,7 @@ export const tests = async () => {
   const address = await signer.getAddress()
 
   await test('verifying getAddress result', async () => {
-    assert.equal(address.toLowerCase(), '0x24E78922FE5eCD765101276A422B8431d7151259'.toLowerCase(), 'wallet address')
+    assert.equal(address.toLowerCase(), '0xfbbabe29b5ec5fcd0beead9fa1c7f367bb985e9d'.toLowerCase(), 'wallet address')
   })
 
   await test('sending a json-rpc request', async () => {
@@ -95,7 +95,7 @@ export const tests = async () => {
     const sig = await signer.signMessage(message)
     assert.equal(
       sig,
-      '0x000100011ec026ba887f4237db570b1546f9e793fafecbc08df331253b385e35ae7d9107020143f742d3f6768a978b7a4c32b003deb15f3d010805436db1cb9332104d8e1b02',
+      '0x00010001adeb90fa6d1d11a249be655249d430e8520d51921e8c9590fee9ba4676e88cac7f4c92d6dfa8cee5609d7eb6464d81d81bda6194f0ae7c129925ff286cb779e61c02',
       'signature match'
     )
 

--- a/packages/0xsequence/tests/browser/testutils/deploy-wallet-context.ts
+++ b/packages/0xsequence/tests/browser/testutils/deploy-wallet-context.ts
@@ -64,5 +64,5 @@ export const testWalletContext: WalletContext = {
   guestModule: "0x872eA617FED42056cDcEB3979838eba48A72FE41",
   mainModule: "0xBbC50F0Dc98B5CcE607f7413c589F9247dd28Ac7",
   mainModuleUpgradable: "0x38364BC14E370C3c5D8Af99A040c24734AB7Cad6",
-  sequenceUtils: "0x10c1c71fb43017d5b968dFea38694632818489b8"
+  sequenceUtils: "0x1086Fcc8c7f296625f1163fcA9b21e7CD7Fa697b"
 }

--- a/packages/abi/src/wallet/sequenceUtils.ts
+++ b/packages/abi/src/wallet/sequenceUtils.ts
@@ -1,346 +1,456 @@
 export const abi = [
   {
-    type: 'function',
-    name: 'requireNonExpired',
-    constant: true,
     inputs: [
       {
-        type: 'uint256'
-      }
-    ],
-    outputs: [],
-    payable: false,
-    stateMutability: 'view'
-  },
-  {
-    type: 'function',
-    name: 'requireMinNonce',
-    constant: true,
-    inputs: [
-      {
-        type: 'address'
+        internalType: "address",
+        name: "_factory",
+        type: "address"
       },
       {
-        type: 'uint256'
+        internalType: "address",
+        name: "_mainModule",
+        type: "address"
       }
     ],
-    outputs: [],
-    payable: false,
-    stateMutability: 'view'
-  },
-  {
-    type: 'function',
-    name: 'requireConfig',
-    constant: false,
-    inputs: [
-      {
-        type: 'address'
-      },
-      {
-        type: 'uint256'
-      },
-      {
-        components: [
-          {
-            type: 'uint256',
-            name: 'weight'
-          },
-          {
-            type: 'address',
-            name: 'signer'
-          }
-        ],
-        type: 'tuple[]'
-      }
-    ],
-    outputs: [],
-    payable: false,
-    stateMutability: 'nonpayable'
+    stateMutability: "nonpayable",
+    type: "constructor"
   },
   {
     anonymous: false,
     inputs: [
       {
-        indexed: true,
-        internalType: 'address',
-        name: '_wallet',
-        type: 'address'
+        "indexed": true,
+        internalType: "address",
+        name: "_wallet",
+        type: "address"
       },
       {
-        indexed: true,
-        internalType: 'bytes32',
-        name: '_imageHash',
-        type: 'bytes32'
+        "indexed": true,
+        internalType: "bytes32",
+        name: "_imageHash",
+        type: "bytes32"
       },
       {
-        indexed: false,
-        internalType: 'uint256',
-        name: '_threshold',
-        type: 'uint256'
+        "indexed": false,
+        internalType: "uint256",
+        name: "_threshold",
+        type: "uint256"
       },
       {
-        indexed: false,
-        internalType: 'bytes',
-        name: '_signers',
-        type: 'bytes'
+        "indexed": false,
+        internalType: "bytes",
+        name: "_signers",
+        type: "bytes"
       }
     ],
-    name: 'RequiredConfig',
-    type: 'event'
+    name: "RequiredConfig",
+    type: "event"
   },
   {
     inputs: [
       {
-        internalType: 'address',
-        name: '_addr',
-        type: 'address'
+        internalType: "address",
+        name: "_addr",
+        type: "address"
       }
     ],
-    name: 'callBalanceOf',
+    name: "callBalanceOf",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callBlockNumber',
+    name: "callBlockNumber",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [
       {
-        internalType: 'uint256',
-        name: '_i',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "_i",
+        type: "uint256"
       }
     ],
-    name: 'callBlockhash',
+    name: "callBlockhash",
     outputs: [
       {
-        internalType: 'bytes32',
-        name: '',
-        type: 'bytes32'
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [],
+    name: "callChainId",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "id",
+        type: "uint256"
+      }
+    ],
+    stateMutability: "pure",
+    type: "function"
   },
   {
     inputs: [
       {
-        internalType: 'address',
-        name: '_addr',
-        type: 'address'
+        internalType: "address",
+        name: "_addr",
+        type: "address"
       }
     ],
-    name: 'callCode',
+    name: "callCode",
     outputs: [
       {
-        internalType: 'bytes',
-        name: 'code',
-        type: 'bytes'
+        internalType: "bytes",
+        name: "code",
+        type: "bytes"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [
       {
-        internalType: 'address',
-        name: '_addr',
-        type: 'address'
+        internalType: "address",
+        name: "_addr",
+        type: "address"
       }
     ],
-    name: 'callCodeHash',
+    name: "callCodeHash",
     outputs: [
       {
-        internalType: 'bytes32',
-        name: 'codeHash',
-        type: 'bytes32'
+        internalType: "bytes32",
+        name: "codeHash",
+        type: "bytes32"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [
       {
-        internalType: 'address',
-        name: '_addr',
-        type: 'address'
+        internalType: "address",
+        name: "_addr",
+        type: "address"
       }
     ],
-    name: 'callCodeSize',
+    name: "callCodeSize",
     outputs: [
       {
-        internalType: 'uint256',
-        name: 'size',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "size",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callCoinbase',
+    name: "callCoinbase",
     outputs: [
       {
-        internalType: 'address',
-        name: '',
-        type: 'address'
+        internalType: "address",
+        name: "",
+        type: "address"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callDifficulty',
+    name: "callDifficulty",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callGasLeft',
+    name: "callGasLeft",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callGasLimit',
+    name: "callGasLimit",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callGasPrice',
+    name: "callGasPrice",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callOrigin',
+    name: "callOrigin",
     outputs: [
       {
-        internalType: 'address',
-        name: '',
-        type: 'address'
+        internalType: "address",
+        name: "",
+        type: "address"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [],
-    name: 'callTimestamp',
+    name: "callTimestamp",
     outputs: [
       {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
       }
     ],
-    stateMutability: 'view',
-    type: 'function'
+    stateMutability: "view",
+    type: "function"
   },
   {
     inputs: [
       {
-        'components': [
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32"
+      }
+    ],
+    name: "imageHashBlockHeight",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
+      }
+    ],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address"
+      }
+    ],
+    name: "initialImageHash",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32"
+      }
+    ],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        components: [
           {
-            internalType: 'bool',
-            name: 'delegateCall',
-            type: 'bool'
+            internalType: "bool",
+            name: "delegateCall",
+            type: "bool"
           },
           {
-            internalType: 'bool',
-            name: 'revertOnError',
-            type: 'bool'
+            internalType: "bool",
+            name: "revertOnError",
+            type: "bool"
           },
           {
-            internalType: 'uint256',
-            name: 'gasLimit',
-            type: 'uint256'
+            internalType: "uint256",
+            name: "gasLimit",
+            type: "uint256"
           },
           {
-            internalType: 'address',
-            name: 'target',
-            type: 'address'
+            internalType: "address",
+            name: "target",
+            type: "address"
           },
           {
-            internalType: 'uint256',
-            name: 'value',
-            type: 'uint256'
+            internalType: "uint256",
+            name: "value",
+            type: "uint256"
           },
           {
-            internalType: 'bytes',
-            name: 'data',
-            type: 'bytes'
+            internalType: "bytes",
+            name: "data",
+            type: "bytes"
           }
         ],
-        internalType: 'struct IModuleCalls.Transaction[]',
-        name: '_txs',
-        type: 'tuple[]'
+        internalType: "struct IModuleCalls.Transaction[]",
+        name: "_txs",
+        type: "tuple[]"
       }
     ],
-    name: 'multiCall',
+    name: "multiCall",
     outputs: [
       {
-        internalType: 'bool[]',
-        name: '_successes',
-        type: 'bool[]'
+        internalType: "bool[]",
+        name: "_successes",
+        type: "bool[]"
       },
       {
-        internalType: 'bytes[]',
-        name: '_results',
-        type: 'bytes[]'
+        internalType: "bytes[]",
+        name: "_results",
+        type: "bytes[]"
       }
     ],
-    stateMutability: 'nonpayable',
-    type: 'function'
+    stateMutability: "payable",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_wallet",
+        type: "address"
+      },
+      {
+        internalType: "uint256",
+        name: "_threshold",
+        type: "uint256"
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "weight",
+            type: "uint256"
+          },
+          {
+            internalType: "address",
+            name: "signer",
+            type: "address"
+          }
+        ],
+        internalType: "struct RequireUtils.Member[]",
+        name: "_members",
+        type: "tuple[]"
+      }
+    ],
+    name: "requireAndIndexConfig",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_wallet",
+        type: "address"
+      },
+      {
+        internalType: "uint256",
+        name: "_threshold",
+        type: "uint256"
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "weight",
+            type: "uint256"
+          },
+          {
+            internalType: "address",
+            name: "signer",
+            type: "address"
+          }
+        ],
+        internalType: "struct RequireUtils.Member[]",
+        name: "_members",
+        type: "tuple[]"
+      }
+    ],
+    name: "requireConfig",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_wallet",
+        type: "address"
+      },
+      {
+        internalType: "uint256",
+        name: "_nonce",
+        type: "uint256"
+      }
+    ],
+    name: "requireMinNonce",
+    outputs: [],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_expiration",
+        type: "uint256"
+      }
+    ],
+    name: "requireNonExpired",
+    outputs: [],
+    stateMutability: "view",
+    type: "function"
   }
 ]

--- a/packages/abi/src/wallet/sequenceUtils.ts
+++ b/packages/abi/src/wallet/sequenceUtils.ts
@@ -19,31 +19,50 @@ export const abi = [
     anonymous: false,
     inputs: [
       {
-        "indexed": true,
+        indexed: true,
         internalType: "address",
         name: "_wallet",
         type: "address"
       },
       {
-        "indexed": true,
+        indexed: true,
         internalType: "bytes32",
         name: "_imageHash",
         type: "bytes32"
       },
       {
-        "indexed": false,
+        indexed: false,
         internalType: "uint256",
         name: "_threshold",
         type: "uint256"
       },
       {
-        "indexed": false,
+        indexed: false,
         internalType: "bytes",
         name: "_signers",
         type: "bytes"
       }
     ],
     name: "RequiredConfig",
+    type: "event"
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_wallet",
+        type: "address"
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_signer",
+        type: "address"
+      }
+    ],
+    name: "RequiredSigner",
     type: "event"
   },
   {
@@ -261,12 +280,12 @@ export const abi = [
   {
     inputs: [
       {
-        internalType: "bytes32",
+        internalType: "address",
         name: "",
-        type: "bytes32"
+        type: "address"
       }
     ],
-    name: "imageHashBlockHeight",
+    name: "lastSignerUpdate",
     outputs: [
       {
         internalType: "uint256",
@@ -285,12 +304,12 @@ export const abi = [
         type: "address"
       }
     ],
-    name: "initialImageHash",
+    name: "lastWalletUpdate",
     outputs: [
       {
-        internalType: "bytes32",
+        internalType: "uint256",
         name: "",
-        type: "bytes32"
+        type: "uint256"
       }
     ],
     stateMutability: "view",
@@ -380,9 +399,14 @@ export const abi = [
         internalType: "struct RequireUtils.Member[]",
         name: "_members",
         type: "tuple[]"
+      },
+      {
+        internalType: "bool",
+        name: "_index",
+        type: "bool"
       }
     ],
-    name: "requireAndIndexConfig",
+    name: "publishConfig",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function"
@@ -395,29 +419,27 @@ export const abi = [
         type: "address"
       },
       {
+        internalType: "bytes32",
+        name: "_hash",
+        type: "bytes32"
+      },
+      {
         internalType: "uint256",
-        name: "_threshold",
+        name: "_sizeMembers",
         type: "uint256"
       },
       {
-        components: [
-          {
-            internalType: "uint256",
-            name: "weight",
-            type: "uint256"
-          },
-          {
-            internalType: "address",
-            name: "signer",
-            type: "address"
-          }
-        ],
-        internalType: "struct RequireUtils.Member[]",
-        name: "_members",
-        type: "tuple[]"
+        internalType: "bytes",
+        name: "_signature",
+        type: "bytes"
+      },
+      {
+        internalType: "bool",
+        name: "_index",
+        type: "bool"
       }
     ],
-    name: "requireConfig",
+    name: "publishInitialSigners",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function"

--- a/packages/multicall/package.json
+++ b/packages/multicall/package.json
@@ -20,7 +20,7 @@
     "ethers": "^5.0.26"
   },
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#indexed-require-config",
+    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#alt-indexed-require-config",
     "@types/web3-provider-engine": "^14.0.0",
     "eth-json-rpc-middleware": "^6.0.0",
     "json-rpc-engine": "^6.1.0",

--- a/packages/multicall/package.json
+++ b/packages/multicall/package.json
@@ -20,7 +20,7 @@
     "ethers": "^5.0.26"
   },
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts",
+    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#indexed-require-config",
     "@types/web3-provider-engine": "^14.0.0",
     "eth-json-rpc-middleware": "^6.0.0",
     "json-rpc-engine": "^6.1.0",

--- a/packages/multicall/package.json
+++ b/packages/multicall/package.json
@@ -20,7 +20,7 @@
     "ethers": "^5.0.26"
   },
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#alt-indexed-require-config",
+    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts",
     "@types/web3-provider-engine": "^14.0.0",
     "eth-json-rpc-middleware": "^6.0.0",
     "json-rpc-engine": "^6.1.0",

--- a/packages/network/src/context.ts
+++ b/packages/network/src/context.ts
@@ -12,9 +12,9 @@ export interface WalletContext {
 
 // sequenceContext are the deployed addresses of modules available on public networks.
 export const sequenceContext: WalletContext = {
-  factory: '0x878C961C6da18574e5a09069E541bDb6627eA65c',
-  mainModule: '0x444C9327FF4e8fbF109ed6d22B96F83bb3cf3A06',
-  mainModuleUpgradable: '0xCdB2f31BCe8c41E731c88BCB14A6692AC09e1C6e',
-  guestModule: '0x0aA220BAdC3FD541b68A811bc46198Eadfc7A162',
-  sequenceUtils: '0xc7406c1556859C567C06f2b8A9356B9D83dfB341'
+  factory: '0x6813Da82a84e31f98824146a50d9Ba0Fbd4cbF14',
+  mainModule: '0xBf7aa3d072d4052D894cDd32EC818B02D9ba4FeC',
+  mainModuleUpgradable: '0xc97c6276702A89741F2313d2F8fC9C7D4dC86128',
+  guestModule: '0xd1345a45Cc1Dc792389a85d722CB911118Bb52Ef',
+  sequenceUtils: '0x6fA52553CCFB101f26d55a7342F84A10e1054E58'
 }

--- a/packages/wallet/.nycrc
+++ b/packages/wallet/.nycrc
@@ -1,0 +1,5 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": true
+}

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts",
+    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#indexed-require-config",
     "ganache-core": "^2.13.2",
     "nyc": "^15.1.0",
     "web3": "^1.3.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#indexed-require-config",
+    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#alt-indexed-require-config",
     "ganache-core": "^2.13.2",
     "nyc": "^15.1.0",
     "web3": "^1.3.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -32,7 +32,8 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts#alt-indexed-require-config",
+    "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts",
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "ganache-core": "^2.13.2",
     "nyc": "^15.1.0",
     "web3": "^1.3.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "test": "yarn test:file tests/**/*.spec.ts",
     "test:file": "TS_NODE_PROJECT=../../tsconfig.test.json mocha -r ts-node/register --timeout 30000",
+    "coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@0xsequence/wallet-contracts": "https://github.com/0xsequence/wallet-contracts",
     "ganache-core": "^2.13.2",
+    "nyc": "^15.1.0",
     "web3": "^1.3.1",
     "web3-typescript-typings": "^0.10.2"
   },

--- a/packages/wallet/src/account.ts
+++ b/packages/wallet/src/account.ts
@@ -321,7 +321,7 @@ export class Account extends Signer {
     const logBlockHeight = (await authContract.lastWalletUpdate(this.address)).toNumber()
     const filter = authContract.filters.RequiredConfig(this.address)
     const lastLog = await findLatestLog(authWallet.provider, { ...filter, fromBlock: logBlockHeight, toBlock: logBlockHeight !== 0 ? logBlockHeight : 'latest'})
-    if (lastLog === undefined) { console.log("LOG NOT FOUND"); return undefined }
+    if (lastLog === undefined) { console.warn("publishConfig: wallet config last log not found"); return undefined }
     const event = authContract.interface.decodeEventLog('RequiredConfig', lastLog.data, lastLog.topics)
 
     const signers = ethers.utils.defaultAbiCoder.decode(

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -604,7 +604,7 @@ export class Wallet extends Signer {
       data: sequenceUtilsInterface.encodeFunctionData(sequenceUtilsInterface.getFunction('publishInitialSigners'), 
         [
           this.address,
-          subDigest,
+          ethers.utils.keccak256(message),
           this.config.signers.length,
           signature,
           index

--- a/packages/wallet/tests/account.spec.ts
+++ b/packages/wallet/tests/account.spec.ts
@@ -117,8 +117,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.publishedImageHash)
-      expect(state.publishedImageHash).to.equal(imageHash(currentConfig))
+      expect(state.imageHash).to.not.equal(state.lastImageHash)
+      expect(state.lastImageHash).to.equal(imageHash(currentConfig))
     })
 
     it('should update config and get current config from chain, not indexed', async () => {
@@ -155,8 +155,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.publishedImageHash)
-      expect(state.publishedImageHash).to.equal(imageHash(currentConfig))
+      expect(state.imageHash).to.not.equal(state.lastImageHash)
+      expect(state.lastImageHash).to.equal(imageHash(currentConfig))
     })
 
     it('should find current config from published config on counter-factual wallet', async () => {
@@ -191,8 +191,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.publishedImageHash)
-      expect(state.publishedImageHash).to.equal('')
+      expect(state.imageHash).to.not.equal(state.lastImageHash)
+      expect(state.lastImageHash).to.equal('')
     })
 
     it('should find current config from published config on counter-factual wallet, not indexed', async () => {
@@ -227,8 +227,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.publishedImageHash)
-      expect(state.publishedImageHash).to.equal('')
+      expect(state.imageHash).to.not.equal(state.lastImageHash)
+      expect(state.lastImageHash).to.equal('')
     })
 
     it('should update config and get current config from chain, matching defined imageHash', async () => {

--- a/packages/wallet/tests/account.spec.ts
+++ b/packages/wallet/tests/account.spec.ts
@@ -94,6 +94,154 @@ describe('Account integration', () => {
       expect(await account.isDeployed()).to.be.false
 
       // deploy the wallet
+      const newSigner = ethers.Wallet.createRandom()
+      await account.updateConfig((await lib.Wallet.singleOwner(newSigner)).config)
+      expect(await account.isDeployed()).to.be.true
+
+      // instanciate account without known new config
+      const account2 = new lib.Account({
+        initialConfig: wallet.config,
+        networks,
+        context
+      }, owner)
+
+      // currentConfig which fetches wallet details from the authChain
+      const currentConfig = await account2.currentConfig()
+      expect(currentConfig.address).to.equal(await account2.getAddress())
+      expect(currentConfig.signers.length).to.equal(1)
+      expect(currentConfig.signers[0].weight).to.equal(1)
+      expect(currentConfig.signers[0].address).to.equal(await newSigner.getAddress())
+      expect(currentConfig.chainId).to.equal(await account2.getChainId())
+
+      // wallet state
+      const state = (await account2.getWalletState())[0]
+      expect(state.config.address).to.equal(await account2.getAddress())
+      expect(state.deployed).to.equal(true)
+      expect(state.imageHash).to.not.equal(state.currentImageHash)
+      expect(state.currentImageHash).to.equal(imageHash(currentConfig))
+    })
+
+    it('should update config and get current config from chain, not indexed', async () => {
+      const { wallet } = account.getWallets()[0]
+      expect(await wallet.getAddress()).to.equal(await account.getAddress())
+
+      const signers = await account.getSigners()
+      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
+
+      expect(await account.isDeployed()).to.be.false
+
+      // deploy the wallet
+      const newSigner = ethers.Wallet.createRandom()
+      await account.updateConfig((await lib.Wallet.singleOwner(newSigner)).config, false)
+      expect(await account.isDeployed()).to.be.true
+
+      // instanciate account without known new config
+      const account2 = new lib.Account({
+        initialConfig: wallet.config,
+        networks,
+        context
+      }, owner)
+
+      // currentConfig which fetches wallet details from the authChain
+      const currentConfig = await account2.currentConfig()
+      expect(currentConfig.address).to.equal(await account2.getAddress())
+      expect(currentConfig.signers.length).to.equal(1)
+      expect(currentConfig.signers[0].weight).to.equal(1)
+      expect(currentConfig.signers[0].address).to.equal(await newSigner.getAddress())
+      expect(currentConfig.chainId).to.equal(await account2.getChainId())
+
+      // wallet state
+      const state = (await account2.getWalletState())[0]
+      expect(state.config.address).to.equal(await account2.getAddress())
+      expect(state.deployed).to.equal(true)
+      expect(state.imageHash).to.not.equal(state.currentImageHash)
+      expect(state.currentImageHash).to.equal(imageHash(currentConfig))
+    })
+
+    it('should find current config from published config on counter-factual wallet', async () => {
+      const { wallet } = account.getWallets()[0]
+      expect(await wallet.getAddress()).to.equal(await account.getAddress())
+
+      const signers = await account.getSigners()
+      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
+
+      expect(await account.isDeployed()).to.be.false
+      await account.publishConfig()
+
+      // instanciate account without config
+      const account2 = new lib.Account({
+        initialConfig: { address: account.address, threshold: 0, signers: []},
+        networks,
+        context
+      }, owner)
+
+      expect(account2.address).to.equal(account.address)
+
+      // currentConfig which fetches wallet details from the authChain
+      const currentConfig = await account2.currentConfig()
+      expect(currentConfig.address).to.equal(await account2.getAddress())
+      expect(currentConfig.signers.length).to.equal(1)
+      expect(currentConfig.signers[0].weight).to.equal(1)
+      expect(currentConfig.signers[0].address).to.equal(await owner.getAddress())
+      expect(currentConfig.chainId).to.equal(await account2.getChainId())
+
+      // wallet state
+      const state = (await account2.getWalletState())[0]
+      expect(state.config.address).to.equal(await account2.getAddress())
+      expect(state.deployed).to.equal(true)
+      expect(state.imageHash).to.not.equal(state.currentImageHash)
+      expect(state.currentImageHash).to.equal('')
+    })
+
+    it('should find current config from published config on counter-factual wallet, not indexed', async () => {
+      const { wallet } = account.getWallets()[0]
+      expect(await wallet.getAddress()).to.equal(await account.getAddress())
+
+      const signers = await account.getSigners()
+      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
+
+      expect(await account.isDeployed()).to.be.false
+      await account.publishConfig(false)
+
+      // instanciate account without config
+      const account2 = new lib.Account({
+        initialConfig: { address: account.address, threshold: 0, signers: []},
+        networks,
+        context
+      }, owner)
+
+      expect(account2.address).to.equal(account.address)
+
+      // currentConfig which fetches wallet details from the authChain
+      const currentConfig = await account2.currentConfig()
+      expect(currentConfig.address).to.equal(await account2.getAddress())
+      expect(currentConfig.signers.length).to.equal(1)
+      expect(currentConfig.signers[0].weight).to.equal(1)
+      expect(currentConfig.signers[0].address).to.equal(await owner.getAddress())
+      expect(currentConfig.chainId).to.equal(await account2.getChainId())
+
+      // wallet state
+      const state = (await account2.getWalletState())[0]
+      expect(state.config.address).to.equal(await account2.getAddress())
+      expect(state.deployed).to.equal(true)
+      expect(state.imageHash).to.not.equal(state.currentImageHash)
+      expect(state.currentImageHash).to.equal('')
+    })
+
+    it('should update config and get current config from chain, matching defined imageHash', async () => {
+      const { wallet } = account.getWallets()[0]
+      expect(await wallet.getAddress()).to.equal(await account.getAddress())
+
+      const signers = await account.getSigners()
+      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
+
+      expect(await account.isDeployed()).to.be.false
+
+      // deploy the wallet
       await account.updateConfig()
       expect(await account.isDeployed()).to.be.true
 

--- a/packages/wallet/tests/account.spec.ts
+++ b/packages/wallet/tests/account.spec.ts
@@ -117,8 +117,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.currentImageHash)
-      expect(state.currentImageHash).to.equal(imageHash(currentConfig))
+      expect(state.imageHash).to.not.equal(state.publishedImageHash)
+      expect(state.publishedImageHash).to.equal(imageHash(currentConfig))
     })
 
     it('should update config and get current config from chain, not indexed', async () => {
@@ -126,7 +126,7 @@ describe('Account integration', () => {
       expect(await wallet.getAddress()).to.equal(await account.getAddress())
 
       const signers = await account.getSigners()
-      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(signers[0]).to.equal((await owner.getAddress()).toLowerCase())
       expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
 
       expect(await account.isDeployed()).to.be.false
@@ -155,8 +155,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.currentImageHash)
-      expect(state.currentImageHash).to.equal(imageHash(currentConfig))
+      expect(state.imageHash).to.not.equal(state.publishedImageHash)
+      expect(state.publishedImageHash).to.equal(imageHash(currentConfig))
     })
 
     it('should find current config from published config on counter-factual wallet', async () => {
@@ -164,7 +164,7 @@ describe('Account integration', () => {
       expect(await wallet.getAddress()).to.equal(await account.getAddress())
 
       const signers = await account.getSigners()
-      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(signers[0]).to.equal((await owner.getAddress()).toLowerCase())
       expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
 
       expect(await account.isDeployed()).to.be.false
@@ -177,7 +177,7 @@ describe('Account integration', () => {
         context
       }, owner)
 
-      expect(account2.address).to.equal(account.address)
+      expect(account2.address).to.equal(account.address.toLowerCase())
 
       // currentConfig which fetches wallet details from the authChain
       const currentConfig = await account2.currentConfig()
@@ -191,8 +191,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.currentImageHash)
-      expect(state.currentImageHash).to.equal('')
+      expect(state.imageHash).to.not.equal(state.publishedImageHash)
+      expect(state.publishedImageHash).to.equal('')
     })
 
     it('should find current config from published config on counter-factual wallet, not indexed', async () => {
@@ -200,7 +200,7 @@ describe('Account integration', () => {
       expect(await wallet.getAddress()).to.equal(await account.getAddress())
 
       const signers = await account.getSigners()
-      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(signers[0]).to.equal((await owner.getAddress()).toLowerCase())
       expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
 
       expect(await account.isDeployed()).to.be.false
@@ -213,7 +213,7 @@ describe('Account integration', () => {
         context
       }, owner)
 
-      expect(account2.address).to.equal(account.address)
+      expect(account2.address).to.equal(account.address.toLowerCase())
 
       // currentConfig which fetches wallet details from the authChain
       const currentConfig = await account2.currentConfig()
@@ -227,8 +227,8 @@ describe('Account integration', () => {
       const state = (await account2.getWalletState())[0]
       expect(state.config.address).to.equal(await account2.getAddress())
       expect(state.deployed).to.equal(true)
-      expect(state.imageHash).to.not.equal(state.currentImageHash)
-      expect(state.currentImageHash).to.equal('')
+      expect(state.imageHash).to.not.equal(state.publishedImageHash)
+      expect(state.publishedImageHash).to.equal('')
     })
 
     it('should update config and get current config from chain, matching defined imageHash', async () => {
@@ -236,7 +236,7 @@ describe('Account integration', () => {
       expect(await wallet.getAddress()).to.equal(await account.getAddress())
 
       const signers = await account.getSigners()
-      expect(signers[0]).to.equal(await owner.getAddress())
+      expect(signers[0]).to.equal((await owner.getAddress()).toLowerCase())
       expect(isValidConfigSigners((await account.getWalletConfig())[0], await account.getSigners())).to.be.true
 
       expect(await account.isDeployed()).to.be.false

--- a/packages/wallet/tests/wallet.spec.ts
+++ b/packages/wallet/tests/wallet.spec.ts
@@ -1348,7 +1348,7 @@ describe('Wallet integration', function () {
     })
     it('Should publish config', async () => {
       const receipt = await (await wallet.publishConfig()).wait()
-      expect(receipt.logs[2].data).to.contain(wallet.config.signers[0].address.slice(2).toLowerCase())
+      expect(receipt.logs[3].data).to.contain(wallet.config.signers[0].address.slice(2).toLowerCase())
     })
     describe('after migrating and updating', () => {
       let wallet2: lib.Wallet

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,9 @@
   dependencies:
     base64url "^3.0.1"
 
-"@0xsequence/wallet-contracts@https://github.com/0xsequence/wallet-contracts#alt-indexed-require-config":
+"@0xsequence/wallet-contracts@https://github.com/0xsequence/wallet-contracts":
   version "1.1.0"
-  resolved "https://github.com/0xsequence/wallet-contracts#7ad3d0dfe6cb2f623d5ed1c7810256267fb167bb"
+  resolved "https://github.com/0xsequence/wallet-contracts#ae753cda6c8e6e9b620f22bbe5270a6751702653"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.5.5":
   version "7.12.11"
@@ -1500,6 +1500,13 @@
     get-package-type "^0.1.0"
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
+
+"@istanbuljs/nyc-config-typescript@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz#55172f5663b3635586add21b14d42ca94a163d58"
+  integrity sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
 
 "@istanbuljs/schema@^0.1.2":
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,13 +8,10 @@
   integrity sha512-G7Ggq3absovUNMBQ1oQDtABt7uCJVtyRxMQNSzxrSddKlSI9FkbB9J+f9X5BpYX640SPXP+CE+gPlSI42qqqxw==
   dependencies:
     base64url "^3.0.1"
-"@0xsequence/wallet-contracts@https://github.com/arcadeum/wallet-contracts#alt-indexed-require-config":
-  version "1.1.0"
-  resolved "https://github.com/arcadeum/wallet-contracts#alt-indexed-require-config#222ef3a7eb1bb84e28e791e91bd8faf0572395c3"
 
-"@0xsequence/wallet-contracts@https://github.com/0xsequence/wallet-contracts":
+"@0xsequence/wallet-contracts@https://github.com/0xsequence/wallet-contracts#alt-indexed-require-config":
   version "1.1.0"
-  resolved "https://github.com/0xsequence/wallet-contracts#222ef3a7eb1bb84e28e791e91bd8faf0572395c3"
+  resolved "https://github.com/0xsequence/wallet-contracts#7ad3d0dfe6cb2f623d5ed1c7810256267fb167bb"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.5.5":
   version "7.12.11"
@@ -1503,13 +1500,6 @@
     get-package-type "^0.1.0"
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
-
-"@istanbuljs/nyc-config-typescript@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz#55172f5663b3635586add21b14d42ca94a163d58"
-  integrity sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==
-  dependencies:
-    "@istanbuljs/schema" "^0.1.2"
 
 "@istanbuljs/schema@^0.1.2":
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-G7Ggq3absovUNMBQ1oQDtABt7uCJVtyRxMQNSzxrSddKlSI9FkbB9J+f9X5BpYX640SPXP+CE+gPlSI42qqqxw==
   dependencies:
     base64url "^3.0.1"
-"@0xsequence/wallet-contracts@https://github.com/arcadeum/wallet-contracts#indexed-require-config":
+"@0xsequence/wallet-contracts@https://github.com/arcadeum/wallet-contracts#alt-indexed-require-config":
   version "1.1.0"
-  resolved "https://github.com/arcadeum/wallet-contracts#indexed-require-config#222ef3a7eb1bb84e28e791e91bd8faf0572395c3"
+  resolved "https://github.com/arcadeum/wallet-contracts#alt-indexed-require-config#222ef3a7eb1bb84e28e791e91bd8faf0572395c3"
 
 "@0xsequence/wallet-contracts@https://github.com/0xsequence/wallet-contracts":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,6 +1501,13 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
+"@istanbuljs/nyc-config-typescript@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz#55172f5663b3635586add21b14d42ca94a163d58"
+  integrity sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+
 "@istanbuljs/schema@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
@@ -9651,7 +9658,7 @@ number-to-bn@1.7.0:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
 
-nyc@^15.0.1:
+nyc@^15.0.1, nyc@^15.1.0:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-15.1.0.tgz#1335dae12ddc87b6e249d5a1994ca4bdaea75f02"
   integrity sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,9 @@
   integrity sha512-G7Ggq3absovUNMBQ1oQDtABt7uCJVtyRxMQNSzxrSddKlSI9FkbB9J+f9X5BpYX640SPXP+CE+gPlSI42qqqxw==
   dependencies:
     base64url "^3.0.1"
+"@0xsequence/wallet-contracts@https://github.com/arcadeum/wallet-contracts#indexed-require-config":
+  version "1.1.0"
+  resolved "https://github.com/arcadeum/wallet-contracts#indexed-require-config#222ef3a7eb1bb84e28e791e91bd8faf0572395c3"
 
 "@0xsequence/wallet-contracts@https://github.com/0xsequence/wallet-contracts":
   version "1.1.0"


### PR DESCRIPTION
Replaces #90 

- Uses indexed wallet to lookup event
- Uses `publishInitialSigners` for counter-factual config publish

Depends on: https://github.com/0xsequence/wallet-contracts/pull/109
