### PR TITLE
Add prefix for EIP-191 signature before hashing (Alternative)

### DIFF
--- a/packages/0xsequence/tests/browser/proxy-transport/channel.test.ts
+++ b/packages/0xsequence/tests/browser/proxy-transport/channel.test.ts
@@ -1,4 +1,4 @@
-import { Web3Provider, ProxyMessageProvider, WalletSession, WalletRequestHandler, ProxyMessageChannel, ProxyMessageHandler } from '@0xsequence/provider'
+import { Web3Provider, ProxyMessageProvider, WalletSession, WalletRequestHandler, ProxyMessageChannel, ProxyMessageHandler, prefixEIP191Message } from '@0xsequence/provider'
 import { ethers, Wallet as EOAWallet } from 'ethers'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { test, assert } from '../../utils/assert'
@@ -6,7 +6,7 @@ import { sequenceContext, testnetNetworks } from '@0xsequence/network'
 import { Wallet, isValidSignature, recoverConfig } from '@0xsequence/wallet'
 import { addressOf } from '@0xsequence/config'
 import { LocalRelayer } from '@0xsequence/relayer'
-import { configureLogger, packMessageData } from '@0xsequence/utils'
+import { configureLogger, encodeMessageDigest, packMessageData } from '@0xsequence/utils'
 import { testAccounts, getEOAWallet } from '../testutils'
 
 configureLogger({ logLevel: 'DEBUG', silence: false })
@@ -133,7 +133,7 @@ export const tests = async () => {
     const sig = await signer.signMessage(message)
     assert.equal(
       sig,
-      '0x0001000148ac663d58ddee141c0bc98f95d2d3017a5328017e3792a8c431186c66669649369aac41bd649cda1708a5af53d5477fa64106faaed4755cf516e559c0bcf51b1c02',
+      '0x00010001230f8b68557d982f26234c9c7ce4ff35a449392c1e7cbc9a1129268ce2acea40529252535b1caa300e30d53d5c24009cb6f2fafd0e132944016f9472c1a0cc8b1b02',
       'signature match'
     )
 
@@ -143,9 +143,10 @@ export const tests = async () => {
     //
     // Verify the message signature
     //
-    const messageDigest = ethers.utils.arrayify(ethers.utils.keccak256(message))
+    // const messageDigest = ethers.utils.arrayify(ethers.utils.keccak256(message))
+    const messageDigest = encodeMessageDigest(prefixEIP191Message(message))
     const isValid = await isValidSignature(address, messageDigest, sig, provider, sequenceContext, chainId)
-    assert.true(isValid, 'signature is valid')
+    assert.true(isValid, 'signature is valid - 1')
 
     // also compute the subDigest of the message, to be provided to the end-user
     // in order to recover the config properly, the subDigest + sig is required.
@@ -158,7 +159,7 @@ export const tests = async () => {
     const walletConfig = await recoverConfig(subDigest, sig)
 
     const recoveredWalletAddress = addressOf(walletConfig, sequenceContext)
-    assert.true(recoveredWalletAddress === address, 'recover address')
+    assert.true(recoveredWalletAddress === address, 'recover address - 1')
 
     const singleSignerAddress = ethers.utils.getAddress('0x4e37E14f5d5AAC4DF1151C6E8DF78B7541680853') // expected from mock-wallet owner
     assert.true(singleSignerAddress === walletConfig.signers[0].address, 'owner address check')

--- a/packages/0xsequence/tests/browser/wallet-provider/dapp.test.ts
+++ b/packages/0xsequence/tests/browser/wallet-provider/dapp.test.ts
@@ -1,7 +1,7 @@
 import { test, assert } from '../../utils/assert'
 import { ethers } from 'ethers'
 import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer'
-import { Wallet, DefaultProviderConfig } from '@0xsequence/provider'
+import { Wallet, DefaultProviderConfig, isValidMessageSignature } from '@0xsequence/provider'
 import { WalletContext } from '@0xsequence/network'
 import { testAccounts, getEOAWallet, testWalletContext, sendETH } from '../testutils'
 import { Transaction, TransactionRequest } from '@0xsequence/transactions'
@@ -201,6 +201,10 @@ export const tests = async () => {
     const isValid = await wallet.utils.isValidMessageSignature(address, message, sig, chainId)
     assert.true(isValid, 'signature is valid - 2')
 
+    // Verify signature with other util
+    const isValid2 = await isValidMessageSignature(address, message, sig, provider)
+    assert.true(isValid2, 'signature is valid - 2b')
+
     // Recover the address / config from the signature
     const walletConfig = await wallet.utils.recoverWalletConfigFromMessage(address, message, sig, chainId)
     assert.true(walletConfig.address === address, 'recover address - 2')
@@ -283,6 +287,10 @@ export const tests = async () => {
     // Verify the signature
     const isValid = await wallet.utils.isValidMessageSignature(address, message, sig, chainId)
     assert.true(isValid, 'signAuthMessage, signature is valid')
+
+    // Verify signature with other util
+    const isValid2 = await isValidMessageSignature(address, message, sig, authProvider)
+    assert.true(isValid2, 'signAuthMessage, signature is valid')
 
     // Recover the address / config from the signature
     const walletConfig = await wallet.utils.recoverWalletConfigFromMessage(address, message, sig, chainId)

--- a/packages/0xsequence/tests/browser/wallet-provider/dapp.test.ts
+++ b/packages/0xsequence/tests/browser/wallet-provider/dapp.test.ts
@@ -190,7 +190,7 @@ export const tests = async () => {
       const sig = await signer.signMessage(m)
       assert.equal(
         sig,
-        '0x0001000148ac663d58ddee141c0bc98f95d2d3017a5328017e3792a8c431186c66669649369aac41bd649cda1708a5af53d5477fa64106faaed4755cf516e559c0bcf51b1c02',
+        '0x00010001230f8b68557d982f26234c9c7ce4ff35a449392c1e7cbc9a1129268ce2acea40529252535b1caa300e30d53d5c24009cb6f2fafd0e132944016f9472c1a0cc8b1b02',
         'signature match'
       )
       return sig
@@ -199,11 +199,11 @@ export const tests = async () => {
 
     // Verify the signature
     const isValid = await wallet.utils.isValidMessageSignature(address, message, sig, chainId)
-    assert.true(isValid, 'signature is valid')
+    assert.true(isValid, 'signature is valid - 2')
 
     // Recover the address / config from the signature
     const walletConfig = await wallet.utils.recoverWalletConfigFromMessage(address, message, sig, chainId)
-    assert.true(walletConfig.address === address, 'recover address')
+    assert.true(walletConfig.address === address, 'recover address - 2')
 
     const singleSignerAddress = '0x4e37E14f5d5AAC4DF1151C6E8DF78B7541680853' // expected from mock-wallet owner
     assert.true(singleSignerAddress === walletConfig.signers[0].address, 'owner address check')
@@ -241,11 +241,11 @@ export const tests = async () => {
 
     // Verify typed data
     const isValid = await wallet.utils.isValidTypedDataSignature(address, { domain, types, message }, sig, chainId)
-    assert.true(isValid, 'signature is valid')
+    assert.true(isValid, 'signature is valid - 3')
 
     // Recover config / address
     const walletConfig = await wallet.utils.recoverWalletConfigFromTypedData(address, { domain, types, message }, sig, chainId)
-    assert.true(walletConfig.address === address, 'recover address')
+    assert.true(walletConfig.address === address, 'recover address - 3')
 
     const singleSignerAddress = '0x4e37E14f5d5AAC4DF1151C6E8DF78B7541680853' // expected from mock-wallet owner
     assert.true(singleSignerAddress === walletConfig.signers[0].address, 'owner address check')
@@ -268,7 +268,7 @@ export const tests = async () => {
     const sig = await signer.signMessage(message, chainId)
     assert.equal(
       sig,
-      '0x000100013fd9888b53c7d78755ed5304178a49c18eb15d438c85a5feabedba6eb634901b35c9184821aabbd1bb41be58f13469bc1c6eb21f7cc8f8639cbca9e2e53f78891c02',
+      '0x00010001bbbabd7be415ffbf6196f17072413bed8f9f59c530357eb479e2fbe7ea210f22428bbb18413f24fed2edc7d4e6c11d588e436a56a54497080c9434fdcfdbb8ed1b02',
       'signAuthMessage, signature match'
     )
 

--- a/packages/0xsequence/tests/browser/wallet-provider/dapp2.test.ts
+++ b/packages/0xsequence/tests/browser/wallet-provider/dapp2.test.ts
@@ -134,11 +134,11 @@ export const tests = async () => {
 
     // Verify typed data
     const isValid = await wallet.utils.isValidTypedDataSignature(address, { domain, types, message }, sig, chainId)
-    assert.true(isValid, 'signature is valid')
+    assert.true(isValid, 'signature is valid - 4')
 
     // Recover config / address
     const walletConfig = await wallet.utils.recoverWalletConfigFromTypedData(address, { domain, types, message }, sig, chainId)
-    assert.true(walletConfig.address === address, 'recover address')
+    assert.true(walletConfig.address === address, 'recover address - 4')
 
     const singleSignerAddress = '0x4e37E14f5d5AAC4DF1151C6E8DF78B7541680853' // expected from mock-wallet owner
     assert.true(singleSignerAddress === walletConfig.signers[0].address, 'owner address check')

--- a/packages/0xsequence/tests/browser/window-transport/dapp.test.ts
+++ b/packages/0xsequence/tests/browser/window-transport/dapp.test.ts
@@ -1,11 +1,11 @@
-import { WindowMessageProvider } from '@0xsequence/provider'
+import { prefixEIP191Message, WindowMessageProvider } from '@0xsequence/provider'
 import { ethers } from 'ethers'
 import { Web3Provider } from '@ethersproject/providers'
 import { test, assert } from '../../utils/assert'
 
 import { isValidSignature, recoverConfig } from '@0xsequence/wallet'
 import { addressOf } from '@0xsequence/config'
-import { configureLogger, packMessageData } from '@0xsequence/utils'
+import { configureLogger, encodeMessageDigest, packMessageData } from '@0xsequence/utils'
 
 import { testWalletContext } from '../testutils'
 
@@ -75,16 +75,16 @@ export const tests = async () => {
     const sig = await signer.signMessage(message)
     assert.equal(
       sig,
-      '0x0001000148ac663d58ddee141c0bc98f95d2d3017a5328017e3792a8c431186c66669649369aac41bd649cda1708a5af53d5477fa64106faaed4755cf516e559c0bcf51b1c02',
+      '0x00010001230f8b68557d982f26234c9c7ce4ff35a449392c1e7cbc9a1129268ce2acea40529252535b1caa300e30d53d5c24009cb6f2fafd0e132944016f9472c1a0cc8b1b02',
       'signature match'
     )
 
     //
     // Verify the message signature
     //
-    const messageDigest = ethers.utils.arrayify(ethers.utils.keccak256(message))
+    const messageDigest = encodeMessageDigest(prefixEIP191Message(message))
     const isValid = await isValidSignature(address, messageDigest, sig, provider, testWalletContext, await signer.getChainId())
-    assert.true(isValid, 'signature is valid')
+    assert.true(isValid, 'signature is valid - 5')
 
     // also compute the subDigest of the message, to be provided to the end-user
     // in order to recover the config properly, the subDigest + sig is required.
@@ -97,7 +97,7 @@ export const tests = async () => {
     const walletConfig = await recoverConfig(subDigest, sig)
 
     const recoveredWalletAddress = addressOf(walletConfig, testWalletContext)
-    assert.true(recoveredWalletAddress === address, 'recover address')
+    assert.true(recoveredWalletAddress === address, 'recover address - 5')
 
     const singleSignerAddress = '0x4e37E14f5d5AAC4DF1151C6E8DF78B7541680853' // expected from mock-wallet owner
     assert.true(singleSignerAddress === walletConfig.signers[0].address, 'owner address check')
@@ -163,7 +163,7 @@ export const tests = async () => {
     const messageHash = ethers.utils._TypedDataEncoder.hash(typedData.domain, typedData.types, typedData.message)
     const messageDigest = ethers.utils.arrayify(messageHash)
     const isValid = await isValidSignature(address, messageDigest, sig, provider, testWalletContext, await signer.getChainId())
-    assert.true(isValid, 'signature is valid')
+    assert.true(isValid, 'signature is valid - 6')
 
     // also compute the subDigest of the message, to be provided to the end-user
     // in order to recover the config properly, the subDigest + sig is required.
@@ -176,7 +176,7 @@ export const tests = async () => {
     const walletConfig = await recoverConfig(subDigest, sig)
 
     const recoveredWalletAddress = addressOf(walletConfig, testWalletContext)
-    assert.true(recoveredWalletAddress === address, 'recover address')
+    assert.true(recoveredWalletAddress === address, 'recover address - 6')
 
     const singleSignerAddress = '0x4e37E14f5d5AAC4DF1151C6E8DF78B7541680853' // expected from mock-wallet owner
     assert.true(singleSignerAddress === walletConfig.signers[0].address, 'owner address check')

--- a/packages/provider/src/transports/wallet-request-handler.ts
+++ b/packages/provider/src/transports/wallet-request-handler.ts
@@ -32,7 +32,7 @@ import { isSignedTransactions, TransactionRequest } from '@0xsequence/transactio
 import { signAuthorization, AuthorizationOptions } from '@0xsequence/auth'
 import { logger, TypedData } from '@0xsequence/utils'
 
-import { isWalletUpToDate } from '../utils'
+import { isWalletUpToDate, prefixEIP191Message } from '../utils'
 
 const SIGNER_READY_TIMEOUT = 10000
 
@@ -305,6 +305,10 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
 
           let sig = ''
 
+          // Message must be prefixed with "\x19Ethereum Signed Message:\n"
+          // as defined by EIP-191
+          message = prefixEIP191Message(message)
+
           // TODO:
           // if (process.env.TEST_MODE === 'true' && this.prompter === null) {
           if (this.prompter === null) {
@@ -313,7 +317,7 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
           } else {
             const promptResultForDeployment = await this.handleConfirmWalletDeployPrompt(this.prompter, signer, chainId)
             if (promptResultForDeployment) {
-              sig = await this.prompter.promptSignMessage({ chainId: chainId, message: message }, this.connectOptions)
+              sig = await this.prompter.promptSignMessage({ chainId: chainId, message }, this.connectOptions)
             }
           }
 

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -7,19 +7,15 @@ import { isValidSignature as _isValidSignature, recoverConfig, Signer, isValidEI
 
 const eip191prefix = ethers.utils.toUtf8Bytes("\x19Ethereum Signed Message:\n")
 
-export const messageToBytes = (message: string | Uint8Array): Uint8Array => {
-  if (typeof message !== 'string') {
-    return message
-  }
-
-  if (ethers.utils.isHexString(message)) {
+export const messageToBytes = (message: BytesLike): Uint8Array => {
+  if (ethers.utils.isBytes(message) || ethers.utils.isHexString(message)) {
     return ethers.utils.arrayify(message)
   }
 
   return ethers.utils.toUtf8Bytes(message)
 }
 
-export const prefixEIP191Message = (message: string | Uint8Array): Uint8Array => {
+export const prefixEIP191Message = (message: BytesLike): Uint8Array => {
   const messageBytes = messageToBytes(message)
   return ethers.utils.concat([
     eip191prefix,


### PR DESCRIPTION
Replaces #249 

Implements EIP-191 prefixing of message, it allow Sequence wallet to login on Opensea among other dapps.

In contrast with the #249 implementation this PR implements the prefixing at the wallet-request-handler level, this ensures low-level signing of non EIP191 messages is still available and doesn't introduce complexity at the digest utility methods.