### PR TITLE
multicall - Fix reporting of error in MulticallProvider

### DIFF
--- a/packages/multicall/src/providers/provider.ts
+++ b/packages/multicall/src/providers/provider.ts
@@ -74,7 +74,7 @@ export class MulticallProvider extends ethers.providers.BaseProvider {
   }
 
   private callback(req: JsonRpcRequest, callback: JsonRpcResponseCallback, resp: any, err?: any) {
-    callback(undefined, {
+    callback(err, {
       jsonrpc: JsonRpcVersion,
       id: req.id!,
       result: resp,

--- a/packages/multicall/tests/multicall.spec.ts
+++ b/packages/multicall/tests/multicall.spec.ts
@@ -410,7 +410,7 @@ describe('Multicall integration', function () {
 
           const multiCallMockB = callMockB.connect(provider)
 
-          await expect(multiCallMockB.callStatic.testCall(1, "0x1122")).to.be.rejected
+          await expect(multiCallMockB.callStatic.testCall(1, "0x1122")).to.be.rejectedWith('VM Exception while processing transaction: revert CallReceiverMock#testCall: REVERT_FLAG')
 
           if (option.ignoreCount) return
           expect(callCounter).to.equal(1)
@@ -425,7 +425,7 @@ describe('Multicall integration', function () {
           await expect(Promise.all([
             multiCallMockB.callStatic.testCall(1, "0x1122"),
             multiCallMockB.callStatic.testCall(2, "0x1122")
-          ])).to.be.rejected
+          ])).to.be.rejectedWith('VM Exception while processing transaction: revert CallReceiverMock#testCall: REVERT_FLAG')
 
           if (option.ignoreCount) return
           expect(callCounter).to.equal(3)


### PR DESCRIPTION
This PR fixes the reporting of errors in MulticallProvider by returning errors in the callback's error parameter.

I left the error in the callback `JsonRpcResponse` payload to prevent possible side effects. **Please confirm** if the error needs to be removed from this `JsonRpcResponse` payload.

I added checks to the error returned in the unit-test to assert the correct error is returned (it was returning `Cannot read property 'toHexString' of undefined` instead of the actual error).

Here are the logs of the tests before the fix:
```
  1) Multicall integration
       Ether.js provider wrapper
         Handle errors
           Should retry after failing to execute using batch:

      AssertionError: expected promise to be rejected with an error including 'VM Exception while processing transaction: revert CallReceiverMock#testCall: REVERT_FLAG' but got 'Cannot read property \'toHexString\' of undefined'
      + expected - actual

      -Cannot read property 'toHexString' of undefined
      +VM Exception while processing transaction: revert CallReceiverMock#testCall: REVERT_FLAG



  2) Multicall integration
       Ether.js provider wrapper (without proxy)
         Handle errors
           Should retry after failing to execute using batch:

      AssertionError: expected promise to be rejected with an error including 'VM Exception while processing transaction: revert CallReceiverMock#testCall: REVERT_FLAG' but got 'Cannot read property \'toHexString\' of undefined'
      + expected - actual

      -Cannot read property 'toHexString' of undefined
      +VM Exception while processing transaction: revert CallReceiverMock#testCall: REVERT_FLAG
```