### PR TITLE
fix: build

### DIFF
--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -1,9 +1,8 @@
 import { BigNumberish } from 'ethers'
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { Relayer } from '@0xsequence/relayer'
+import { Relayer, RpcRelayerOptions } from '@0xsequence/relayer'
 import { urlClean } from '@0xsequence/utils'
 import { createNetworkConfig } from './utils'
-import { RpcRelayerOptions } from '@0xsequence/relayer/src/rpc-relayer'
 
 export interface NetworkConfig {
   title?: string

--- a/packages/relayer/src/rpc-relayer/index.ts
+++ b/packages/relayer/src/rpc-relayer/index.ts
@@ -1,4 +1,4 @@
-import { TransactionResponse, BlockTag } from '@ethersproject/providers'
+import { TransactionResponse } from '@ethersproject/providers'
 import { ethers } from 'ethers'
 import fetchPonyfill from 'fetch-ponyfill'
 import {
@@ -131,7 +131,7 @@ export class RpcRelayer extends BaseRelayer implements Relayer {
     }
   }
 
-  async getNonce(config: WalletConfig, context: WalletContext, space?: number, blockTag?: BlockTag): Promise<number> {
+  async getNonce(config: WalletConfig, context: WalletContext, space?: number): Promise<number> {
     const addr = addressOf(config, context)
     logger.info(`[rpc-relayer/getNonce] get nonce for wallet ${addr} space: ${space}`)
     const resp = await this.service.getMetaTxnNonce({ walletContractAddress: addr })


### PR DESCRIPTION
If the project uses `multicall`, `@0xsequence/relayer@latest` is needed and if you have in your `tsconfig.json` the following property:  `"noUnusedParameters": true,` the build fails with: 

```
node_modules/@0xsequence/relayer/src/rpc-relayer/index.ts:1:31 - error TS6133: 'BlockTag' is declared but its value is never read.

1 import { TransactionResponse, BlockTag } from '@ethersproject/providers'
                                ~~~~~~~~


Found 1 error.
```

This PR, remove unused properties and simplify an import