### PR TITLE
relayer: add optional waitForReceipt parameter to Relayer.relay

### DIFF
--- a/packages/relayer/src/index.ts
+++ b/packages/relayer/src/index.ts
@@ -39,7 +39,8 @@ export interface Relayer {
 
   // relayer will submit the transaction(s) to the network and return the transaction response.
   // The quote should be the one returned from getFeeOptions, if any.
-  relay(signedTxs: SignedTransactions, quote?: FeeQuote): Promise<TransactionResponse>
+  // waitForReceipt must default to true.
+  relay(signedTxs: SignedTransactions, quote?: FeeQuote, waitForReceipt?: boolean): Promise<TransactionResponse>
 
   // wait for transaction confirmation
   // timeout is the maximum time to wait for the transaction response

--- a/packages/relayer/src/provider-relayer.ts
+++ b/packages/relayer/src/provider-relayer.ts
@@ -54,7 +54,7 @@ export abstract class ProviderRelayer extends BaseRelayer implements Relayer {
     ...transactions: Transaction[]
   ): Promise<FeeOption[]>
 
-  abstract relay(signedTxs: SignedTransactions, quote?: FeeQuote): Promise<TransactionResponse>
+  abstract relay(signedTxs: SignedTransactions, quote?: FeeQuote, waitForReceipt?: boolean): Promise<TransactionResponse>
 
   async simulate(wallet: string, ...transactions: Transaction[]): Promise<SimulateResult[]> {
     return (await Promise.all(transactions.map(async tx => {


### PR DESCRIPTION
Prior to this change, the waiting behaviour of Relayer.relay was not well-defined: The LocalRelayer never waited for a receipt; the RpcRelayer always waited for one.

With this change, the default behaviour is to wait for a receipt, and callers must explicitly specify waitForReceipt as false to not wait.