### PR TITLE
Gas estimation module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ cache/
 build/
 dist/
 
+test_chain/
+
 *.js.map
 PROD.env
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^9.0.0",
     "typescript": "^4.2.4",
+    "wait-on": "^6.0.0",
     "wsrun": "^5.2.4"
   },
   "resolutions": {

--- a/packages/estimator/package.json
+++ b/packages/estimator/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@0xsequence/wallet-contracts": "1.9.1",
     "@ethersproject/abstract-signer": "5.0.14",
     "@ethersproject/properties": "^5.0.9",
     "ethers": "^5.0.32",

--- a/packages/estimator/package.json
+++ b/packages/estimator/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "yarn test:concurrently 'yarn test:run'",
-    "test:run": "yarn test:file tests/**/*.spec.ts",
+    "test:run": "wait-on -t 120000 http-get://127.0.0.1:10045/ && yarn test:file tests/**/*.spec.ts",
     "test:file": "TS_NODE_PROJECT=../../tsconfig.test.json mocha -r ts-node/register --timeout 30000",
     "test:concurrently": "concurrently -k --success first 'yarn start:geth > /dev/null'",
     "start:geth": "docker run --rm -t -p 10045:10045 ethereum/client-go:v1.10.3 --rpc --rpcport 10045 --rpcaddr 0.0.0.0 --datadir test_chain --http --dev",

--- a/packages/estimator/package.json
+++ b/packages/estimator/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@0xsequence/estimator",
+  "version": "0.23.0",
+  "description": "estimator sub-package for Sequence",
+  "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/estimator",
+  "source": "src/index.ts",
+  "main": "dist/0xsequence-estimator.cjs.js",
+  "module": "dist/0xsequence-estimator.esm.js",
+  "author": "Horizon Blockchain Games",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "yarn test:concurrently 'yarn test:run'",
+    "test:run": "yarn test:file tests/**/*.spec.ts",
+    "test:file": "TS_NODE_PROJECT=../../tsconfig.test.json mocha -r ts-node/register --timeout 30000",
+    "test:concurrently": "concurrently -k --success first 'yarn start:geth > /dev/null'",
+    "start:geth": "docker run --rm -t -p 10045:8545 ethereum/client-go:v1.10.4 --datadir test_chain --http --dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ethersproject/abstract-signer": "5.0.14",
+    "@ethersproject/properties": "^5.0.9",
+    "ethers": "^5.0.32",
+    "js-base64": "^3.6.0"
+  },
+  "peerDependencies": {},
+  "devDependencies": {},
+  "files": [
+    "src",
+    "dist"
+  ]
+}

--- a/packages/estimator/package.json
+++ b/packages/estimator/package.json
@@ -13,10 +13,14 @@
     "test:run": "yarn test:file tests/**/*.spec.ts",
     "test:file": "TS_NODE_PROJECT=../../tsconfig.test.json mocha -r ts-node/register --timeout 30000",
     "test:concurrently": "concurrently -k --success first 'yarn start:geth > /dev/null'",
-    "start:geth": "docker run --rm -t -p 10045:8545 ethereum/client-go:v1.10.4 --datadir test_chain --http --dev",
+    "start:geth": "docker run --rm -t -p 10045:10045 ethereum/client-go:v1.10.4 --rpc --rpcport 10045 --rpcaddr 0.0.0.0 --datadir test_chain --http --dev",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@0xsequence/config": "^0.23.0",
+    "@0xsequence/transactions": "^0.23.0",
+    "@0xsequence/network": "^0.23.0",
+    "@0xsequence/utils": "^0.23.0",
     "@0xsequence/wallet-contracts": "1.9.1",
     "@ethersproject/abstract-signer": "5.0.14",
     "@ethersproject/properties": "^5.0.9",

--- a/packages/estimator/package.json
+++ b/packages/estimator/package.json
@@ -13,7 +13,7 @@
     "test:run": "yarn test:file tests/**/*.spec.ts",
     "test:file": "TS_NODE_PROJECT=../../tsconfig.test.json mocha -r ts-node/register --timeout 30000",
     "test:concurrently": "concurrently -k --success first 'yarn start:geth > /dev/null'",
-    "start:geth": "docker run --rm -t -p 10045:10045 ethereum/client-go:v1.10.4 --rpc --rpcport 10045 --rpcaddr 0.0.0.0 --datadir test_chain --http --dev",
+    "start:geth": "docker run --rm -t -p 10045:10045 ethereum/client-go:v1.10.3 --rpc --rpcport 10045 --rpcaddr 0.0.0.0 --datadir test_chain --http --dev",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/estimator/package.json
+++ b/packages/estimator/package.json
@@ -17,9 +17,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@0xsequence/abi": "^0.23.0",
     "@0xsequence/config": "^0.23.0",
-    "@0xsequence/transactions": "^0.23.0",
     "@0xsequence/network": "^0.23.0",
+    "@0xsequence/transactions": "^0.23.0",
     "@0xsequence/utils": "^0.23.0",
     "@0xsequence/wallet-contracts": "1.9.1",
     "@ethersproject/abstract-signer": "5.0.14",

--- a/packages/estimator/src/estimator.ts
+++ b/packages/estimator/src/estimator.ts
@@ -1,0 +1,15 @@
+import { WalletConfig } from "@0xsequence/config"
+import { WalletContext } from "@0xsequence/network"
+import { Transaction } from "@0xsequence/transactions"
+import { ethers } from "ethers"
+
+export interface Estimator {
+  estimateGasLimits(
+    config: WalletConfig,
+    context: WalletContext,
+    ...transactions: Transaction[]
+  ): Promise<{
+    transactions:Transaction[],
+    total: ethers.BigNumber
+  }>
+}

--- a/packages/estimator/src/index.ts
+++ b/packages/estimator/src/index.ts
@@ -1,1 +1,1 @@
-export const stub = "stub"
+export * from './overwriter-estimator'

--- a/packages/estimator/src/index.ts
+++ b/packages/estimator/src/index.ts
@@ -1,0 +1,1 @@
+export const stub = "stub"

--- a/packages/estimator/src/index.ts
+++ b/packages/estimator/src/index.ts
@@ -1,1 +1,2 @@
 export * from './overwriter-estimator'
+export * from './overwriter-sequence-estimator'

--- a/packages/estimator/src/index.ts
+++ b/packages/estimator/src/index.ts
@@ -1,2 +1,3 @@
 export * from './overwriter-estimator'
 export * from './overwriter-sequence-estimator'
+export * from './estimator'

--- a/packages/estimator/src/overwriter-estimator.ts
+++ b/packages/estimator/src/overwriter-estimator.ts
@@ -1,0 +1,92 @@
+import { ethers } from "ethers"
+import { isBigNumberish } from '@0xsequence/utils'
+
+const GasEstimator = require("@0xsequence/wallet-contracts/artifacts/contracts/modules/utils/GasEstimator.sol/GasEstimator.json")
+
+function toQuantity(number: ethers.BigNumberish | string): string {
+  if (isBigNumberish(number)) {
+    return ethers.BigNumber.from(number).toHexString()
+  }
+
+  return number
+}
+
+function toHexNumber(number: ethers.BigNumberish): string {
+  return ethers.BigNumber.from(number).toHexString()
+}
+
+function txBaseCost(data: ethers.BytesLike): number {
+  const bytes = ethers.utils.arrayify(data)
+  return bytes.reduce((p, c) => c == 0 ? p.add(4) : p.add(16), ethers.constants.Zero).add(21000).toNumber()
+}
+
+export class OverwriterEstimator {
+  constructor(public rpc: string | ethers.providers.JsonRpcProvider) {}
+
+  async estimate(args: {
+    to: string,
+    from?: string,
+    data?: ethers.BytesLike,
+    gasPrice?: ethers.BigNumberish,
+    gas?: ethers.BigNumberish,
+    overwrites?: {
+      address: string,
+      code?: string,
+      balance?: ethers.BigNumberish,
+      nonce?: ethers.BigNumberish,
+      stateDiff?: {
+        key: string,
+        value: string,
+      }[],
+      state?: {
+        key: string,
+        value: string,
+      }[]
+    }[],
+    blockTag?: string | ethers.BigNumberish
+  }): Promise<ethers.BigNumber> {
+    const provider = typeof(this.rpc) === 'string' ? new ethers.providers.JsonRpcProvider(this.rpc) : this.rpc
+
+    const blockTag = args.blockTag ? toQuantity(args.blockTag) : "latest"
+    const data = args.data ? args.data : []
+    const from = args.from ? ethers.utils.getAddress(args.from) : ethers.Wallet.createRandom().address
+
+    const gasEstimatorInterface = new ethers.utils.Interface(GasEstimator.abi)
+    const encodedEstimate = gasEstimatorInterface.encodeFunctionData("estimate", [args.to, data])
+
+    const providedOverwrites = args.overwrites ? args.overwrites.reduce((p, o) => {
+      const address = ethers.utils.getAddress(o.address)
+
+      if (address === from) {
+        throw Error("Can't overwrite from address values")
+      }
+
+      return {
+        ...p,
+        [address]: {
+          code: o.code ? ethers.utils.hexlify(o.code) : undefined,
+          nonce: o.nonce ? toHexNumber(o.nonce) : undefined,
+          balance: o.balance ? toHexNumber(o.balance) : undefined,
+          state: o.state ? o.state : undefined,
+          stateDiff: o.stateDiff ? o.stateDiff : undefined
+          }
+      }
+    }, {}) : {}
+
+    const overwrites = { ...providedOverwrites, 
+      [from]: {
+        code: GasEstimator.deployedBytecode
+      }
+    }
+
+    const response = await provider.send("eth_call", [{
+      to: from,
+      data: encodedEstimate,
+      gasPrice: args.gasPrice,
+      gas: args.gas,
+    }, blockTag, overwrites])
+
+    const decoded = gasEstimatorInterface.decodeFunctionResult("estimate", response)
+    return ethers.BigNumber.from(decoded.gas).add(txBaseCost(data))
+  }
+}

--- a/packages/estimator/src/overwriter-estimator.ts
+++ b/packages/estimator/src/overwriter-estimator.ts
@@ -21,7 +21,11 @@ function txBaseCost(data: ethers.BytesLike): number {
 }
 
 export class OverwriterEstimator {
-  constructor(public rpc: string | ethers.providers.JsonRpcProvider) {}
+  public provider: ethers.providers.JsonRpcProvider
+
+  constructor(public rpc: string | ethers.providers.JsonRpcProvider) {
+    this.provider = typeof(this.rpc) === 'string' ? new ethers.providers.JsonRpcProvider(this.rpc) : this.rpc
+  }
 
   async estimate(args: {
     to: string,
@@ -45,8 +49,6 @@ export class OverwriterEstimator {
     }[],
     blockTag?: string | ethers.BigNumberish
   }): Promise<ethers.BigNumber> {
-    const provider = typeof(this.rpc) === 'string' ? new ethers.providers.JsonRpcProvider(this.rpc) : this.rpc
-
     const blockTag = args.blockTag ? toQuantity(args.blockTag) : "latest"
     const data = args.data ? args.data : []
     const from = args.from ? ethers.utils.getAddress(args.from) : ethers.Wallet.createRandom().address
@@ -79,7 +81,7 @@ export class OverwriterEstimator {
       }
     }
 
-    const response = await provider.send("eth_call", [{
+    const response = await this.provider.send("eth_call", [{
       to: from,
       data: encodedEstimate,
       gasPrice: args.gasPrice,

--- a/packages/estimator/src/overwriter-estimator.ts
+++ b/packages/estimator/src/overwriter-estimator.ts
@@ -11,6 +11,14 @@ function toQuantity(number: ethers.BigNumberish | string): string {
   return number
 }
 
+function tryDecodeError(bytes: ethers.BytesLike): string {
+  try {
+    return ethers.utils.toUtf8String('0x' + ethers.utils.hexlify(bytes).substr(138))
+  } catch (e) {
+    return 'UNKNOWN_ERROR'
+  }
+}
+
 function toHexNumber(number: ethers.BigNumberish): string {
   return ethers.BigNumber.from(number).toHexString()
 }
@@ -34,19 +42,20 @@ export class OverwriterEstimator {
     gasPrice?: ethers.BigNumberish,
     gas?: ethers.BigNumberish,
     overwrites?: {
-      address: string,
-      code?: string,
-      balance?: ethers.BigNumberish,
-      nonce?: ethers.BigNumberish,
-      stateDiff?: {
-        key: string,
-        value: string,
-      }[],
-      state?: {
-        key: string,
-        value: string,
-      }[]
-    }[],
+      [address: string]: {
+        code?: string,
+        balance?: ethers.BigNumberish,
+        nonce?: ethers.BigNumberish,
+        stateDiff?: {
+          key: string,
+          value: string,
+        }[],
+        state?: {
+          key: string,
+          value: string,
+        }[]
+      }
+    },
     blockTag?: string | ethers.BigNumberish
   }): Promise<ethers.BigNumber> {
     const blockTag = args.blockTag ? toQuantity(args.blockTag) : "latest"
@@ -56,8 +65,9 @@ export class OverwriterEstimator {
     const gasEstimatorInterface = new ethers.utils.Interface(GasEstimator.abi)
     const encodedEstimate = gasEstimatorInterface.encodeFunctionData("estimate", [args.to, data])
 
-    const providedOverwrites = args.overwrites ? args.overwrites.reduce((p, o) => {
-      const address = ethers.utils.getAddress(o.address)
+    const providedOverwrites = args.overwrites ? Object.keys(args.overwrites).reduce((p, a) => {
+      const address = ethers.utils.getAddress(a)
+      const o = args.overwrites![a]
 
       if (address === from) {
         throw Error("Can't overwrite from address values")
@@ -66,11 +76,11 @@ export class OverwriterEstimator {
       return {
         ...p,
         [address]: {
-          code: o.code ? ethers.utils.hexlify(o.code) : undefined,
-          nonce: o.nonce ? toHexNumber(o.nonce) : undefined,
-          balance: o.balance ? toHexNumber(o.balance) : undefined,
-          state: o.state ? o.state : undefined,
-          stateDiff: o.stateDiff ? o.stateDiff : undefined
+            code: o.code ? ethers.utils.hexlify(o.code) : undefined,
+            nonce: o.nonce ? toHexNumber(o.nonce) : undefined,
+            balance: o.balance ? toHexNumber(o.balance) : undefined,
+            state: o.state ? o.state : undefined,
+            stateDiff: o.stateDiff ? o.stateDiff : undefined
           }
       }
     }, {}) : {}
@@ -89,6 +99,11 @@ export class OverwriterEstimator {
     }, blockTag, overwrites])
 
     const decoded = gasEstimatorInterface.decodeFunctionResult("estimate", response)
+
+    if (!decoded.success) {
+      throw Error(`Failed gas estimation with ${tryDecodeError(decoded.result)}`)
+    }
+
     return ethers.BigNumber.from(decoded.gas).add(txBaseCost(data))
   }
 }

--- a/packages/estimator/src/overwriter-sequence-estimator.ts
+++ b/packages/estimator/src/overwriter-sequence-estimator.ts
@@ -1,22 +1,92 @@
 import { WalletContext } from '@0xsequence/network'
-import { WalletConfig, addressOf } from '@0xsequence/config'
-import { Transaction } from '@0xsequence/transactions'
+import { WalletConfig, addressOf, encodeSignature } from '@0xsequence/config'
+import { readSequenceNonce, Transaction } from '@0xsequence/transactions'
 import { OverwriterEstimator } from './overwriter-estimator'
+import { Interface } from 'ethers/lib/utils'
+import { walletContracts } from '@0xsequence/abi'
+import { ethers } from 'ethers'
 
 export class OverwriterSequenceEstimator {
   constructor(public estimator: OverwriterEstimator) {}
 
   async estimateGasLimits(config: WalletConfig, context: WalletContext, ...transactions: Transaction[]): Promise<Transaction[]> {
     const wallet = addressOf(config, context)
+    const walletInterface = new Interface(walletContracts.mainModule.abi)
 
-    // This is the "base" gas for the transactions
-    // it accounts for the overhead of the signature and calling sequence
-    // this is required to retrieve an accurate estimation of each sub-call
-    const baseGas = this.estimator.estimate({
-      to: wallet,
-      data: []
-    })
+    // Get non-eoa signers
+    // required for computing worse case scenario
+    const signers = await Promise.all(config.signers.map(async (s, i) => ({
+      ...s,
+      index: i,
+      isEOA: ethers.utils.arrayify(await this.estimator.provider.getCode(s.address)).length === 0
+    })))
 
-    return []
+    // Define designated signers
+    let weightSum = 0
+
+    const definedSigners = signers
+      .sort((a, b) => !a.isEOA && b.isEOA ? -1 : 0) // Contract signers sign first
+      .map((s) => {                                 // Define signers and not signers
+        if (weightSum >= config.threshold) {
+          return { ...s, signs: false }
+        }
+
+        weightSum += s.weight
+        return { ...s, signs: true }
+      })
+      .sort((a, b) => a.index - b.index)            // Sort back to original configuration
+
+    // Generate a fake signature, meant to resemble the final signature of the transaction
+    // this "fake" signature is provided to compute a more accurate gas estimation
+    const stubSignature = encodeSignature({ threshold: config.threshold, signers: definedSigners.map((s) => {
+      if (!s.signs) return s
+
+      if (s.isEOA) {
+        return {
+          weight: s.weight,
+          signature: ethers.Wallet.createRandom().signMessage("") + '02'
+        }
+      }
+
+      // Assume a 2/3 nested contract signature
+      // TODO: Improve this, how do we get the nested signer config?
+      const nestedSignature = encodeSignature({
+        threshold: 2,
+        signers: [{
+          address: ethers.Wallet.createRandom().address,
+          weight: 1
+        }, {
+          address: ethers.Wallet.createRandom().signMessage("") + '02',
+          weight: 1
+        }, {
+          address: ethers.Wallet.createRandom().signMessage("") + '02',
+          weight: 1
+        }]
+      }) + '03'
+
+      return {
+        weight: s.weight,
+        signature: nestedSignature
+      }
+    })})
+
+    // Use the provided nonce
+    // TODO: Maybe ignore if this fails on the MainModuleGasEstimation
+    // it could help reduce the edge cases for when the gas estimation fails
+    const nonce = readSequenceNonce(...transactions)
+
+    const estimates = await Promise.all([
+      ...transactions.map(async (_, i) => {
+        return this.estimator.estimate({
+          to: wallet,
+          data: walletInterface.encodeFunctionData(walletInterface.getFunction('execute'), [transactions.slice(0, i), nonce, stubSignature])
+        })
+      }), this.estimator.estimate({
+        to: wallet,     // Compute full gas estimation with all transaction
+        data: walletInterface.encodeFunctionData(walletInterface.getFunction('execute'), [transactions, nonce, stubSignature])
+      })
+    ])
+
+    return transactions.map((t, i) => ({ ...t, gasLimit: estimates[i + 1].sub(estimates[i]) }))
   }
 }

--- a/packages/estimator/src/overwriter-sequence-estimator.ts
+++ b/packages/estimator/src/overwriter-sequence-estimator.ts
@@ -1,0 +1,22 @@
+import { WalletContext } from '@0xsequence/network'
+import { WalletConfig, addressOf } from '@0xsequence/config'
+import { Transaction } from '@0xsequence/transactions'
+import { OverwriterEstimator } from './overwriter-estimator'
+
+export class OverwriterSequenceEstimator {
+  constructor(public estimator: OverwriterEstimator) {}
+
+  async estimateGasLimits(config: WalletConfig, context: WalletContext, ...transactions: Transaction[]): Promise<Transaction[]> {
+    const wallet = addressOf(config, context)
+
+    // This is the "base" gas for the transactions
+    // it accounts for the overhead of the signature and calling sequence
+    // this is required to retrieve an accurate estimation of each sub-call
+    const baseGas = this.estimator.estimate({
+      to: wallet,
+      data: []
+    })
+
+    return []
+  }
+}

--- a/packages/estimator/src/overwriter-sequence-estimator.ts
+++ b/packages/estimator/src/overwriter-sequence-estimator.ts
@@ -28,8 +28,10 @@ export class OverwriterSequenceEstimator implements Estimator {
     let weightSum = 0
 
     const definedSigners = signers
-      .sort((a, b) => !a.isEOA && b.isEOA ? -1 : 0) // Contract signers sign first
-      .map((s) => {                                 // Define signers and not signers
+      // Contract signers sign first, then lowest weight signers
+      .sort((a, b) => !a.isEOA && b.isEOA ? -1 : a.isEOA && !b.isEOA ? +1 : a.weight - b.weight)
+      // Define signers and not signers
+      .map((s) => {
         if (weightSum >= config.threshold) {
           return { ...s, signs: false }
         }

--- a/packages/estimator/src/overwriter-sequence-estimator.ts
+++ b/packages/estimator/src/overwriter-sequence-estimator.ts
@@ -5,10 +5,11 @@ import { OverwriterEstimator } from './overwriter-estimator'
 import { Interface } from 'ethers/lib/utils'
 import { walletContracts } from '@0xsequence/abi'
 import { ethers } from 'ethers'
+import { Estimator } from './estimator'
 
 const MainModuleGasEstimation = require("@0xsequence/wallet-contracts/artifacts/contracts/modules/MainModuleGasEstimation.sol/MainModuleGasEstimation.json")
 
-export class OverwriterSequenceEstimator {
+export class OverwriterSequenceEstimator implements Estimator {
   constructor(public estimator: OverwriterEstimator) {}
 
   async estimateGasLimits(config: WalletConfig, context: WalletContext, ...transactions: Transaction[]): Promise<{ transactions:Transaction[], total: ethers.BigNumber }> {

--- a/packages/estimator/tests/estimator.spec.ts
+++ b/packages/estimator/tests/estimator.spec.ts
@@ -25,7 +25,7 @@ describe('estimator', function() {
       provider.getSigner()
     ).deploy()) as unknown) as CallReceiverMock
 
-    estimator = new OverwriterEstimator(url)
+    estimator = new OverwriterEstimator({ rpc: url })
   })
 
   beforeEach(async () => {

--- a/packages/estimator/tests/estimator.spec.ts
+++ b/packages/estimator/tests/estimator.spec.ts
@@ -1,7 +1,43 @@
-import { assert } from "chai"
+import { before } from "mocha"
+import { ethers } from "ethers"
 
-describe('estimator', function() {  
-  it('sample estimator test', () => {
-    assert(true)
+import { CallReceiverMock } from '@0xsequence/wallet-contracts'
+import { OverwriterEstimator } from '@0xsequence/estimator'
+import { encodeData } from "@0xsequence/wallet/tests/utils"
+import { expect } from "chai"
+
+const CallReceiverMockArtifact = require('@0xsequence/wallet-contracts/artifacts/contracts/mocks/CallReceiverMock.sol/CallReceiverMock.json')
+
+describe('estimator', function() {
+
+  let url: string
+  let provider: ethers.providers.JsonRpcProvider
+  let callReceiver: CallReceiverMock
+
+  let estimator: OverwriterEstimator
+
+  before(async () => {
+    url = "http://127.0.0.1:10045/"
+    provider = new ethers.providers.JsonRpcProvider(url)
+
+    callReceiver = ((await new ethers.ContractFactory(
+      CallReceiverMockArtifact.abi,
+      CallReceiverMockArtifact.bytecode,
+      provider.getSigner()
+    ).deploy()) as unknown) as CallReceiverMock
+
+    estimator = new OverwriterEstimator(url)
+  })
+
+  beforeEach(async () => {
+    await callReceiver.setRevertFlag(false)
+    await callReceiver.testCall(0, [])
+  })
+
+  it('should estimate the gas of a single call', async () => {
+    const gas = await estimator.estimate({ to: callReceiver.address, data: await encodeData(callReceiver, "testCall", 1, "0x112233") })
+    const tx = await (await callReceiver.testCall(1, "0x112233")).wait()
+    expect(gas.toNumber()).to.be.above(tx.gasUsed.toNumber())
+    expect(gas.toNumber()).to.be.approximately(tx.gasUsed.toNumber(), 5000)
   })
 })

--- a/packages/estimator/tests/estimator.spec.ts
+++ b/packages/estimator/tests/estimator.spec.ts
@@ -1,0 +1,7 @@
+import { assert } from "chai"
+
+describe('estimator', function() {  
+  it('sample estimator test', () => {
+    assert(true)
+  })
+})

--- a/packages/estimator/tests/estimator.spec.ts
+++ b/packages/estimator/tests/estimator.spec.ts
@@ -1,4 +1,3 @@
-import { before } from "mocha"
 import { ethers } from "ethers"
 
 import { CallReceiverMock } from '@0xsequence/wallet-contracts'

--- a/packages/estimator/tests/sequence-estimator.spec.ts
+++ b/packages/estimator/tests/sequence-estimator.spec.ts
@@ -224,7 +224,7 @@ describe('Wallet integration', function () {
               const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
               const realTx = await (await wallet.sendTransaction(estimation.transactions)).wait(1)
   
-              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 5000)
+              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 10000)
               expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
   
               expect((await callReceiver.lastValA()).toNumber()).to.equal(14442)
@@ -234,7 +234,7 @@ describe('Wallet integration', function () {
               const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
               const realTx = await (await wallet.sendTransaction(txs)).wait(1)
       
-              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 5000)
+              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 10000)
               expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
       
               expect((await callReceiver.lastValA()).toNumber()).to.equal(14442)
@@ -245,7 +245,7 @@ describe('Wallet integration', function () {
               const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
               const realTx = await (await wallet.sendTransaction(estimation.transactions)).wait(1)
       
-              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 5000)
+              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 10000)
               expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
       
               expect((await callReceiver.lastValA()).toNumber()).to.equal(0)
@@ -282,7 +282,7 @@ describe('Wallet integration', function () {
               const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
               const realTx = await (await wallet.sendTransaction(estimation.transactions)).wait(1)
   
-              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 20000)
+              expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 30000)
               expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
   
               expect(ethers.utils.hexlify(await callReceiver.lastValB())).to.equal(ethers.utils.hexlify(valB))

--- a/packages/estimator/tests/sequence-estimator.spec.ts
+++ b/packages/estimator/tests/sequence-estimator.spec.ts
@@ -1,0 +1,236 @@
+
+import { CallReceiverMock, HookCallerMock } from '@0xsequence/wallet-contracts'
+
+import { Transaction } from '@0xsequence/transactions'
+
+import { LocalRelayer } from '@0xsequence/relayer'
+
+import { WalletContext, Networks } from '@0xsequence/network'
+import { JsonRpcProvider } from '@ethersproject/providers'
+import { ethers, Signer as AbstractSigner } from 'ethers'
+
+import { configureLogger } from '@0xsequence/utils'
+
+import chaiAsPromised from 'chai-as-promised'
+import * as chai from 'chai'
+
+const CallReceiverMockArtifact = require('@0xsequence/wallet-contracts/artifacts/contracts/mocks/CallReceiverMock.sol/CallReceiverMock.json')
+const HookCallerMockArtifact = require('@0xsequence/wallet-contracts/artifacts/contracts/mocks/HookCallerMock.sol/HookCallerMock.json')
+
+const { expect } = chai.use(chaiAsPromised)
+
+configureLogger({ logLevel: 'DEBUG' })
+
+import { Wallet } from '@0xsequence/wallet'
+import { deployWalletContext } from '@0xsequence/wallet/tests/utils/deploy-wallet-context'
+import { OverwriterSequenceEstimator } from '../src'
+import { OverwriterEstimator } from '../dist/0xsequence-estimator.cjs'
+import { encodeData } from '@0xsequence/wallet/tests/utils'
+
+type EthereumInstance = {
+  chainId: number
+  provider: JsonRpcProvider
+  signer: AbstractSigner
+}
+
+describe('Wallet integration', function () {
+  let ethnode: EthereumInstance
+
+  let relayer: LocalRelayer
+  let callReceiver: CallReceiverMock
+  let hookCaller: HookCallerMock
+
+  let context: WalletContext
+  let networks: Networks
+
+  let estimator: OverwriterSequenceEstimator
+
+  before(async () => {
+    // Provider from hardhat without a server instance
+    const url = "http://127.0.0.1:10045/"
+    const provider = new ethers.providers.JsonRpcProvider(url)
+
+    ethnode = {
+      chainId: (await provider.getNetwork()).chainId,
+      provider: provider,
+      signer: provider.getSigner()
+    }
+
+    networks = [{
+      name: 'local',
+      chainId: ethnode.chainId,
+      provider: ethnode.provider,
+      isDefaultChain: true,
+      isAuthChain: true
+    }]
+
+    // Deploy Sequence env
+    const [
+      factory,
+      mainModule,
+      mainModuleUpgradable,
+      guestModule,
+      sequenceUtils
+    ] = await deployWalletContext(ethnode.signer)
+
+    // Create fixed context obj
+    context = {
+      factory: factory.address,
+      mainModule: mainModule.address,
+      mainModuleUpgradable: mainModuleUpgradable.address,
+      guestModule: guestModule.address,
+      sequenceUtils: sequenceUtils.address
+    }
+
+    // Deploy call receiver mock
+    callReceiver = (await new ethers.ContractFactory(
+      CallReceiverMockArtifact.abi,
+      CallReceiverMockArtifact.bytecode,
+      ethnode.signer
+    ).deploy()) as CallReceiverMock
+
+    // Deploy hook caller mock
+    hookCaller = (await new ethers.ContractFactory(
+      HookCallerMockArtifact.abi,
+      HookCallerMockArtifact.bytecode,
+      ethnode.signer
+    ).deploy()) as HookCallerMock
+
+    // Deploy local relayer
+    relayer = new LocalRelayer({signer: ethnode.signer })
+
+    // Create gas estimator
+    estimator = new OverwriterSequenceEstimator(new OverwriterEstimator(ethnode.provider))
+  })
+
+  function sleep(ms: number) {
+       return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+  beforeEach(async () => {
+    await callReceiver.setRevertFlag(false)
+    await callReceiver.testCall(0, [])
+  })
+
+  describe('estimate gas of transactions', () => {
+    const options = [{
+      name: "single signer wallet",
+      getWallet: async () => {
+        const pk = ethers.utils.randomBytes(32)
+        const wallet = await Wallet.singleOwner(pk, context)
+        return wallet.connect(ethnode.provider, relayer)
+      }
+    }, {
+      name: "multiple signers wallet",
+      getWallet: async () => {
+        const signers = new Array(4).fill(0).map(() => ethers.Wallet.createRandom())
+
+        const config = {
+          threshold: 3,
+          signers: signers.map((s) => ({ weight: 1, address: s.address}))
+        }
+
+        const wallet = new Wallet({ context, config }, ...signers.slice(0, 3))
+        return wallet.connect(ethnode.provider, relayer)
+      }
+    }, {
+      name: "many multiple signers wallet",
+      getWallet: async () => {
+        const signers = new Array(111).fill(0).map(() => ethers.Wallet.createRandom())
+
+        const config = {
+          threshold: 11,
+          signers: signers.map((s) => ({ weight: 1, address: s.address}))
+        }
+
+        const wallet = new Wallet({ context, config }, ...signers.slice(0, 12))
+        return wallet.connect(ethnode.provider, relayer)
+      }
+    }, {
+      name: "nested wallet",
+      getWallet: async () => {
+        const EOAsigners = new Array(2).fill(0).map(() => ethers.Wallet.createRandom())
+
+        const NestedSigners = await Promise.all(new Array(2).fill(0).map(async () => {
+          const signers = new Array(3).fill(0).map(() => ethers.Wallet.createRandom())
+          const config = {
+            threshold: 2,
+            signers: signers.map((s) => ({ weight: 1, address: s.address }))
+          }
+          const wallet = new Wallet({ context: context, config: config }, ...signers.slice(0, 2)).connect(ethnode.provider, relayer)
+          await relayer.deployWallet(wallet.config, wallet.context)
+          return wallet.connect(ethnode.provider, relayer)
+        }))
+
+        const signers = [...NestedSigners, ...EOAsigners]
+
+        const config = {
+          threshold: 3,
+          signers: signers.map((s) => ({ weight: 1, address: s.address}))
+        }
+
+        const wallet = new Wallet({ context, config }, ...signers)
+        return wallet.connect(ethnode.provider, relayer)
+      }
+    }
+  ]
+
+    options.map((o) => {
+      describe(`with ${o.name}`, () => {
+        let wallet: Wallet
+
+        beforeEach(async () => {
+          wallet = await o.getWallet()
+        })
+
+        describe("with deployed wallet", () => {
+          let txs: Transaction[]
+    
+          beforeEach(async () => {
+            await relayer.deployWallet(wallet.config, wallet.context)
+            txs = [{
+              delegateCall: false,
+              revertOnError: false,
+              gasLimit: 0,
+              to: callReceiver.address,
+              value: ethers.constants.Zero,
+              data: await encodeData(callReceiver, "testCall", 14442, "0x112233"),
+              nonce: 0
+            }]
+          })
+
+          it("should use estimated gas for a single transaction", async () => {
+            const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
+            const realTx = await (await wallet.sendTransaction(estimation.transactions)).wait(1)
+
+            expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 5000)
+            expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
+
+            expect((await callReceiver.lastValA()).toNumber()).to.equal(14442)
+          })
+
+          it("should predict gas usage for a single transaction", async () => {
+            const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
+            const realTx = await (await wallet.sendTransaction(txs)).wait(1)
+    
+            expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 5000)
+            expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
+    
+            expect((await callReceiver.lastValA()).toNumber()).to.equal(14442)
+          })
+
+          it("should use estimated gas for a single failing transaction", async () => {
+            await callReceiver.setRevertFlag(true)
+            const estimation = await estimator.estimateGasLimits(wallet.config, wallet.context, ...txs)
+            const realTx = await (await wallet.sendTransaction(estimation.transactions)).wait(1)
+    
+            expect(realTx.gasUsed.toNumber()).to.be.approximately(estimation.total.toNumber(), 5000)
+            expect(realTx.gasUsed.toNumber()).to.be.below(estimation.total.toNumber())
+    
+            expect((await callReceiver.lastValA()).toNumber()).to.equal(0)
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/estimator/tests/sequence-estimator.spec.ts
+++ b/packages/estimator/tests/sequence-estimator.spec.ts
@@ -100,7 +100,7 @@ describe('Wallet integration', function () {
     relayer = new LocalRelayer({signer: ethnode.signer })
 
     // Create gas estimator
-    estimator = new OverwriterSequenceEstimator(new OverwriterEstimator(ethnode.provider))
+    estimator = new OverwriterSequenceEstimator(new OverwriterEstimator({ rpc: ethnode.provider }))
   })
 
   function sleep(ms: number) {

--- a/packages/estimator/tests/sequence-estimator.spec.ts
+++ b/packages/estimator/tests/sequence-estimator.spec.ts
@@ -172,6 +172,22 @@ describe('Wallet integration', function () {
         const wallet = new Wallet({ context, config }, ...signers)
         return wallet.connect(ethnode.provider, relayer)
       }
+    }, {
+      name: "asymetrical signers wallet",
+      getWallet: async () => {
+        const signersA = new Array(5).fill(0).map(() => ethers.Wallet.createRandom())
+        const signersB = new Array(6).fill(0).map(() => ethers.Wallet.createRandom())
+
+        const signers = [...signersA, ...signersB]
+
+        const config = {
+          threshold: 5,
+          signers: signers.map((s, i) => ({ weight: (i <= signersA.length ? 1 : 10), address: s.address}))
+        }
+
+        const wallet = new Wallet({ context, config }, ...signersA)
+        return wallet.connect(ethnode.provider, relayer)
+      }
     }
   ]
 
@@ -187,6 +203,7 @@ describe('Wallet integration', function () {
           let txs: Transaction[]
     
           beforeEach(async () => {
+            await callReceiver.testCall(0, [])
             await relayer.deployWallet(wallet.config, wallet.context)
           })
 

--- a/packages/estimator/tsconfig.json
+++ b/packages/estimator/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/multicall/package.json
+++ b/packages/multicall/package.json
@@ -20,7 +20,7 @@
     "ethers": "^5.0.32"
   },
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "1.8.0",
+    "@0xsequence/wallet-contracts": "1.9.1",
     "@types/web3-provider-engine": "^14.0.0",
     "eth-json-rpc-middleware": "^7.0.1",
     "json-rpc-engine": "^6.1.0",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@0xsequence/wallet-contracts": "1.8.0",
+    "@0xsequence/wallet-contracts": "1.9.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "ganache-core": "^2.13.2",
     "web3": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     js-base64 "^3.6.0"
 
-"@0xsequence/wallet-contracts@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@0xsequence/wallet-contracts/-/wallet-contracts-1.8.0.tgz#1a1fbd4f22d2f7768201e2d692fe8adb9a9975c0"
-  integrity sha512-H2D3RTv1x2w0VdjoZBQ3tSSkrkT6QYfRy9Gcx69RoL8+1r1pk57wKAW1wHGPGvkYfA7mbiKAz9abcsZTOuOZWA==
+"@0xsequence/wallet-contracts@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@0xsequence/wallet-contracts/-/wallet-contracts-1.9.1.tgz#5e1b8e579ba452a58c1856bfcfd2e41e0935973f"
+  integrity sha512-wq74t1sZtwdL3arrgmn8IvaO2A82e1jgWTWxlFDA5jgbkAnYeQcXfHt3R6mNAx1YJZ8692NEiE9yHkN/5s0Ibw==
   optionalDependencies:
     ethers "^5.0.32"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7766,7 +7766,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-hosted-git-info@2.8.9, hosted-git-info@^2.1.4:
+hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,6 +1940,18 @@
     camel-case "4.1.1"
     tslib "~2.0.1"
 
+"@hapi/hoek@^9.0.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@httptoolkit/httpolyglot@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@httptoolkit/httpolyglot/-/httpolyglot-1.0.0.tgz#1b06642389303b71681b4c0c2caff8be53d58a10"
@@ -2259,6 +2271,23 @@
   dependencies:
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
+
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -8658,6 +8687,17 @@ jest-worker@^26.3.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+joi@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20"
+  integrity sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
 js-base64@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.0.tgz#773e1de628f4f298d65a7e9842c50244751f5756"
@@ -11642,6 +11682,13 @@ rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.2.0.tgz#5cd12409639e9514a71c9f5f9192b2c4ae94de31"
+  integrity sha512-aX8w9OpKrQmiPKfT1bqETtUr9JygIz6GZ+gql8v7CijClsP0laoFUdKzxFAoWuRdSlOdU2+crss+cMf+cqMTnw==
+  dependencies:
+    tslib "~2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -12850,7 +12897,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3:
+tslib@^2.0.0, tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
@@ -13294,6 +13341,17 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+wait-on@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
+  integrity sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==
+  dependencies:
+    axios "^0.21.1"
+    joi "^17.4.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    rxjs "^7.1.0"
 
 watchpack@^2.0.0:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7766,7 +7766,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-hosted-git-info@^2.1.4:
+hosted-git-info@2.8.9, hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==


### PR DESCRIPTION
- Estimate gas usage using `eth_call` and overwrites
- Use docker geth instance for testing
- Compute gas usage of transactions in batch by measuring delta between partial estimations
- Support nested Sequence wallets up to a depth of 1 (assumes 2/3 config for the child sequence wallets)
- Account for calldata and base cost
