### PR TITLE
v2 config tracker interface changes

### DIFF
--- a/packages/0xsequence/tests/browser/wallet-provider/dapp.test.ts
+++ b/packages/0xsequence/tests/browser/wallet-provider/dapp.test.ts
@@ -291,7 +291,7 @@ export const tests = async () => {
 
       const ethAmount = ethers.utils.parseEther('1.4242')
 
-      // NOTE: when a wallet is undeployed (counter-factual), and although the txn contents are to send from our
+      // NOTE: when a wallet is undeployed (counterfactual), and although the txn contents are to send from our
       // sequence wallet to the test account, the transaction by the Sequence Wallet instance will be sent `to` the
       // `GuestModule` smart contract address of the Sequence context `from` the Sequence Relayer (local) account.
       //

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -562,17 +562,8 @@ export class Account {
     if (status.fullyMigrated) return 0
 
     const wallet = this.walletForStatus(chainId, status)
-    const signed = await this.migrator.signMissingMigrations(
-      this.address,
-      status.version,
-      wallet
-    )
-
-    await Promise.all(signed.map((migration) => Promise.all([
-      this.tracker.saveMigration(this.address, migration, this.contexts),
-      this.tracker.saveWalletConfig({ config: migration.toConfig })
-    ])))
-
+    const signed = await this.migrator.signMissingMigrations(this.address, status.version, wallet)
+    await Promise.all(signed.map(migration => this.tracker.saveMigration(this.address, migration, this.contexts)))
     return signed.length
   }
 

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -463,16 +463,12 @@ export class Account {
     // sign the update struct, using chain id 0
     const signature = await this.signDigest(updateStruct, 0, false)
 
-    // save both the new config and the presigned transaction
-    // to the sessions tracker
-    await Promise.all([
-      this.tracker.saveWalletConfig({ config }),
-      this.tracker.savePresignedConfiguration({
-        nextImageHash,
-        signature,
-        wallet: this.address
-      })
-    ])
+    // save the presigned transaction to the sessions tracker
+    return this.tracker.savePresignedConfiguration({
+      wallet: this.address,
+      nextConfig: config,
+      signature
+    })
   }
 
   /**

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -125,7 +125,7 @@ export class Account {
 
     await Promise.all([
       options.tracker.saveWalletConfig({ config }),
-      options.tracker.saveCounterFactualWallet({
+      options.tracker.saveCounterfactualWallet({
         context: Object.values(options.contexts),
         imageHash
       })
@@ -235,13 +235,13 @@ export class Account {
     }
     current: number
   }> {
-    // First we need to use the tracker to get the counter-factual imageHash
-    const firstImageHash = await this.tracker.imageHashOfCounterFactualWallet({
+    // First we need to use the tracker to get the counterfactual imageHash
+    const firstImageHash = await this.tracker.imageHashOfCounterfactualWallet({
       wallet: this.address
     })
 
     if (!firstImageHash) {
-      throw new Error(`Counter-factual imageHash not found for wallet ${this.address}`)
+      throw new Error(`Counterfactual imageHash not found for wallet ${this.address}`)
     }
 
     const current = await version.versionOf(
@@ -274,11 +274,11 @@ export class Account {
 
     let onChainImageHash = await this.reader(chainId).imageHash(this.address)
     if (!onChainImageHash) {
-      const counterFactualImageHash = await this.tracker.imageHashOfCounterFactualWallet({
+      const counterfactualImageHash = await this.tracker.imageHashOfCounterfactualWallet({
         wallet: this.address
       })
 
-      onChainImageHash = counterFactualImageHash?.imageHash
+      onChainImageHash = counterfactualImageHash?.imageHash
     }
 
     if (!onChainImageHash) {

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -123,13 +123,7 @@ export class Account {
     const context = options.contexts[lastMigration.version]
     const address = commons.context.addressOf(context, imageHash)
 
-    await Promise.all([
-      options.tracker.saveWalletConfig({ config }),
-      options.tracker.saveCounterfactualWallet({
-        context: Object.values(options.contexts),
-        imageHash
-      })
-    ])
+    await options.tracker.saveCounterfactualWallet({ config, context: Object.values(options.contexts) })
 
     return new Account({
       address,

--- a/packages/account/tests/account.spec.ts
+++ b/packages/account/tests/account.spec.ts
@@ -501,8 +501,7 @@ describe('Account', () => {
 
       // Sessions server MUST have information about the old wallet
       // in production this is retrieved from SequenceUtils contract
-      await tracker.saveCounterfactualWallet({ imageHash, context: [contexts[1]] })
-      await tracker.saveWalletConfig({ config })
+      await tracker.saveCounterfactualWallet({ config, context: [contexts[1]] })
 
       // Importing the account should work!
       const account = new Account({ ...defaultArgs, address, orchestrator: new Orchestrator([signer1]) })
@@ -592,8 +591,7 @@ describe('Account', () => {
 
       // Feed all information to sequence-sessions
       // (on prod this would be imported from SequenceUtils)
-      await tracker.saveCounterfactualWallet({ imageHash, context: Object.values(contexts) })
-      await tracker.saveWalletConfig({ config })
+      await tracker.saveCounterfactualWallet({ config, context: Object.values(contexts) })
 
       // Importing the account should work!
       const account = new Account({
@@ -721,9 +719,8 @@ describe('Account', () => {
       })
 
       // Feed the tracker with all the data
-      await tracker.saveCounterfactualWallet({ imageHash: imageHash1a, context: [contexts[1]] })
+      await tracker.saveCounterfactualWallet({ config: config1a, context: [contexts[1]] })
       await tracker.saveWalletConfig({ config: config1b })
-      await tracker.saveWalletConfig({ config: config1a })
 
       // Status on network 0 should be deployed, network 1 not
       // and the configuration on network 0 should be the B one

--- a/packages/account/tests/account.spec.ts
+++ b/packages/account/tests/account.spec.ts
@@ -501,7 +501,7 @@ describe('Account', () => {
 
       // Sessions server MUST have information about the old wallet
       // in production this is retrieved from SequenceUtils contract
-      await tracker.saveCounterFactualWallet({ imageHash, context: [contexts[1]] })
+      await tracker.saveCounterfactualWallet({ imageHash, context: [contexts[1]] })
       await tracker.saveWalletConfig({ config })
 
       // Importing the account should work!
@@ -592,7 +592,7 @@ describe('Account', () => {
 
       // Feed all information to sequence-sessions
       // (on prod this would be imported from SequenceUtils)
-      await tracker.saveCounterFactualWallet({ imageHash, context: Object.values(contexts) })
+      await tracker.saveCounterfactualWallet({ imageHash, context: Object.values(contexts) })
       await tracker.saveWalletConfig({ config })
 
       // Importing the account should work!
@@ -721,7 +721,7 @@ describe('Account', () => {
       })
 
       // Feed the tracker with all the data
-      await tracker.saveCounterFactualWallet({ imageHash: imageHash1a, context: [contexts[1]] })
+      await tracker.saveCounterfactualWallet({ imageHash: imageHash1a, context: [contexts[1]] })
       await tracker.saveWalletConfig({ config: config1b })
       await tracker.saveWalletConfig({ config: config1a })
 

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -416,7 +416,7 @@ export class Session {
 
     if (isSessionDumpV1(dump)) {
       // Old configuration format used to also contain an "address" field
-      // but if it doesn't, it means that it was a "counter-factual" account
+      // but if it doesn't, it means that it was a "counterfactual" account
       // not yet updated, so we need to compute the address
       const oldAddress = dump.config.address || commons.context.addressOf(
         contexts[1],

--- a/packages/core/src/commons/context.ts
+++ b/packages/core/src/commons/context.ts
@@ -29,7 +29,7 @@ export function addressOf(context: WalletContext, imageHash: ethers.BytesLike) {
   return ethers.utils.getAddress(ethers.utils.hexDataSlice(hash, 12))
 }
 
-export async function isValidCounterFactual(
+export async function isValidCounterfactual(
   wallet: string,
   digest: ethers.BytesLike,
   signature: ethers.BytesLike,

--- a/packages/core/src/commons/reader.ts
+++ b/packages/core/src/commons/reader.ts
@@ -1,7 +1,7 @@
 import { walletContracts } from "@0xsequence/abi"
 import { ethers } from "ethers"
 import { commons } from ".."
-import { isValidCounterFactual } from "./context"
+import { isValidCounterfactual } from "./context"
 
 /**
  * Provides stateful information about the wallet.
@@ -95,10 +95,10 @@ export interface Reader {
       return isValid === '0x1626ba7e' // as defined in ERC1271
     }
 
-    // We can try to recover the counter-factual address
+    // We can try to recover the counterfactual address
     // and check if it matches the wallet address
     if (this.contexts) {
-      return isValidCounterFactual(
+      return isValidCounterfactual(
         wallet,
         digest,
         signature,

--- a/packages/migration/src/migrations/migration_01_02.ts
+++ b/packages/migration/src/migrations/migration_01_02.ts
@@ -60,8 +60,7 @@ export class Migration_v1v2 implements Migration<
       tx,
       fromVersion: this.version - 1,
       toVersion: this.version,
-      toConfig: newConfig,
-      toImageHash: v2.config.ConfigCoder.imageHashOf(newConfig)
+      toConfig: newConfig
     }
   }
 

--- a/packages/migration/src/migrator.ts
+++ b/packages/migration/src/migrator.ts
@@ -5,10 +5,9 @@ import { ethers } from 'ethers'
 import { Migration } from "./migrations"
 
 export type UnsignedMigration = {
-  tx: commons.transaction.TransactionBundle,
-  fromVersion: number,
-  toVersion: number,
-  toImageHash: string,
+  tx: commons.transaction.TransactionBundle
+  fromVersion: number
+  toVersion: number
   toConfig: commons.config.Config
 }
 

--- a/packages/sessions/src/tracker.ts
+++ b/packages/sessions/src/tracker.ts
@@ -1,11 +1,13 @@
 import { commons } from '@0xsequence/core'
 import { ethers } from 'ethers'
 
-export type PresignedConfigLink = {
-  wallet: string,
-  nextImageHash: string,
+export type PresignedConfig = {
+  wallet: string
+  nextConfig: commons.config.Config
   signature: string
 }
+
+export type PresignedConfigLink = Omit<PresignedConfig, 'nextConfig'> & { nextImageHash: string }
 
 export type ConfigDataDump = {
   configurations: commons.config.Config[],
@@ -23,9 +25,7 @@ export abstract class ConfigTracker {
     longestPath?: boolean
   }) => Promise<PresignedConfigLink[]>
 
-  savePresignedConfiguration: (
-    args: PresignedConfigLink
-  ) => Promise<void>
+  savePresignedConfiguration: (args: PresignedConfig) => Promise<void>
 
   saveWitness: ( args: {
     wallet: string,

--- a/packages/sessions/src/tracker.ts
+++ b/packages/sessions/src/tracker.ts
@@ -49,10 +49,7 @@ export abstract class ConfigTracker {
     context: commons.context.WalletContext
   } | undefined>
 
-  saveCounterfactualWallet: (args: {
-    imageHash: string,
-    context: commons.context.WalletContext[]
-  }) => Promise<void>
+  saveCounterfactualWallet: (args: { config: commons.config.Config; context: commons.context.WalletContext[] }) => Promise<void>
 
   walletsOfSigner: (args: {
     signer: string

--- a/packages/sessions/src/tracker.ts
+++ b/packages/sessions/src/tracker.ts
@@ -42,14 +42,14 @@ export abstract class ConfigTracker {
     config: commons.config.Config
   }) => Promise<void>
 
-  imageHashOfCounterFactualWallet: (args: {
+  imageHashOfCounterfactualWallet: (args: {
     wallet: string
   }) => Promise<{
     imageHash: string,
     context: commons.context.WalletContext
   } | undefined>
 
-  saveCounterFactualWallet: (args: {
+  saveCounterfactualWallet: (args: {
     imageHash: string,
     context: commons.context.WalletContext[]
   }) => Promise<void>

--- a/packages/sessions/src/trackers/local.ts
+++ b/packages/sessions/src/trackers/local.ts
@@ -482,15 +482,14 @@ export class LocalConfigTracker implements ConfigTracker, migrator.PresignedMigr
           signature: encoded.encoded,
           intent: {
             id: ethers.utils.keccak256(payload.message),
-            wallet: address,
+            wallet: address
           }
         },
-        toImageHash: coder.config.imageHashOf(currentConfig as any),
         toConfig: currentConfig,
         fromVersion,
         toVersion: fromVersion + 1
       } as migrator.SignedMigration
-    })).then((c) => c.filter((c) => c !== undefined))
+    })).then(c => c.filter(c => c !== undefined))
 
     // Return the first valid candidate
     return candidates[0]

--- a/packages/sessions/src/trackers/local.ts
+++ b/packages/sessions/src/trackers/local.ts
@@ -140,14 +140,18 @@ export class LocalConfigTracker implements ConfigTracker, migrator.PresignedMigr
   }
 
   saveCounterfactualWallet = async (args: {
-    imageHash: string,
+    config: commons.config.Config
     context: commons.context.WalletContext[]
   }): Promise<void> => {
-    const { imageHash, context } = args
-    await Promise.all(context.map((ctx) => {
-      const address = commons.context.addressOf(ctx, imageHash)
-      return this.store.saveCounterfactualWallet(address, imageHash, ctx)
-    }))
+    const { config, context } = args
+    const imageHash = universal.genericCoderFor(config.version).config.imageHashOf(config)
+    await Promise.all([
+      this.saveWalletConfig({ config }),
+      ...context.map(ctx => {
+        const address = commons.context.addressOf(ctx, imageHash)
+        return this.store.saveCounterfactualWallet(address, imageHash, ctx)
+      })
+    ])
   }
 
   imageHashOfCounterfactualWallet = async (args: {

--- a/packages/sessions/src/trackers/local.ts
+++ b/packages/sessions/src/trackers/local.ts
@@ -139,25 +139,25 @@ export class LocalConfigTracker implements ConfigTracker, migrator.PresignedMigr
     throw new Error(`Unknown config type: ${config}`)
   }
 
-  saveCounterFactualWallet = async (args: {
+  saveCounterfactualWallet = async (args: {
     imageHash: string,
     context: commons.context.WalletContext[]
   }): Promise<void> => {
     const { imageHash, context } = args
     await Promise.all(context.map((ctx) => {
       const address = commons.context.addressOf(ctx, imageHash)
-      return this.store.saveCounterFactualWallet(address, imageHash, ctx)
+      return this.store.saveCounterfactualWallet(address, imageHash, ctx)
     }))
   }
 
-  imageHashOfCounterFactualWallet = async (args: {
+  imageHashOfCounterfactualWallet = async (args: {
     wallet: string
   }): Promise<{
     imageHash: string,
     context: commons.context.WalletContext
   } | undefined> => {
     const { wallet } = args
-    const result = await this.store.loadCounterFactualWallet(wallet)
+    const result = await this.store.loadCounterfactualWallet(wallet)
 
     if (!result) return undefined
 

--- a/packages/sessions/src/trackers/multiple.ts
+++ b/packages/sessions/src/trackers/multiple.ts
@@ -84,18 +84,18 @@ export class MultipleTracker implements migrator.PresignedMigrationTracker, Conf
     }))
   }
 
-  async imageHashOfCounterFactualWallet(args: { wallet: string }): Promise<{ imageHash: string; context: commons.context.WalletContext } | undefined> {
-    const promises = this.trackers.map(async (t, i) => ({ res: await t.imageHashOfCounterFactualWallet(args), i }))
+  async imageHashOfCounterfactualWallet(args: { wallet: string }): Promise<{ imageHash: string; context: commons.context.WalletContext } | undefined> {
+    const promises = this.trackers.map(async (t, i) => ({ res: await t.imageHashOfCounterfactualWallet(args), i }))
     const result = await raceUntil(promises, undefined, (val) => val?.res !== undefined)
     if (!result?.res) return undefined
-    this.saveCounterFactualWallet({ imageHash: result.res.imageHash, context: [result.res.context], skipTracker: result.i })
+    this.saveCounterfactualWallet({ imageHash: result.res.imageHash, context: [result.res.context], skipTracker: result.i })
     return result.res
   }
 
-  async saveCounterFactualWallet(args: { imageHash: string; context: commons.context.WalletContext[], skipTracker?: number }): Promise<void> {
+  async saveCounterfactualWallet(args: { imageHash: string; context: commons.context.WalletContext[], skipTracker?: number }): Promise<void> {
     await Promise.all(this.trackers.map((t, i) => {
       if (i === args.skipTracker) return
-      return t.saveCounterFactualWallet(args)
+      return t.saveCounterfactualWallet(args)
     }))
   }
 

--- a/packages/sessions/src/trackers/stores/index.ts
+++ b/packages/sessions/src/trackers/stores/index.ts
@@ -40,9 +40,9 @@ export interface TrackerStore {
   loadV2Node: (nodeHash: string) => Promise<PlainNode | PlainNested | v2.config.Topology | undefined>
   saveV2Node: (nodeHash: string, node: PlainNode | PlainNested | v2.config.Topology) => Promise<void>
 
-  // counter-factual wallets
-  loadCounterFactualWallet: (wallet: string) => Promise<{ imageHash: string, context: commons.context.WalletContext } | undefined>
-  saveCounterFactualWallet: (wallet: string, imageHash: string, context: commons.context.WalletContext) => Promise<void>
+  // counterfactual wallets
+  loadCounterfactualWallet: (wallet: string) => Promise<{ imageHash: string, context: commons.context.WalletContext } | undefined>
+  saveCounterfactualWallet: (wallet: string, imageHash: string, context: commons.context.WalletContext) => Promise<void>
 
   // payloads
   loadPayloadOfSubdigest: (subdigest: string) => Promise<commons.signature.SignedPayload | undefined>

--- a/packages/sessions/src/trackers/stores/indexedDBStore.ts
+++ b/packages/sessions/src/trackers/stores/indexedDBStore.ts
@@ -13,7 +13,7 @@ export interface LocalTrackerDBSchema extends DBSchema {
     key: string,
     value: v2.config.Topology | PlainNode | PlainNested
   },
-  'counterFactualWallets': {
+  'counterfactualWallets': {
     key: string,
     value: {
       imageHash: string,
@@ -94,7 +94,7 @@ export class IndexedDBStore implements TrackerStore {
         if (oldVersion === 0) {
           db.createObjectStore('configs')
           db.createObjectStore('v2Nodes')
-          db.createObjectStore('counterFactualWallets')
+          db.createObjectStore('counterfactualWallets')
           db.createObjectStore('payloads')
 
           const signatures = db.createObjectStore('signatures')
@@ -128,14 +128,14 @@ export class IndexedDBStore implements TrackerStore {
     await db.put('v2Nodes', node, nodeHash)
   }
 
-  loadCounterFactualWallet = async (wallet: string): Promise<{ imageHash: string; context: commons.context.WalletContext } | undefined> => {
+  loadCounterfactualWallet = async (wallet: string): Promise<{ imageHash: string; context: commons.context.WalletContext } | undefined> => {
     const db = await this.getDb()
-    return db.get('counterFactualWallets', wallet)
+    return db.get('counterfactualWallets', wallet)
   }
 
-  saveCounterFactualWallet = async (wallet: string, imageHash: string, context: commons.context.WalletContext): Promise<void> => {
+  saveCounterfactualWallet = async (wallet: string, imageHash: string, context: commons.context.WalletContext): Promise<void> => {
     const db = await this.getDb()
-    await db.put('counterFactualWallets', { imageHash, context }, wallet)
+    await db.put('counterfactualWallets', { imageHash, context }, wallet)
   }
 
   loadPayloadOfSubdigest = async (subdigest: string): Promise<commons.signature.SignedPayload | undefined> => {

--- a/packages/sessions/src/trackers/stores/memoryStore.ts
+++ b/packages/sessions/src/trackers/stores/memoryStore.ts
@@ -5,7 +5,7 @@ import { PlainNested, PlainNode, PlainV2Config, TrackerStore } from "."
 export class MemoryTrackerStore implements TrackerStore {
   private configs: { [imageHash: string]: v1.config.WalletConfig | PlainV2Config } = {}
   private v2Nodes: { [nodeHash: string]: PlainNode | PlainNested | v2.config.Topology } = {}
-  private counterFactualWallets: { [wallet: string]: { imageHash: string, context: commons.context.WalletContext } } = {}
+  private counterfactualWallets: { [wallet: string]: { imageHash: string, context: commons.context.WalletContext } } = {}
   private payloads: { [subdigest: string]: commons.signature.SignedPayload } = {}
   private signatures: { [signer: string]: { [subdigest: string]: ethers.BytesLike } } = {}
   private migrations: { [wallet: string]: { [fromVersion: number]: { [toVersion: number]: string[] } } } = {}
@@ -28,12 +28,12 @@ export class MemoryTrackerStore implements TrackerStore {
     return Promise.resolve()
   }
 
-  loadCounterFactualWallet = (wallet: string): Promise<{ imageHash: string; context: commons.context.WalletContext } | undefined> => {
-    return Promise.resolve(this.counterFactualWallets[wallet])
+  loadCounterfactualWallet = (wallet: string): Promise<{ imageHash: string; context: commons.context.WalletContext } | undefined> => {
+    return Promise.resolve(this.counterfactualWallets[wallet])
   }
 
-  saveCounterFactualWallet = (wallet: string, imageHash: string, context: commons.context.WalletContext): Promise<void> => {
-    this.counterFactualWallets[wallet] = { imageHash, context }
+  saveCounterfactualWallet = (wallet: string, imageHash: string, context: commons.context.WalletContext): Promise<void> => {
+    this.counterfactualWallets[wallet] = { imageHash, context }
     return Promise.resolve()
   }
 

--- a/packages/sessions/tests/local.spec.ts
+++ b/packages/sessions/tests/local.spec.ts
@@ -265,10 +265,11 @@ describe('Local config tracker', () => {
       describe('Counterfactual address', () => {
         it('Should set and get address', async () => {
           const context = randomContext()
-          const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+          const config = utils.configs.random.genRandomV1Config()
+          const imageHash = universal.genericCoderFor(config.version).config.imageHashOf(config)
 
           const wallet = commons.context.addressOf(context, imageHash)
-          await tracker.saveCounterfactualWallet({ context: [context], imageHash })
+          await tracker.saveCounterfactualWallet({ config, context: [context] })
           const res = await tracker.imageHashOfCounterfactualWallet({ wallet })
 
           expect(res).to.deep.equal({ imageHash, context })
@@ -276,10 +277,11 @@ describe('Local config tracker', () => {
 
         it('Should set address for multiple configs', async () => {
           const contexts = new Array(5).fill(0).map(() => randomContext())
-          const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+          const config = utils.configs.random.genRandomV1Config()
+          const imageHash = universal.genericCoderFor(config.version).config.imageHashOf(config)
 
-          const wallets = contexts.map((c) => commons.context.addressOf(c, imageHash))
-          await tracker.saveCounterfactualWallet({ context: contexts, imageHash })
+          const wallets = contexts.map(c => commons.context.addressOf(c, imageHash))
+          await tracker.saveCounterfactualWallet({ config, context: contexts })
 
           for (let i = 0; i < wallets.length; i++) {
             const res = await tracker.imageHashOfCounterfactualWallet({ wallet: wallets[i] })
@@ -787,10 +789,11 @@ describe('Local config tracker', () => {
     describe('Counterfactual addresses', () => {
       it('Should store counterfactual address in both', async () => {
         const context = randomContext()
-        const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+        const config = utils.configs.random.genRandomV1Config()
+        const imageHash = universal.genericCoderFor(config.version).config.imageHashOf(config)
 
         const wallet = commons.context.addressOf(context, imageHash)
-        await combined.saveCounterfactualWallet({ context: [context], imageHash })
+        await combined.saveCounterfactualWallet({ config, context: [context] })
 
         const res1 = await combined.imageHashOfCounterfactualWallet({ wallet })
         const res2 = await tracker1.imageHashOfCounterfactualWallet({ wallet })
@@ -803,10 +806,11 @@ describe('Local config tracker', () => {
 
       it('Should mirror counterfactual address from tracker1', async () => {
         const context = randomContext()
-        const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+        const config = utils.configs.random.genRandomV1Config()
+        const imageHash = universal.genericCoderFor(config.version).config.imageHashOf(config)
 
         const wallet = commons.context.addressOf(context, imageHash)
-        await tracker1.saveCounterfactualWallet({ context: [context], imageHash })
+        await tracker1.saveCounterfactualWallet({ config, context: [context] })
 
         const res1 = await combined.imageHashOfCounterfactualWallet({ wallet })
 

--- a/packages/sessions/tests/local.spec.ts
+++ b/packages/sessions/tests/local.spec.ts
@@ -262,14 +262,14 @@ describe('Local config tracker', () => {
         })
       })
 
-      describe('Counter factual address', () => {
+      describe('Counterfactual address', () => {
         it('Should set and get address', async () => {
           const context = randomContext()
           const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
 
           const wallet = commons.context.addressOf(context, imageHash)
-          await tracker.saveCounterFactualWallet({ context: [context], imageHash })
-          const res = await tracker.imageHashOfCounterFactualWallet({ wallet })
+          await tracker.saveCounterfactualWallet({ context: [context], imageHash })
+          const res = await tracker.imageHashOfCounterfactualWallet({ wallet })
 
           expect(res).to.deep.equal({ imageHash, context })
         })
@@ -279,17 +279,17 @@ describe('Local config tracker', () => {
           const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
 
           const wallets = contexts.map((c) => commons.context.addressOf(c, imageHash))
-          await tracker.saveCounterFactualWallet({ context: contexts, imageHash })
+          await tracker.saveCounterfactualWallet({ context: contexts, imageHash })
 
           for (let i = 0; i < wallets.length; i++) {
-            const res = await tracker.imageHashOfCounterFactualWallet({ wallet: wallets[i] })
+            const res = await tracker.imageHashOfCounterfactualWallet({ wallet: wallets[i] })
             expect(res).to.deep.equal({ imageHash, context: contexts[i] })
           }
         })
 
         it('Should return undefined for unknown wallet', async () => {
           const wallet = ethers.Wallet.createRandom().address
-          expect(await tracker.imageHashOfCounterFactualWallet({ wallet })).to.be.undefined
+          expect(await tracker.imageHashOfCounterfactualWallet({ wallet })).to.be.undefined
         })
       })
 
@@ -784,36 +784,36 @@ describe('Local config tracker', () => {
       })
     })
 
-    describe('Counter factual addresses', () => {
-      it('Should store counter-factual address in both', async () => {
+    describe('Counterfactual addresses', () => {
+      it('Should store counterfactual address in both', async () => {
         const context = randomContext()
         const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
 
         const wallet = commons.context.addressOf(context, imageHash)
-        await combined.saveCounterFactualWallet({ context: [context], imageHash })
+        await combined.saveCounterfactualWallet({ context: [context], imageHash })
 
-        const res1 = await combined.imageHashOfCounterFactualWallet({ wallet })
-        const res2 = await tracker1.imageHashOfCounterFactualWallet({ wallet })
-        const res3 = await tracker2.imageHashOfCounterFactualWallet({ wallet })
+        const res1 = await combined.imageHashOfCounterfactualWallet({ wallet })
+        const res2 = await tracker1.imageHashOfCounterfactualWallet({ wallet })
+        const res3 = await tracker2.imageHashOfCounterfactualWallet({ wallet })
 
         expect(res1).to.deep.equal({ imageHash, context })
         expect(res2).to.deep.equal({ imageHash, context })
         expect(res3).to.deep.equal({ imageHash, context })
       })
 
-      it('Should mirror counter-factual address from tracker1', async () => {
+      it('Should mirror counterfactual address from tracker1', async () => {
         const context = randomContext()
         const imageHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
 
         const wallet = commons.context.addressOf(context, imageHash)
-        await tracker1.saveCounterFactualWallet({ context: [context], imageHash })
+        await tracker1.saveCounterfactualWallet({ context: [context], imageHash })
 
-        const res1 = await combined.imageHashOfCounterFactualWallet({ wallet })
+        const res1 = await combined.imageHashOfCounterfactualWallet({ wallet })
 
         await wait(500)
 
-        const res2 = await tracker1.imageHashOfCounterFactualWallet({ wallet })
-        const res3 = await tracker2.imageHashOfCounterFactualWallet({ wallet })
+        const res2 = await tracker1.imageHashOfCounterfactualWallet({ wallet })
+        const res3 = await tracker2.imageHashOfCounterfactualWallet({ wallet })
 
         expect(res1).to.deep.equal({ imageHash, context })
         expect(res2).to.deep.equal({ imageHash, context })

--- a/packages/sessions/tests/local.spec.ts
+++ b/packages/sessions/tests/local.spec.ts
@@ -331,7 +331,7 @@ describe('Local config tracker', () => {
 
           await tracker.saveWalletConfig({ config })
           await tracker.saveWalletConfig({ config: nextConfig })
-          await tracker.savePresignedConfiguration({ wallet: address, nextImageHash, signature })
+          await tracker.savePresignedConfiguration({ wallet: address, nextConfig, signature })
 
           const res = await tracker.loadPresignedConfiguration({ wallet: address, fromImageHash: imageHash })
           expect(res.length).to.equal(1)
@@ -355,7 +355,7 @@ describe('Local config tracker', () => {
 
           await tracker.saveWalletConfig({ config })
           await tracker.saveWalletConfig({ config: nextConfig })
-          await tracker.savePresignedConfiguration({ wallet: address, nextImageHash, signature })
+          await tracker.savePresignedConfiguration({ wallet: address, nextConfig, signature })
 
           const wrongWallet = ethers.Wallet.createRandom().address
           const res = await tracker.loadPresignedConfiguration({ wallet: wrongWallet, fromImageHash: imageHash })
@@ -411,7 +411,7 @@ describe('Local config tracker', () => {
           await tracker.saveWalletConfig({ config: nextConfig2 })
           await tracker.savePresignedConfiguration({
             wallet: address,
-            nextImageHash: nextImageHash2,
+            nextConfig: nextConfig2,
             signature: signature2
           })
 
@@ -436,7 +436,7 @@ describe('Local config tracker', () => {
           // Adding the 0_1 step should give us a full chain to 2
           await tracker.savePresignedConfiguration({
             wallet: address,
-            nextImageHash: nextImageHash1,
+            nextConfig: nextConfig1,
             signature: signature1
           })
 
@@ -501,8 +501,8 @@ describe('Local config tracker', () => {
           await tracker.saveWalletConfig({ config: config1 })
           await tracker.saveWalletConfig({ config: config2 })
           await tracker.saveWalletConfig({ config: config3 })
-          await tracker.savePresignedConfiguration({ wallet: address, nextImageHash: imageHash2, signature: signature1 })
-          await tracker.savePresignedConfiguration({ wallet: address, nextImageHash: imageHash3, signature: signature2 })
+          await tracker.savePresignedConfiguration({ wallet: address, nextConfig: config2, signature: signature1 })
+          await tracker.savePresignedConfiguration({ wallet: address, nextConfig: config3, signature: signature2 })
 
           // Going from 1 to 3 should give us 1 jump
           const resa = await tracker.loadPresignedConfiguration({
@@ -847,7 +847,7 @@ describe('Local config tracker', () => {
 
         await combined.saveWalletConfig({ config })
         await combined.saveWalletConfig({ config: nextConfig })
-        await combined.savePresignedConfiguration({ wallet: address, nextImageHash, signature })
+        await combined.savePresignedConfiguration({ wallet: address, nextConfig, signature })
 
         const res2 = await tracker1.loadPresignedConfiguration({ wallet: address, fromImageHash: imageHash })
         const res3 = await tracker2.loadPresignedConfiguration({ wallet: address, fromImageHash: imageHash })
@@ -884,7 +884,7 @@ describe('Local config tracker', () => {
 
         await tracker2.saveWalletConfig({ config })
         await tracker2.saveWalletConfig({ config: nextConfig })
-        await tracker2.savePresignedConfiguration({ wallet: address, nextImageHash, signature })
+        await tracker2.savePresignedConfiguration({ wallet: address, nextConfig, signature })
 
         const res1 = await combined.loadPresignedConfiguration({ wallet: address, fromImageHash: imageHash })
 
@@ -956,7 +956,7 @@ describe('Local config tracker', () => {
         await tracker1.saveWalletConfig({ config: nextConfig1 })
         await tracker1.savePresignedConfiguration({
           wallet: address,
-          nextImageHash: nextImageHash1,
+          nextConfig: nextConfig1,
           signature: signature1
         })
 
@@ -966,12 +966,12 @@ describe('Local config tracker', () => {
         await tracker2.saveWalletConfig({ config: nextConfig2 })
         await tracker2.savePresignedConfiguration({
           wallet: address,
-          nextImageHash: nextImageHash1,
+          nextConfig: nextConfig1,
           signature: signature1
         })
         await tracker2.savePresignedConfiguration({
           wallet: address,
-          nextImageHash: nextImageHash2,
+          nextConfig: nextConfig2,
           signature: signature2
         })
 


### PR DESCRIPTION
- require config to be passed to `saveCounterfactualWallet`, `savePresignedConfiguration`, and `saveMigration`, so that they can't be saved without having the necessary configs saved too
- remove `UnsignedMigration.toImageHash` since it's derivable from `UnsignedMigration.toConfig` and we don't want the caller to be able to pass an image hash that doesn't match the corresponding config
- counterfactual is one word