### PR TITLE
fix: support queue higher than batches

### DIFF
--- a/packages/multicall/src/multicall.ts
+++ b/packages/multicall/src/multicall.ts
@@ -57,7 +57,7 @@ export class Multicall {
   private queue = [] as QueueEntry[]
 
   scheduleExecution = () => {
-    if (this.queue.length < this.options.batchSize) {
+    if (this.queue.length > 0) {
       if (this.timeout) clearTimeout(this.timeout)
       this.timeout = setTimeout(this.run, this.options.timeWindow)
     }


### PR DESCRIPTION
If the queue's size is high enough to make this true `batchsize < queue - batchsize`.  Subsequent requests are not going to be processed