### PR TITLE
Skip redundant steps on config update

### DIFF
--- a/packages/multicall/tests/multicall.spec.ts
+++ b/packages/multicall/tests/multicall.spec.ts
@@ -418,7 +418,7 @@ describe('Multicall integration', function () {
           const random = ethers.utils.hexlify(ethers.utils.randomBytes(32))
           await callMock.testCall(random, "0x00")
           const storageAt = await provider.getStorageAt(callMock.address, 0)
-          expect(storageAt).to.equal(random)
+          expect(storageAt).to.equal(ethers.utils.defaultAbiCoder.encode(['bytes32'], [random]))
         })
 
         it("Should detect network", async () => {

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -581,6 +581,12 @@ export class Wallet extends Signer {
 
     const transactions = [...preTransaction, transaction, ...postTransaction]
 
+    // If update config reguires a single transaction
+    // skip nested selfExecute bundle
+    if (transactions.length === 1) {
+      return transactions
+    }
+
     return [{
       delegateCall: false,
       revertOnError: false,

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -540,7 +540,7 @@ export class Wallet extends Signer {
 
     const isUpgradable = await (async () => {
       try {
-        const implementation = await this.provider.getStorageAt(this.address, ethers.utils.defaultAbiCoder.encode(['string'], [this.address]))
+        const implementation = await this.provider.getStorageAt(this.address, ethers.utils.defaultAbiCoder.encode(['address'], [this.address]))
         return compareAddr(implementation, this.context.mainModuleUpgradable) === 0
       } catch {
         return false

--- a/packages/wallet/tests/wallet.spec.ts
+++ b/packages/wallet/tests/wallet.spec.ts
@@ -38,6 +38,8 @@ const Web3 = require('web3')
 const { expect } = chai.use(chaiAsPromised)
 
 import hardhat from 'hardhat'
+import { Interface } from 'ethers/lib/utils'
+import { walletContracts } from '@0xsequence/abi'
 
 type EthereumInstance = {
   chainId?: number
@@ -1650,6 +1652,47 @@ describe('Wallet integration', function () {
       expect(updatedWallet.address).to.not.be.equal(addressOf(newConfig, context))
 
       await updatedWallet.sendTransaction(transaction)
+    })
+    it('Should skip mainModule implementation upgrade if already up to date', async () => {
+      const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+      const s2 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+      const newConfig = {
+        threshold: 2,
+        signers: [
+          {
+            address: s1.address,
+            weight: 1
+          },
+          {
+            address: s2.address,
+            weight: 1
+          }
+        ]
+      }
+
+      const oldConfig = wallet.config
+      const [config, tx] = await wallet.updateConfig(newConfig)
+      await tx.wait()
+
+      const updatedWallet = new lib.Wallet({ config, context }, s1, s2).connect(ethnode.provider, relayer)
+
+      const updateTx = await updatedWallet.buildUpdateConfigTransaction(oldConfig, true, true)
+
+      const mainModuleInterface = new Interface(walletContracts.mainModule.abi)
+      const mainModuleUpgradableInterface = new Interface(walletContracts.mainModuleUpgradable.abi)
+      const sequenceUtilsInterface = new Interface(walletContracts.sequenceUtils.abi)
+
+      expect(updateTx.length).to.equal(1)
+
+      const decoded = mainModuleInterface.decodeFunctionData('selfExecute', updateTx[0].data)[0]
+      expect(decoded.length).to.equal(2)
+
+      const decoded0 = mainModuleUpgradableInterface.decodeFunctionData('updateImageHash', decoded[0].data)
+      expect(decoded0).to.not.be.undefined
+
+      const decoded1 = sequenceUtilsInterface.decodeFunctionData('publishConfig', decoded[1].data)
+      expect(decoded1).to.not.be.undefined
     })
     it('Should migrate and publish config', async () => {
       const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))


### PR DESCRIPTION
- Fix updated implementation detection
- Skip selfExecute on single tx wallet upgrade

(Gas savings on mainnet and skip redundant update implementation)