### PR TITLE
Remove duplicated defaultChainId on wallet request handler

### DIFF
--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -64,14 +64,9 @@ export class Web3Provider extends providers.Web3Provider implements JsonRpcHandl
   }
 
   async getChainId(): Promise<number> {
-    // If the dapp is asking for a particular default chain, then we first need to see
-    // if the wallet supports the network, for that we need to query the wallet networks
-    // and see if it contains the default chain. If it does, then we can return the default.
-    if (this._defaultChainId) {
-      const networks = await this.getNetworks()
-      if (networks.find((n) => n.chainId === this._defaultChainId)) return this._defaultChainId
-      throw new Error(`Default chainId ${this._defaultChainId} not supported by wallet`)
-    }
+    // If we already have a default chainId, then we can just return it
+    const defaultChainId = this._defaultChainId
+    if (defaultChainId) return defaultChainId
 
     // If there is no default chain, then we can just return the chainId of the provider
     return this.send('eth_chainId', [])

--- a/packages/provider/src/transports/base-wallet-transport.ts
+++ b/packages/provider/src/transports/base-wallet-transport.ts
@@ -385,9 +385,10 @@ export abstract class BaseWalletTransport implements WalletTransport {
         let chainId: number | undefined = undefined
         try {
           if (networkId) {
-            chainId = this.walletRequestHandler.setDefaultNetwork(networkId)
+            const networkIdNumber = ethers.BigNumber.from(networkId).toNumber()
+            chainId = await this.walletRequestHandler.setDefaultNetwork(networkIdNumber)
           } else {
-            chainId = this.walletRequestHandler.defaultNetworkId
+            chainId = this.walletRequestHandler.defaultNetworkId()
           }
         } catch (err) {
           console.error(err)
@@ -422,9 +423,10 @@ export abstract class BaseWalletTransport implements WalletTransport {
         let chainId: number | undefined = undefined
         try {
           if (networkId) {
-            chainId = this.walletRequestHandler.setDefaultNetwork(networkId)
+            const networkIdNumber = ethers.BigNumber.from(networkId).toNumber()
+            chainId = await this.walletRequestHandler.setDefaultNetwork(networkIdNumber)
           } else {
-            chainId = this.walletRequestHandler.defaultNetworkId
+            chainId = this.walletRequestHandler.defaultNetworkId()
           }
         } catch (err) {
           console.error(err)

--- a/packages/provider/src/transports/base-wallet-transport.ts
+++ b/packages/provider/src/transports/base-wallet-transport.ts
@@ -386,9 +386,9 @@ export abstract class BaseWalletTransport implements WalletTransport {
         try {
           if (networkId) {
             const networkIdNumber = ethers.BigNumber.from(networkId).toNumber()
-            chainId = await this.walletRequestHandler.setDefaultNetwork(networkIdNumber)
+            chainId = await this.walletRequestHandler.setDefaultChainId(networkIdNumber)
           } else {
-            chainId = this.walletRequestHandler.defaultNetworkId()
+            chainId = this.walletRequestHandler.defaultChainId()
           }
         } catch (err) {
           console.error(err)
@@ -424,9 +424,9 @@ export abstract class BaseWalletTransport implements WalletTransport {
         try {
           if (networkId) {
             const networkIdNumber = ethers.BigNumber.from(networkId).toNumber()
-            chainId = await this.walletRequestHandler.setDefaultNetwork(networkIdNumber)
+            chainId = await this.walletRequestHandler.setDefaultChainId(networkIdNumber)
           } else {
-            chainId = this.walletRequestHandler.defaultNetworkId()
+            chainId = this.walletRequestHandler.defaultChainId()
           }
         } catch (err) {
           console.error(err)


### PR DESCRIPTION
This removes `defaultNetworkId` from the wallet request handler, in its place we use the prompter to query this information directly from the wallet webapp. This avoids duplicating this information, something that could lead to sync issues.