### PR TITLE
improve openWindow state options handling + typings

### DIFF
--- a/packages/provider/src/transports/base-provider-transport.ts
+++ b/packages/provider/src/transports/base-provider-transport.ts
@@ -4,7 +4,7 @@ import {
   ProviderTransport, ProviderMessage, ProviderMessageRequest,
   ProviderMessageType, ProviderMessageEvent, ProviderMessageResponse,
   ProviderMessageResponseCallback, ProviderMessageTransport,
-  WalletSession, ConnectionState
+  WalletSession, ConnectionState, OpenWalletIntent
 } from '../types'
 
 import { NetworkConfig, WalletContext, JsonRpcRequest, JsonRpcResponseCallback, JsonRpcResponse } from '@0xsequence/network'
@@ -49,7 +49,7 @@ export abstract class BaseProviderTransport implements ProviderTransport {
     throw new Error('abstract method')
   }
 
-  openWallet(path?: string, state?: any, defaultNetworkId?: string | number) {
+  openWallet(path?: string, state?: OpenWalletIntent, defaultNetworkId?: string | number) {
     throw new Error('abstract method')
   }
 
@@ -72,10 +72,10 @@ export abstract class BaseProviderTransport implements ProviderTransport {
 
     // open/focus the wallet.
     // automatically open the wallet when a provider request makes it here.
-    await this.openWallet()
+    await this.openWallet(undefined, { type: 'jsonRpcRequest', method: request.method })
     if (!this.isConnected()) {
       await this.waitUntilConnected()
-    }
+  }
 
     // send message request, await, and then execute callback after receiving the response
     try {

--- a/packages/provider/src/transports/mux-transport/mux-message-provider.ts
+++ b/packages/provider/src/transports/mux-transport/mux-message-provider.ts
@@ -1,6 +1,6 @@
 import {
   ProviderMessage, ProviderMessageType, ProviderTransport,
-  ProviderMessageEvent, ProviderMessageRequest, ProviderMessageResponse, WalletSession
+  ProviderMessageEvent, ProviderMessageRequest, ProviderMessageResponse, WalletSession, OpenWalletIntent
 } from '../../types'
 
 import { JsonRpcRequest, JsonRpcResponseCallback } from '@0xsequence/network'
@@ -50,7 +50,7 @@ export class MuxMessageProvider implements ProviderTransport {
     this.provider = undefined
   }
 
-  openWallet = (path?: string, state?: any, defaultNetworkId?: string | number): void => {
+  openWallet = (path?: string, state?: OpenWalletIntent, defaultNetworkId?: string | number): void => {
     if (this.provider) {
       this.provider.openWallet(path, state, defaultNetworkId)
       return

--- a/packages/provider/src/transports/proxy-transport/proxy-message-provider.ts
+++ b/packages/provider/src/transports/proxy-transport/proxy-message-provider.ts
@@ -1,7 +1,7 @@
 import { BaseProviderTransport } from '../base-provider-transport'
 
 import {
-  ProviderMessage, ConnectionState
+  ProviderMessage, ConnectionState, OpenWalletIntent
 } from '../../types'
 
 import { ProxyMessageChannelPort } from './proxy-message-channel'
@@ -42,7 +42,7 @@ export class ProxyMessageProvider extends BaseProviderTransport {
     this.port.handleMessage = undefined
   }
 
-  openWallet = (path?: string, state?: any, defaultNetworkId?: string | number): void => {
+  openWallet = (path?: string, state?: OpenWalletIntent, defaultNetworkId?: string | number): void => {
     this.connect(defaultNetworkId)
   }
 

--- a/packages/provider/src/transports/window-transport/window-message-handler.ts
+++ b/packages/provider/src/transports/window-transport/window-message-handler.ts
@@ -3,6 +3,10 @@ import { WalletRequestHandler } from '../wallet-request-handler'
 import { BaseWalletTransport } from '../base-wallet-transport'
 import { sanitizeNumberString } from '@0xsequence/utils'
 
+export interface RegisterOptions {
+  loadingPath: string
+}
+
 export class WindowMessageHandler extends BaseWalletTransport {
   protected parentWindow: Window
   protected parentOrigin: string
@@ -13,7 +17,7 @@ export class WindowMessageHandler extends BaseWalletTransport {
     super(walletRequestHandler)
   }
 
-  register() {
+  register(options?: RegisterOptions) {
     const isPopup = parent.window.opener !== null
     this._isPopup = isPopup
     if (isPopup !== true) {
@@ -24,7 +28,14 @@ export class WindowMessageHandler extends BaseWalletTransport {
     const location = new URL(window.location.href)
     this._sessionId = sanitizeNumberString(location.searchParams.get('sid')!)
     location.searchParams.delete('sid')
-    window.history.replaceState({}, document.title, location.pathname)
+
+    const jsonRpcRequest = location.searchParams.get('jsonRpcRequest')
+
+    if (options?.loadingPath && !!jsonRpcRequest) {
+      window.history.replaceState({}, document.title, options.loadingPath)
+    } else {
+      window.history.replaceState({}, document.title, location.pathname)
+    }
 
     // record parent window instance for communication
     this.parentWindow = parent.window.opener
@@ -82,5 +93,4 @@ export class WindowMessageHandler extends BaseWalletTransport {
   get isPopup(): boolean {
     return this._isPopup
   }
-
 }

--- a/packages/provider/src/transports/window-transport/window-message-provider.ts
+++ b/packages/provider/src/transports/window-transport/window-message-provider.ts
@@ -1,4 +1,4 @@
-import { ProviderMessage } from '../../types'
+import { OpenWalletIntent, ProviderMessage } from '../../types'
 import { BaseProviderTransport } from '../base-provider-transport'
 
 // ..
@@ -48,7 +48,7 @@ export class WindowMessageProvider extends BaseProviderTransport {
     this.events.removeAllListeners()
   }
 
-  openWallet = (path?: string, state?: any, defaultNetworkId?: string | number): void => {
+  openWallet = (path?: string, state?: OpenWalletIntent, defaultNetworkId?: string | number): void => {
     if (this.walletWindow && this.isConnected()) {
       // TODO: update the location of window to path
       this.walletWindow.focus()
@@ -57,6 +57,12 @@ export class WindowMessageProvider extends BaseProviderTransport {
 
     this.sessionId = `${performance.now()}`
     this.walletURL.searchParams.set('sid', this.sessionId)
+    
+    if(state?.type === 'jsonRpcRequest') {
+      this.walletURL.searchParams.set('jsonRpcRequest', state.method)
+    } else {
+      this.walletURL.searchParams.delete('jsonRpcRequest')
+    }
 
     const walletURL = new URL(this.walletURL.href)
     if (path && path !== '') {

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -21,7 +21,7 @@ export interface WalletSession {
 export interface ProviderTransport extends JsonRpcHandler, ProviderMessageTransport, ProviderMessageRequestHandler {
   register(): void
   unregister(): void
-  openWallet(path?: string, state?: any, defaultNetworkId?: string | number): void
+  openWallet(path?: string, state?: OpenWalletIntent, defaultNetworkId?: string | number): void
   closeWallet(): void
   isConnected(): boolean
   on(event: ProviderMessageEvent, fn: (...args: any[]) => void): void
@@ -104,3 +104,5 @@ export interface MessageToSign {
   typedData?: TypedData
   chainId?: number
 }
+
+export type OpenWalletIntent = { type: 'login' } | { type: 'jsonRpcRequest'; method: string }

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -7,7 +7,7 @@ import { WalletConfig, WalletState } from '@0xsequence/config'
 import { JsonRpcProvider, JsonRpcSigner, ExternalProvider } from '@ethersproject/providers'
 import { Web3Provider, Web3Signer } from './provider'
 import { MuxMessageProvider, WindowMessageProvider, ProxyMessageProvider, ProxyMessageChannelPort } from './transports'
-import { WalletSession, ProviderMessageEvent, ProviderTransport } from './types'
+import { WalletSession, ProviderMessageEvent, ProviderTransport, OpenWalletIntent } from './types'
 import { WalletCommands } from './commands'
 import { ethers } from 'ethers'
 
@@ -25,7 +25,7 @@ export interface WalletProvider {
   getChainId(): Promise<number>
   getAuthChainId(): Promise<number>
 
-  openWallet(path?: string, state?: any): Promise<boolean>
+  openWallet(path?: string, state?: OpenWalletIntent): Promise<boolean>
   closeWallet(): void
 
   getProvider(chainId?: ChainId): Web3Provider | undefined
@@ -183,7 +183,7 @@ export class Wallet implements WalletProvider {
       return true
     }
 
-    await this.openWallet('', { login: true })
+    await this.openWallet(undefined, { type: 'login' })
     const sessionPayload = await this.transport.messageProvider!.waitUntilLoggedIn()
     this.useSession(sessionPayload, true)
 
@@ -270,8 +270,8 @@ export class Wallet implements WalletProvider {
     throw new Error('expecting first or second network in list to be the auth chain')
   }
 
-  openWallet = async (path?: string, state?: any): Promise<boolean> => {
-    if (state?.login !== true && !this.isLoggedIn()) {
+  openWallet = async (path?: string, state?: OpenWalletIntent): Promise<boolean> => {
+    if (state?.type !== 'login' && !this.isLoggedIn()) {
       throw new Error('login first')
     }
 


### PR DESCRIPTION
added extra state options in openWindow to distinguish between jsonRpcRequest and regular wallet open 
this improves popup loading performance from dapps

instead of always loading root path (/wallet) and corresponding HTTP requests when a popup is open, the new states allows the wallet to distinguish openWindow intent and display an intermediary loading route, then proceed straight to the corresponding jsonRpcRequest handler routes

related: https://github.com/horizon-games/issue-tracker/issues/3936