### PR TITLE
More connect options

### DIFF
--- a/packages/provider/src/transports/window-transport/window-message-provider.ts
+++ b/packages/provider/src/transports/window-transport/window-message-provider.ts
@@ -82,7 +82,7 @@ export class WindowMessageProvider extends BaseProviderTransport {
     this._init = InitState.NIL
     this._sessionId = `${performance.now()}`
     windowSessionParams.set('sid', this._sessionId)
-    
+
     if (intent) {
       // for the window-transport, we eagerly/optimistically set the origin host
       // when connecting to the wallet, however, this will be verified and enforced
@@ -96,7 +96,7 @@ export class WindowMessageProvider extends BaseProviderTransport {
           intent.options.origin = window.location.origin
         }
       }
-      // encode intent as base6 url-encoded param
+      // encode intent as base64 url-encoded param
       windowSessionParams.set('intent', base64EncodeObject(intent))
     }
     if (networkId) {
@@ -109,16 +109,13 @@ export class WindowMessageProvider extends BaseProviderTransport {
 
     if (isBrowserExtension()) {
       windowSize = [450, 750]
-      windowPos = [
-        Math.abs(window.screen.width / 2 - windowSize[0] / 2),
-        Math.abs(window.screen.height / 2 - windowSize[1] / 2)
-      ]
+      windowPos = [Math.abs(window.screen.width / 2 - windowSize[0] / 2), Math.abs(window.screen.height / 2 - windowSize[1] / 2)]
     } else {
       windowSize = [450, 750]
       windowPos = [
         Math.abs(window.screenX + window.innerWidth / 2 - windowSize[0] / 2),
         Math.abs(window.screenY + window.innerHeight / 2 - windowSize[1] / 2)
-      ]  
+      ]
     }
 
     const windowFeatures =

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -135,49 +135,49 @@ export enum InitState {
 }
 
 export interface ConnectOptions {
-  // networkId specifics the default network a dapp would like to connect to. This field
-  // is optional as it can be provided a number of different ways.
+  /** Specifies the default network a dapp would like to connect to. This field
+  is optional as it can be provided a number of different ways. */
   networkId?: string | number
 
-  // app name of the dapp which will be announced to user on connect screen
+  /** app name of the dapp which will be announced to user on connect screen */
   app?: string
 
-  // origin hint of the dapp's host opening the wallet. This value will automatically
-  // be determined and verified for integrity, and can be omitted.
+  /** origin hint of the dapp's host opening the wallet. This value will automatically
+  be determined and verified for integrity, and can be omitted. */
   origin?: string
 
-  // expiry number (in seconds) to expire connect session. default is 1 week of seconds.
+  /** expiry number (in seconds) to expire connect session. default is 1 week of seconds. */
   expiry?: number
 
-  // authorize will perform an ETHAuth eip712 signing and return the proof to the dapp.
+  /** authorize will perform an ETHAuth eip712 signing and return the proof to the dapp. */
   authorize?: boolean
 
-  // askForEmail will prompt to give permission to the dapp to access email address
+  /** *Currently not used* askForEmail will prompt to give permission to the dapp to access email address */
   // TODO: this feature is currently not used as the wallet does not report emails yet
   askForEmail?: boolean
 
-  // refresh flag will force a full re-connect (ie. disconnect then connect again)
+  /** refresh flag will force a full re-connect (ie. disconnect then connect again) */
   refresh?: boolean
 
-  // keepWalletOpened will keep the wallet window opened after connecting. The default
-  // is to automatically close the wallet after connecting.
+  /** keepWalletOpened will keep the wallet window opened after connecting. The default
+  is to automatically close the wallet after connecting. */
   keepWalletOpened?: boolean
 
-  // Specify a wallet theme, which will also become the default wallet theme.
+  /** Specify a wallet theme, which will also become the default wallet theme. */
   theme?: ThemeOption
 
-  // Specify payment providers to use. If not specified,
-  // all available payment providers will be enabled.
+  /** Specify payment providers to use. If not specified,
+  all available payment providers will be enabled. */
   includedPaymentProviders?: PaymentProviderOption[]
 
-  // Specify a default currency to use with payment providers.
-  // If not specified, the default is USDC.
+  /** Specify a default currency to use with payment providers.
+  If not specified, the default is USDC. */
   defaultFundingCurrency?: CurrencyOption
 
-  // If true, lockFundingCurrencyToDefault disables picking any currency provided by payment
-  // providers other than the defaultFundingCurrency.
-  // If false, it allows picking any currency provided by payment providers.
-  // The default is true.
+  /** If true, lockFundingCurrencyToDefault disables picking any currency provided by payment
+  providers other than the defaultFundingCurrency.
+  If false, it allows picking any currency provided by payment providers.
+  The default is true. */
   lockFundingCurrencyToDefault?: boolean
 }
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -169,11 +169,10 @@ export interface ConnectOptions {
 
 /** Options to further customize the wallet experience. */
 export interface Settings {
-  /** Specify a wallet theme, which will also become the default wallet theme.
-   * light and dark are the main themes, to use other themes in wallet settings,
-   * you can use the camel case version of the name in the wallet settings.
+  /** Specify a wallet theme. `light` and `dark` are the main themes, to use other available
+   * themes, you can use the camel case version of the theme names in the wallet settings.
    * For example: "Blue Dark" on wallet UI can be passed as "blueDark".
-   * Can be persisted with setAsDefault option. */
+   * This setting can be persisted with setAsDefault parameter. */
   theme?: ThemeOption
 
   /** Specify payment providers to use. If not specified,

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -136,14 +136,14 @@ export enum InitState {
 
 export interface ConnectOptions {
   /** Specifies the default network a dapp would like to connect to. This field
-  is optional as it can be provided a number of different ways. */
+   * is optional as it can be provided a number of different ways. */
   networkId?: string | number
 
   /** app name of the dapp which will be announced to user on connect screen */
   app?: string
 
   /** origin hint of the dapp's host opening the wallet. This value will automatically
-  be determined and verified for integrity, and can be omitted. */
+   * be determined and verified for integrity, and can be omitted. */
   origin?: string
 
   /** expiry number (in seconds) to expire connect session. default is 1 week of seconds. */
@@ -160,28 +160,34 @@ export interface ConnectOptions {
   refresh?: boolean
 
   /** keepWalletOpened will keep the wallet window opened after connecting. The default
-  is to automatically close the wallet after connecting. */
+   * is to automatically close the wallet after connecting. */
   keepWalletOpened?: boolean
 
-  /** Specify a wallet theme, which will also become the default wallet theme. */
+  /** Specify a wallet theme, which will also become the default wallet theme.
+   * light and dark are the main themes, to use other themes in wallet settings,
+   * you can use the camel case version of the name in the wallet settings.
+   * For example: "Blue Dark" on wallet UI can be passed as "blueDark" */
   theme?: ThemeOption
 
   /** Specify payment providers to use. If not specified,
-  all available payment providers will be enabled. */
+   * all available payment providers will be enabled. */
   includedPaymentProviders?: PaymentProviderOption[]
 
   /** Specify a default currency to use with payment providers.
-  If not specified, the default is USDC. */
+   * If not specified, the default is USDC. */
   defaultFundingCurrency?: CurrencyOption
 
   /** If true, lockFundingCurrencyToDefault disables picking any currency provided by payment
-  providers other than the defaultFundingCurrency.
-  If false, it allows picking any currency provided by payment providers.
-  The default is true. */
+   * providers other than the defaultFundingCurrency.
+   * If false, it allows picking any currency provided by payment providers.
+   * The default is true. */
   lockFundingCurrencyToDefault?: boolean
 }
 
-export type ThemeOption = 'light' | 'dark' | string
+/** light and dark are the main themes, to use other themes in wallet settings,
+ * you can use the camel case version of the name in the wallet settings.
+ * For example: "Blue Dark" on wallet UI can be passed as "blueDark" */
+export type ThemeOption = { name: 'light' | 'dark' | string; setAsDefault: boolean }
 export type PaymentProviderOption = 'moonpay' | 'wyre' | 'ramp'
 export type CurrencyOption = 'usdc' | 'eth' | 'matic'
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -163,24 +163,37 @@ export interface ConnectOptions {
    * is to automatically close the wallet after connecting. */
   keepWalletOpened?: boolean
 
+  /** Options to further customize the wallet experience. */
+  settings?: Settings
+}
+
+/** Options to further customize the wallet experience. */
+export interface Settings {
   /** Specify a wallet theme, which will also become the default wallet theme.
    * light and dark are the main themes, to use other themes in wallet settings,
    * you can use the camel case version of the name in the wallet settings.
-   * For example: "Blue Dark" on wallet UI can be passed as "blueDark" */
+   * For example: "Blue Dark" on wallet UI can be passed as "blueDark".
+   * Can be persisted with setAsDefault option. */
   theme?: ThemeOption
 
   /** Specify payment providers to use. If not specified,
-   * all available payment providers will be enabled. */
+   * all available payment providers will be enabled.
+   * Note that this setting will not be persisted, use wallet.open with 'openWithOptions' intent
+   * to set when you open the wallet for user. */
   includedPaymentProviders?: PaymentProviderOption[]
 
   /** Specify a default currency to use with payment providers.
-   * If not specified, the default is USDC. */
+   * If not specified, the default is USDC.
+   * Note that this setting will not be persisted, use wallet.open with 'openWithOptions' intent
+   * to set when you open the wallet for user. */
   defaultFundingCurrency?: CurrencyOption
 
   /** If true, lockFundingCurrencyToDefault disables picking any currency provided by payment
    * providers other than the defaultFundingCurrency.
    * If false, it allows picking any currency provided by payment providers.
-   * The default is true. */
+   * The default is true.
+   * Note that this setting will not be persisted, use wallet.open with 'openWithOptions' intent
+   * to set when you open the wallet for user. */
   lockFundingCurrencyToDefault?: boolean
 }
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -172,7 +172,8 @@ export interface Settings {
   /** Specify a wallet theme. `light` and `dark` are the main themes, to use other available
    * themes, you can use the camel case version of the theme names in the wallet settings.
    * For example: "Blue Dark" on wallet UI can be passed as "blueDark".
-   * This setting can be persisted with setAsDefault parameter. */
+   * Note that this setting will not be persisted, use wallet.open with 'openWithOptions' intent
+   * to set when you open the wallet for user. */
   theme?: ThemeOption
 
   /** Specify payment providers to use. If not specified,
@@ -199,7 +200,7 @@ export interface Settings {
 /** light and dark are the main themes, to use other themes in wallet settings,
  * you can use the camel case version of the name in the wallet settings.
  * For example: "Blue Dark" on wallet UI can be passed as "blueDark" */
-export type ThemeOption = { name: 'light' | 'dark' | string; setAsDefault: boolean }
+export type ThemeOption = 'light' | 'dark' | string
 export type PaymentProviderOption = 'moonpay' | 'wyre' | 'ramp'
 export type CurrencyOption = 'usdc' | 'eth' | 'matic'
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -23,7 +23,7 @@ export interface WalletTransport extends JsonRpcHandler, ProviderMessageTranspor
   register(): void
   unregister(): void
 
-  notifyOpen(openInfo: { chainId?: string, sessionId?: string, session?: WalletSession, error?: string }): void
+  notifyOpen(openInfo: { chainId?: string; sessionId?: string; session?: WalletSession; error?: string }): void
   notifyClose(error?: ProviderRpcError): void
 
   notifyConnect(connectDetails: ConnectDetails): void
@@ -33,10 +33,10 @@ export interface WalletTransport extends JsonRpcHandler, ProviderMessageTranspor
 }
 
 export interface ProviderMessage<T> {
-  idx: number       // message id number
-  type: string      // message type
-  data: T           // the ethereum json-rpc payload
-  chainId?: number  // chain id which the message is intended
+  idx: number // message id number
+  type: string // message type
+  data: T // the ethereum json-rpc payload
+  chainId?: number // chain id which the message is intended
 }
 
 export type ProviderMessageRequest = ProviderMessage<JsonRpcRequest>
@@ -83,8 +83,8 @@ export class WindowSessionParams extends URLSearchParams {
 
 export interface TransportSession {
   sessionId?: string | null
-  networkId?: string | number | null,
-  intent?: OpenWalletIntent,
+  networkId?: string | number | null
+  intent?: OpenWalletIntent
 }
 
 export enum EventType {
@@ -105,21 +105,21 @@ export enum EventType {
 }
 
 export interface WalletEventTypes {
-  'open': (openInfo: { chainId?: string, sessionId?: string, session?: WalletSession, error?: string }) => void
-  'close': (error?: ProviderRpcError) => void
+  open: (openInfo: { chainId?: string; sessionId?: string; session?: WalletSession; error?: string }) => void
+  close: (error?: ProviderRpcError) => void
 
-  'connect': (connectDetails: ConnectDetails) => void
-  'disconnect': (error?: ProviderRpcError) => void
+  connect: (connectDetails: ConnectDetails) => void
+  disconnect: (error?: ProviderRpcError) => void
 
-  'accountsChanged': (accounts: string[]) => void
-  'chainChanged': (chainIdHex: string) => void
+  accountsChanged: (accounts: string[]) => void
+  chainChanged: (chainIdHex: string) => void
 
-  'networks': (networks: NetworkConfig[]) => void
-  'walletContext': (walletContext: WalletContext) => void
+  networks: (networks: NetworkConfig[]) => void
+  walletContext: (walletContext: WalletContext) => void
 }
 
 export interface ProviderEventTypes extends WalletEventTypes {
-  'message': (message: ProviderMessageResponse) => void
+  message: (message: ProviderMessageResponse) => void
 }
 
 export enum OpenState {
@@ -162,7 +162,28 @@ export interface ConnectOptions {
   // keepWalletOpened will keep the wallet window opened after connecting. The default
   // is to automatically close the wallet after connecting.
   keepWalletOpened?: boolean
+
+  // Specify a wallet theme, which will also become the default wallet theme.
+  theme?: ThemeOption
+
+  // Specify payment providers to use. If not specified,
+  // all available payment providers will be enabled.
+  includedPaymentProviders?: PaymentProviderOption[]
+
+  // Specify a default currency to use with payment providers.
+  // If not specified, the default is USDC.
+  defaultFundingCurrency?: CurrencyOption
+
+  // If true, lockFundingCurrencyToDefault disables picking any currency provided by payment
+  // providers other than the defaultFundingCurrency.
+  // If false, it allows picking any currency provided by payment providers.
+  // The default is true.
+  lockFundingCurrencyToDefault?: boolean
 }
+
+export type ThemeOption = 'light' | 'dark' | string
+export type PaymentProviderOption = 'moonpay' | 'wyre' | 'ramp'
+export type CurrencyOption = 'usdc' | 'eth' | 'matic'
 
 export interface ConnectDetails {
   // chainId (in hex) and error are defined by EIP-1193 expected fields
@@ -187,8 +208,9 @@ export interface ConnectDetails {
 export type PromptConnectDetails = Pick<ConnectDetails, 'chainId' | 'error' | 'connected' | 'proof' | 'email'>
 
 export type OpenWalletIntent =
-  { type: 'connect'; options?: ConnectOptions } |
-  { type: 'jsonRpcRequest'; method: string }
+  | { type: 'connect'; options?: ConnectOptions }
+  | { type: 'openWithOptions'; options?: ConnectOptions }
+  | { type: 'jsonRpcRequest'; method: string }
 
 export interface MessageToSign {
   message?: string
@@ -230,23 +252,21 @@ export const ErrSignedInRequired = new ProviderError('Wallet is not signed in. C
 
 // TODO: lets build some nice error handling tools, prob in /utils ...
 
-export interface TypedEventEmitter<Events>{
-  addListener<E extends keyof Events> (event: E, listener: Events[E]): this
-  on<E extends keyof Events> (event: E, listener: Events[E]): this
-  once<E extends keyof Events> (event: E, listener: Events[E]): this
-  prependListener<E extends keyof Events> (event: E, listener: Events[E]): this
-  prependOnceListener<E extends keyof Events> (event: E, listener: Events[E]): this
+export interface TypedEventEmitter<Events> {
+  addListener<E extends keyof Events>(event: E, listener: Events[E]): this
+  on<E extends keyof Events>(event: E, listener: Events[E]): this
+  once<E extends keyof Events>(event: E, listener: Events[E]): this
+  prependListener<E extends keyof Events>(event: E, listener: Events[E]): this
+  prependOnceListener<E extends keyof Events>(event: E, listener: Events[E]): this
 
   off<E extends keyof Events>(event: E, listener: Events[E]): this
-  removeAllListeners<E extends keyof Events> (event?: E): this
-  removeListener<E extends keyof Events> (event: E, listener: Events[E]): this
+  removeAllListeners<E extends keyof Events>(event?: E): this
+  removeListener<E extends keyof Events>(event: E, listener: Events[E]): this
 
-  emit<E extends keyof Events> (event: E, ...args: Arguments<Events[E]>): boolean
-  eventNames (): (keyof Events | string | symbol)[]
-  listeners<E extends keyof Events> (event: E): Function[]
-  listenerCount<E extends keyof Events> (event: E): number
+  emit<E extends keyof Events>(event: E, ...args: Arguments<Events[E]>): boolean
+  eventNames(): (keyof Events | string | symbol)[]
+  listeners<E extends keyof Events>(event: E): Function[]
+  listenerCount<E extends keyof Events>(event: E): number
 }
 
-type Arguments<T> = [T] extends [(...args: infer U) => any]
-  ? U
-  : [T] extends [void] ? [] : [T]
+type Arguments<T> = [T] extends [(...args: infer U) => any] ? U : [T] extends [void] ? [] : [T]


### PR DESCRIPTION
- Adds `theme`,  `includedPaymentProviders`, `defaultFundingCurrency` and `lockFundingCurrencyToDefault` setting options and types for supporting.
- Adds `openWithOptions` intent.
-`includedPaymentProviders`, `defaultFundingCurrency` and `lockFundingCurrencyToDefault` are not persisted, dApps can pass `openWithOptions` intent to `wallet.openWallet(path, intent)` to specify these options.

You can see a video of the feature in action here:
https://github.com/0xsequence/demo-dapp/pull/3