### PR TITLE
JsonRpcProvider with middleware and caching support

### DIFF
--- a/packages/0xsequence/tests/browser/json-rpc-provider/rpc.test.ts
+++ b/packages/0xsequence/tests/browser/json-rpc-provider/rpc.test.ts
@@ -1,0 +1,43 @@
+import { ethers } from 'ethers'
+import { test, assert } from '../../utils/assert'
+
+import { configureLogger } from '@0xsequence/utils'
+import { JsonRpcProvider, loggingProviderMiddleware } from '@0xsequence/network'
+
+
+configureLogger({ logLevel: 'DEBUG', silence: false })
+
+
+export const tests = async () => {  
+  
+  // const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545', 31337)
+  const provider = new JsonRpcProvider('http://localhost:8545', 31337)
+
+  await test('sending a json-rpc request', async () => {
+    {
+      const network = await provider.getNetwork()
+      console.log('network?', network)
+    }
+    {
+      const chainId = await provider.send('eth_chainId', [])
+      assert.true(ethers.BigNumber.from(chainId).toString() === '31337')
+    }
+    {
+      const chainId = await provider.send('eth_chainId', [])
+      assert.true(ethers.BigNumber.from(chainId).toString() === '31337')
+    }
+    {
+      const chainId = await provider.send('eth_chainId', [])
+      assert.true(ethers.BigNumber.from(chainId).toString() === '31337')
+    }
+    {
+      const chainId = await provider.send('eth_chainId', [])
+      assert.true(ethers.BigNumber.from(chainId).toString() === '31337')
+    }
+    {
+      const netVersion = await provider.send('net_version', [])
+      assert.true(netVersion === '31337')
+    }
+  })
+
+}

--- a/packages/0xsequence/tests/browser/mock-wallet/mock-wallet.test.ts
+++ b/packages/0xsequence/tests/browser/mock-wallet/mock-wallet.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import { WalletRequestHandler, WindowMessageHandler } from '@0xsequence/provider'
 import { Wallet, Account } from '@0xsequence/wallet'
-import { NetworkConfig } from '@0xsequence/network'
+import { NetworkConfig, JsonRpcProvider } from '@0xsequence/network'
 import { LocalRelayer } from '@0xsequence/relayer'
 import { configureLogger } from '@0xsequence/utils'
 
@@ -18,8 +18,8 @@ const main = async () => {
   //
   // Providers
   //
-  const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545')
-  const provider2 = new ethers.providers.JsonRpcProvider('http://localhost:9545')
+  const provider = new JsonRpcProvider('http://localhost:8545')
+  const provider2 = new JsonRpcProvider('http://localhost:9545')
 
   //
   // Deploy Sequence WalletContext (deterministic)

--- a/packages/0xsequence/tests/browser/mux-transport/mux.test.ts
+++ b/packages/0xsequence/tests/browser/mux-transport/mux.test.ts
@@ -12,14 +12,11 @@ import {
 } from '@0xsequence/provider'
 import { providers } from 'ethers'
 import { test, assert } from '../../utils/assert'
-import { NetworkConfig, WalletContext } from '@0xsequence/network'
+import { NetworkConfig, WalletContext, JsonRpcProvider } from '@0xsequence/network'
 import { Wallet as SequenceWallet, Account as SequenceAccount, isValidSignature, recoverConfig } from '@0xsequence/wallet'
-import { addressOf } from '@0xsequence/config'
 import { LocalRelayer } from '@0xsequence/relayer'
 import { configureLogger, packMessageData } from '@0xsequence/utils'
 import { testAccounts, getEOAWallet, testWalletContext } from '../testutils'
-
-const { JsonRpcProvider } = providers
 
 configureLogger({ logLevel: 'DEBUG', silence: false })
 

--- a/packages/0xsequence/tests/json-rpc-provider.spec.ts
+++ b/packages/0xsequence/tests/json-rpc-provider.spec.ts
@@ -1,0 +1,3 @@
+import { runBrowserTests } from './utils/browser-test-runner'
+
+runBrowserTests('json-rpc-provider', 'json-rpc-provider/rpc.test.html')

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -11,7 +11,7 @@ import {
 import { ETHAuth, Proof } from '@0xsequence/ethauth'
 import { Indexer, SequenceIndexerClient } from '@0xsequence/indexer'
 import { SequenceMetadataClient } from '@0xsequence/metadata'
-import { ChainIdLike, NetworkConfig, WalletContext, findNetworkConfig, getAuthNetwork } from '@0xsequence/network'
+import { ChainIdLike, NetworkConfig, WalletContext, findNetworkConfig, getAuthNetwork, JsonRpcProvider } from '@0xsequence/network'
 import { jwtDecodeClaims } from '@0xsequence/utils'
 import { Account } from '@0xsequence/wallet'
 import { ethers, Signer as AbstractSigner } from 'ethers'
@@ -505,7 +505,7 @@ export class Session {
 function getAuthProvider(networks: NetworkConfig[]): ethers.providers.JsonRpcProvider {
   const authChain = getAuthNetwork(networks)
   if (!authChain) throw Error('Auth chain not found')
-  return authChain.provider ?? new ethers.providers.JsonRpcProvider(authChain.rpcUrl)
+  return authChain.provider ?? new JsonRpcProvider(authChain.rpcUrl!, authChain.chainId)
 }
 
 function getJWTExpiration(jwt: string): number {

--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -53,6 +53,7 @@ export interface NetworkConfig {
   testnet?: boolean
 
   blockExplorer?: BlockExplorerConfig
+  ensAddress?: string
 
   rpcUrl?: string
   provider?: providers.JsonRpcProvider
@@ -90,7 +91,8 @@ export const networks: Record<ChainId, NetworkConfig> = {
     blockExplorer: {
       name: 'Etherscan',
       rootUrl: 'https://etherscan.io/'
-    }
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
   },
   [ChainId.ROPSTEN]: {
     chainId: ChainId.ROPSTEN,
@@ -100,7 +102,8 @@ export const networks: Record<ChainId, NetworkConfig> = {
     blockExplorer: {
       name: 'Etherscan (Ropsten)',
       rootUrl: 'https://ropsten.etherscan.io/'
-    }
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
   },
   [ChainId.RINKEBY]: {
     chainId: ChainId.RINKEBY,
@@ -111,6 +114,7 @@ export const networks: Record<ChainId, NetworkConfig> = {
       name: 'Etherscan (Rinkeby)',
       rootUrl: 'https://rinkeby.etherscan.io/'
     },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     disabled: true
   },
   [ChainId.GOERLI]: {
@@ -121,7 +125,8 @@ export const networks: Record<ChainId, NetworkConfig> = {
     blockExplorer: {
       name: 'Etherscan (Goerli)',
       rootUrl: 'https://goerli.etherscan.io/'
-    }
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
   },
   [ChainId.KOVAN]: {
     chainId: ChainId.KOVAN,

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,4 +1,5 @@
 export * from './config'
 export * from './context'
 export * from './json-rpc'
+export * from './json-rpc-provider'
 export * from './utils'

--- a/packages/network/src/json-rpc-provider.ts
+++ b/packages/network/src/json-rpc-provider.ts
@@ -39,7 +39,8 @@ export class JsonRpcProvider extends ethers.providers.JsonRpcProvider {
       const name = network?.name || ''
       return {
         name: name,
-        chainId: chainId
+        chainId: chainId,
+        ensAddress: network.ensAddress
       }
     } else {
       const chainIdHex = await this.send('eth_chainId', [])

--- a/packages/network/src/json-rpc-provider.ts
+++ b/packages/network/src/json-rpc-provider.ts
@@ -37,10 +37,11 @@ export class JsonRpcProvider extends ethers.providers.JsonRpcProvider {
     if (chainId) {
       const network = networks[chainId as ChainId]
       const name = network?.name || ''
+      const ensAddress = network?.ensAddress
       return {
         name: name,
         chainId: chainId,
-        ensAddress: network.ensAddress
+        ensAddress: ensAddress
       }
     } else {
       const chainIdHex = await this.send('eth_chainId', [])

--- a/packages/network/src/json-rpc-provider.ts
+++ b/packages/network/src/json-rpc-provider.ts
@@ -1,0 +1,82 @@
+import { ethers } from 'ethers'
+import { JsonRpcRouter, JsonRpcSender, loggingProviderMiddleware, CachedProvider, JsonRpcMiddleware, JsonRpcMiddlewareHandler } from './json-rpc'
+import { networks, ChainId } from './config'
+
+// TODO: we can cache eth_getCode for our own wallet address..
+// this does not change often at all.. but it's more tricky to ensure we expire
+// / prune the cache perfectly, so we can add support for it another time.
+
+// JsonRpcProvider with a middleware stack. By default it will use a simple caching middleware.
+export class JsonRpcProvider extends ethers.providers.JsonRpcProvider {
+  private _chainId?: number
+  private _sender: JsonRpcSender
+
+  constructor(url: ethers.utils.ConnectionInfo | string, chainId?: number, middlewares?: Array<JsonRpcMiddleware | JsonRpcMiddlewareHandler>) {
+    super(url, chainId)
+
+    this._chainId = chainId
+
+    // NOTE: it will either use the middleware stack passed to the constructor
+    // or it will use the default caching middleware provider. It does not concat them,
+    // so if you set middlewares, make sure you set the caching middleware yourself if you'd
+    // like to keep using it.
+    const router = new JsonRpcRouter(
+      middlewares ?? 
+      [
+        // loggingProviderMiddleware,
+        new CachedProvider({ chainId })
+      ],
+      new JsonRpcSender(this.fetch, chainId)
+    )
+
+    this._sender = new JsonRpcSender(router, chainId)
+  }
+
+  async getNetwork(): Promise<ethers.providers.Network> {
+    const chainId = this._chainId
+    if (chainId) {
+      const network = networks[chainId as ChainId]
+      const name = network?.name || ''
+      return {
+        name: name,
+        chainId: chainId
+      }
+    } else {
+      const chainIdHex = await this.send('eth_chainId', [])
+      this._chainId = ethers.BigNumber.from(chainIdHex).toNumber()
+      return this.getNetwork()
+    }
+  }
+
+  send = (method: string, params: Array<any>): Promise<any> => {
+    return this._sender.send(method, params)
+  }
+
+  private fetch = (method: string, params: Array<any>): Promise<any> => {
+    const request = {
+      method: method,
+      params: params,
+      id: (this._nextId++),
+      jsonrpc: '2.0'
+    }
+
+    const result = ethers.utils.fetchJson(this.connection, JSON.stringify(request), getResult).then((result) => {
+      return result
+    }, (error) => {
+      throw error
+    })
+
+    return result
+  }
+}
+
+function getResult(payload: { error?: { code?: number, data?: any, message?: string }, result?: any }): any {
+  if (payload.error) {
+    // @TODO: not any
+    const error: any = new Error(payload.error.message)
+    error.code = payload.error.code
+    error.data = payload.error.data
+    throw error
+  }
+  return payload.result
+}

--- a/packages/network/src/json-rpc/middleware/public-provider.ts
+++ b/packages/network/src/json-rpc/middleware/public-provider.ts
@@ -48,6 +48,8 @@ export class PublicProvider implements JsonRpcMiddlewareHandler {
       this.provider = undefined
     } else {
       this.rpcUrl = rpcUrl
+      // TODO: maybe use @0xsequence/network JsonRpcProvider here instead,
+      // which supports better caching.
       this.provider = new providers.JsonRpcProvider(rpcUrl)
     }
   }

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -532,7 +532,7 @@ export class Wallet implements WalletProvider {
             chainId: network.chainId
           }),
           new SigningProvider(this.transport.provider!),
-          new CachedProvider(network.chainId)
+          new CachedProvider({ defaultChainId: network.chainId })
         ],
         new JsonRpcSender(rpcProvider)
       )

--- a/packages/wallet/src/account.ts
+++ b/packages/wallet/src/account.ts
@@ -584,9 +584,9 @@ export class Account extends Signer {
       )
 
       if (network.provider) {
-        wallet.setProvider(network.provider)
+        wallet.setProvider(network.provider, network.chainId)
       } else if (network.rpcUrl && network.rpcUrl !== '') {
-        wallet.setProvider(network.rpcUrl)
+        wallet.setProvider(network.rpcUrl, network.chainId)
       } else {
         throw new Error(`network config is missing provider settings for chainId ${network.chainId}`)
       }

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -34,7 +34,8 @@ import {
   NetworkConfig,
   isJsonRpcProvider,
   sequenceContext,
-  getChainId
+  getChainId,
+  JsonRpcProvider
 } from '@0xsequence/network'
 
 import {
@@ -143,13 +144,13 @@ export class Wallet extends Signer {
   // ie. new Wallet({ config: initConfig }).useConfig(latestConfig).useSigners(signers)
   useConfig(config: WalletConfig, strict?: boolean): Wallet {
     return new Wallet({ config, context: this.context, strict }, ...this._signers)
-      .setProvider(this.provider)
+      .setProvider(this.provider, this.chainId)
       .setRelayer(this.relayer)
   }
 
   useSigners(...signers: (BytesLike | AbstractSigner)[]): Wallet {
     return new Wallet({ config: this.config, context: this.context }, ...signers)
-      .setProvider(this.provider)
+      .setProvider(this.provider, this.chainId)
       .setRelayer(this.relayer)
   }
 
@@ -159,7 +160,7 @@ export class Wallet extends Signer {
   connect(provider: providers.Provider, relayer?: Relayer): Wallet {
     if (isJsonRpcProvider(provider)) {
       return new Wallet({ config: this.config, context: this.context }, ...this._signers)
-        .setProvider(provider)
+        .setProvider(provider, this.chainId)
         .setRelayer(relayer!)
     } else {
       throw new Error('Wallet provider argument is expected to be a JsonRpcProvider')
@@ -167,17 +168,17 @@ export class Wallet extends Signer {
   }
 
   // setProvider assigns a json-rpc provider to this wallet instance
-  setProvider(provider: providers.JsonRpcProvider | ConnectionInfo | string): Wallet {
+  setProvider(provider: providers.JsonRpcProvider | ConnectionInfo | string, chainId?: number): Wallet {
     if (provider === undefined) return this
     if (providers.Provider.isProvider(provider)) {
       this.provider = provider
       this.sender = new JsonRpcSender(provider)
     } else {
-      const jsonProvider = new providers.JsonRpcProvider(<ConnectionInfo | string>provider)
+      const jsonProvider = new JsonRpcProvider(<ConnectionInfo | string>provider, chainId)
       this.provider = jsonProvider
       this.sender = new JsonRpcSender(jsonProvider)
     }
-    this.chainId = undefined // reset chainId value
+    this.chainId = chainId // reset chainId value
     return this
   }
 


### PR DESCRIPTION
usage of this JsonRpcProvider will remove the countless eth_chainId calls that ethers makes in normal use, leading to many wasted and pointless http requests. This JsonRpcProvider also lets you pass your own middleware stack to do interesting things for more advanced caching or introspection.