### PR TITLE
auth: JWT and signing request piggybacking again

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,35 +1,26 @@
 export * from './api.gen'
 
-import { ArcadeumAPI as BaseArcadeumAPI } from './api.gen'
 import fetch from 'cross-fetch'
 
-export class ArcadeumAPIClient extends BaseArcadeumAPI {
-  jwtAuth: string | undefined = undefined
+import { ArcadeumAPI as BaseArcadeumAPI } from './api.gen'
 
-  constructor(hostname: string) {
+export class ArcadeumAPIClient extends BaseArcadeumAPI {
+  constructor(hostname: string, public jwtAuth?: string) {
     super(hostname, fetch)
     this.fetch = this._fetch
   }
 
   _fetch = (input: RequestInfo, init?: RequestInit): Promise<Response> => {
-    return new Promise<Response>((resolve, reject) => {
-      // automatically include jwt auth header to requests
-      // if its been set on the api client
-      const headers: { [key: string]: any } = {}
-      if (this.jwtAuth && this.jwtAuth.length > 0) {
-        headers['Authorization'] = `BEARER ${this.jwtAuth}`
-      }
+    // automatically include jwt auth header to requests
+    // if its been set on the api client
+    const headers: { [key: string]: any } = {}
+    if (this.jwtAuth && this.jwtAuth.length > 0) {
+      headers['Authorization'] = `BEARER ${this.jwtAuth}`
+    }
 
-      // before the request is made
-      init!.headers = { ...init!.headers, ...headers }
-  
-      fetch(input, init).then(resp => {
-        // after the request has been made..
-        resolve(resp)
-      }).catch(err => {
-        // request error
-        reject(err)
-      })
-    })
-  } 
+    // before the request is made
+    init!.headers = { ...init!.headers, ...headers }
+
+    return fetch(input, init)
+  }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,6 +23,7 @@
     "@0xsequence/ethauth": "^0.4.3",
     "@0xsequence/network": "^0.19.3",
     "@0xsequence/wallet": "^0.19.3",
+    "@0xsequence/utils": "^0.19.3",
     "ethers": "^5.0.32"
   },
   "peerDependencies": {},

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -521,7 +521,7 @@ export class Wallet extends Signer {
 
     const [txs, n] = await Promise.all([
       this.buildUpdateConfigTransaction(config, publish, indexed),
-      nonce ? nonce : await this.getNonce()
+      nonce ?? this.getNonce()
     ])
 
     return [

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -554,9 +554,11 @@ export class Wallet extends Signer {
 
     const walletInterface = new Interface(walletContracts.mainModule.abi)
 
-    // 131072 gas, enough for both calls
-    // and a power of two to keep the gas cost of data low
-    const gasLimit = ethers.constants.Two.pow(17)
+    // empirically, this seems to work for the tests:
+    // const gasLimit = 100000 + 1800 * config.signers.length
+    //
+    // but we're going to play it safe with this instead:
+    const gasLimit = 2 * (100000 + 1800 * config.signers.length)
 
     const preTransaction = isUpgradable ? [] : [{
       delegateCall: false,

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -594,7 +594,7 @@ export class Wallet extends Signer {
 
     return [{
       delegateCall: false,
-      revertOnError: false,
+      revertOnError: true,
       gasLimit: gasLimit,
       to: this.address,
       value: ethers.constants.Zero,


### PR DESCRIPTION
The regression turned out to be caused by a hard-coded constant gas limit for config updates that ends up reverting if the config accumulates too many signers (~50 or so).