### PR TITLE
Util for trimming EIP-191 prefix

### DIFF
--- a/packages/provider/src/transports/wallet-request-handler.ts
+++ b/packages/provider/src/transports/wallet-request-handler.ts
@@ -374,7 +374,9 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
           if (typeof typedDataObject === 'string') {
             try {
               typedData = JSON.parse(typedDataObject)
-            } catch (e) {}
+            } catch (e) {
+              console.warn('error parsing typedData', e)
+            }
           } else {
             typedData = typedDataObject
           }

--- a/packages/provider/src/transports/wallet-request-handler.ts
+++ b/packages/provider/src/transports/wallet-request-handler.ts
@@ -375,7 +375,7 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
             try {
               typedData = JSON.parse(typedDataObject)
             } catch (e) {
-              console.warn('error parsing typedData', e)
+              console.warn('walletRequestHandler: error parsing typedData', e)
             }
           } else {
             typedData = typedDataObject

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -37,7 +37,7 @@ export const removeEIP191Prefix = (prefixedMessage: Uint8Array): Uint8Array => {
   // and we need to find the prefix that will match this.
   // Here first we take the max prefix char length, and check if as a number it is bigger
   // than the length of the message (since prefix is added to represent length of original message),
-  // if it is we we remove 1 from char length, if not we keep the max prefix char length.
+  // if it is we remove 1 from char length, if not we keep the max prefix char length.
   // As an example for the case where , if the message is 123456789, the expected prefix char is 9, with starting value 9123456789
   // the char length of the total message with the prefix is 10, so the max prefix char length we start is 2 from [1,0], and as a number 10, it is longer
   // than the length of the message after removing prefix (10 - 2 = 8), so we slice 1 char less, which is 9, and we get the correct prefix.

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -23,6 +23,46 @@ export const prefixEIP191Message = (message: BytesLike): Uint8Array => {
   }
 }
 
+export const removeEIP191Prefix = (prefixedMessage: Uint8Array): Uint8Array => {
+  // If the message is not prefixed, we return the message as is.
+  if (JSON.stringify(prefixedMessage.slice(0, eip191prefix.length)) !== JSON.stringify(eip191prefix)) {
+    return prefixedMessage
+  }
+
+  // We have two parts to remove.
+  // First is the EIP-191 prefix.
+  const ethereumSignedMessagePartSlicedArray = prefixedMessage.slice(eip191prefix.length)
+
+  // Second is the digits added which represent length of the message without the prefix
+  // and we need to find the prefix that will match this.
+  // Here first we take the max prefix char length, and check if as a number it is bigger
+  // than the length of the message (since prefix is added to represent length of original message),
+  // if it is we we remove 1 from char length, if not we keep the max prefix char length.
+  // As an example for the case where , if the message is 123456789, the expected prefix char is 9, with starting value 9123456789
+  // the char length of the total message with the prefix is 10, so the max prefix char length we start is 2 from [1,0], and as a number 10, it is longer
+  // than the length of the message after removing prefix (10 - 2 = 8), so we slice 1 char less, which is 9, and we get the correct prefix.
+  const maxPrefixCharLength = String(ethereumSignedMessagePartSlicedArray.length).length
+
+  let prefixCharLenght: number
+  let prefixAsNumber: number
+
+  try {
+    prefixAsNumber = Number(ethers.utils.toUtf8String(ethereumSignedMessagePartSlicedArray.slice(0, maxPrefixCharLength)))
+  } catch {
+    prefixAsNumber = Number(ethers.utils.hexlify(ethereumSignedMessagePartSlicedArray.slice(0, maxPrefixCharLength)))
+  }
+
+  if (prefixAsNumber > ethereumSignedMessagePartSlicedArray.length) {
+    prefixCharLenght = maxPrefixCharLength - 1
+  } else {
+    prefixCharLenght = maxPrefixCharLength
+  }
+
+  const prefixRevertedMessage = ethereumSignedMessagePartSlicedArray.slice(prefixCharLenght)
+
+  return prefixRevertedMessage
+}
+
 export const isValidSignature = async (
   address: string,
   digest: Uint8Array,
@@ -91,10 +131,7 @@ export const isUnityPlugin = (): boolean => !!navigator.userAgent.match(/UnitySe
 //  * @param {Status} of the wallet
 //  */
 export const isWalletUpToDate = (status: AccountStatus): boolean => {
-  return (
-    status.onChain.deployed &&
-    status.fullyMigrated
-  )
+  return status.onChain.deployed && status.fullyMigrated
 }
 
 export interface ItemStore {

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -23,7 +23,7 @@ export const prefixEIP191Message = (message: BytesLike): Uint8Array => {
   }
 }
 
-export const removeEIP191Prefix = (prefixedMessage: Uint8Array): Uint8Array => {
+export const trimEIP191Prefix = (prefixedMessage: Uint8Array): Uint8Array => {
   // If the message is not prefixed, we return the message as is.
   if (JSON.stringify(prefixedMessage.slice(0, eip191prefix.length)) !== JSON.stringify(eip191prefix)) {
     return prefixedMessage

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -52,7 +52,7 @@ export const removeEIP191Prefix = (prefixedMessage: Uint8Array): Uint8Array => {
     prefixAsNumber = Number(ethers.utils.hexlify(ethereumSignedMessagePartSlicedArray.slice(0, maxPrefixCharLength)))
   }
 
-  if (prefixAsNumber > ethereumSignedMessagePartSlicedArray.length) {
+  if (prefixAsNumber > ethereumSignedMessagePartSlicedArray.length || !Number.isInteger(prefixAsNumber)) {
     prefixCharLenght = maxPrefixCharLength - 1
   } else {
     prefixCharLenght = maxPrefixCharLength

--- a/packages/provider/tests/messages.ts
+++ b/packages/provider/tests/messages.ts
@@ -84,8 +84,10 @@ export const removeIep191Prefix_test2_raw = dlcText
 export const removeIep191Prefix_test3_raw = '1915 Robe' // 9 chars
 export const removeIep191Prefix_test4_raw =
   '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789' // 99 chars
+export const removeIep191Prefix_test5_raw = 'Robe 1915'
 
 export const removeIep191Prefix_test1_prefixed = prefixEIP191Message(removeIep191Prefix_test1_raw)
 export const removeIep191Prefix_test2_prefixed = prefixEIP191Message(dlcText)
 export const removeIep191Prefix_test3_prefixed = prefixEIP191Message(removeIep191Prefix_test3_raw)
 export const removeIep191Prefix_test4_prefixed = prefixEIP191Message(removeIep191Prefix_test4_raw)
+export const removeIep191Prefix_test5_prefixed = prefixEIP191Message(removeIep191Prefix_test5_raw)

--- a/packages/provider/tests/messages.ts
+++ b/packages/provider/tests/messages.ts
@@ -50,9 +50,9 @@ export const zeroExV3Order = new Uint8Array([
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ])
 
-// Messages for testing remove-iep191prefix
+// Messages for testing trim-eip191prefix
 
-export const removeIep191Prefix_test1_raw = `1915 Robert Frost
+export const trimEIP191Prefix_test1_raw = `1915 Robert Frost
 The Road Not Taken
   
 Two roads diverged in a yellow wood,
@@ -80,14 +80,14 @@ I took the one less traveled by,
 And that has made all the difference.
   
 \u2601 \u2600 \u2602`
-export const removeIep191Prefix_test2_raw = dclText
-export const removeIep191Prefix_test3_raw = '1915 Robe' // 9 chars
-export const removeIep191Prefix_test4_raw =
+export const trimEIP191Prefix_test2_raw = dclText
+export const trimEIP191Prefix_test3_raw = '1915 Robe' // 9 chars
+export const trimEIP191Prefix_test4_raw =
   '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789' // 99 chars
-export const removeIep191Prefix_test5_raw = 'Robe 1915'
+export const trimEIP191Prefix_test5_raw = 'Robe 1915'
 
-export const removeIep191Prefix_test1_prefixed = prefixEIP191Message(removeIep191Prefix_test1_raw)
-export const removeIep191Prefix_test2_prefixed = prefixEIP191Message(dclText)
-export const removeIep191Prefix_test3_prefixed = prefixEIP191Message(removeIep191Prefix_test3_raw)
-export const removeIep191Prefix_test4_prefixed = prefixEIP191Message(removeIep191Prefix_test4_raw)
-export const removeIep191Prefix_test5_prefixed = prefixEIP191Message(removeIep191Prefix_test5_raw)
+export const trimEIP191Prefix_test1_prefixed = prefixEIP191Message(trimEIP191Prefix_test1_raw)
+export const trimEIP191Prefix_test2_prefixed = prefixEIP191Message(dclText)
+export const trimEIP191Prefix_test3_prefixed = prefixEIP191Message(trimEIP191Prefix_test3_raw)
+export const trimEIP191Prefix_test4_prefixed = prefixEIP191Message(trimEIP191Prefix_test4_raw)
+export const trimEIP191Prefix_test5_prefixed = prefixEIP191Message(trimEIP191Prefix_test5_raw)

--- a/packages/provider/tests/messages.ts
+++ b/packages/provider/tests/messages.ts
@@ -7,11 +7,11 @@ export const message1 = new Uint8Array([
   72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33
 ])
 
-const dlcText = `Decentraland Login
+const dclText = `Decentraland Login
 Ephemeral address: 0xe1bCF3CAc83534a055f7254C1FD88B21159fCc67
 Expiration: 2022-10-27T16:03:29.191Z`
 
-export const dclLogin = ethers.utils.toUtf8Bytes(dlcText)
+export const dclLogin = ethers.utils.toUtf8Bytes(dclText)
 
 // Ethereum personal sign 0x v3 order
 export const zeroExV3Order = new Uint8Array([
@@ -80,14 +80,14 @@ I took the one less traveled by,
 And that has made all the difference.
   
 \u2601 \u2600 \u2602`
-export const removeIep191Prefix_test2_raw = dlcText
+export const removeIep191Prefix_test2_raw = dclText
 export const removeIep191Prefix_test3_raw = '1915 Robe' // 9 chars
 export const removeIep191Prefix_test4_raw =
   '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789' // 99 chars
 export const removeIep191Prefix_test5_raw = 'Robe 1915'
 
 export const removeIep191Prefix_test1_prefixed = prefixEIP191Message(removeIep191Prefix_test1_raw)
-export const removeIep191Prefix_test2_prefixed = prefixEIP191Message(dlcText)
+export const removeIep191Prefix_test2_prefixed = prefixEIP191Message(dclText)
 export const removeIep191Prefix_test3_prefixed = prefixEIP191Message(removeIep191Prefix_test3_raw)
 export const removeIep191Prefix_test4_prefixed = prefixEIP191Message(removeIep191Prefix_test4_raw)
 export const removeIep191Prefix_test5_prefixed = prefixEIP191Message(removeIep191Prefix_test5_raw)

--- a/packages/provider/tests/messages.ts
+++ b/packages/provider/tests/messages.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+import { prefixEIP191Message } from '../src/utils'
 
 // Ethereum personal sign: Hello, World!
 export const message1 = new Uint8Array([
@@ -6,10 +7,11 @@ export const message1 = new Uint8Array([
   72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33
 ])
 
-
-export const dclLogin = ethers.utils.toUtf8Bytes(`Decentraland Login
+const dlcText = `Decentraland Login
 Ephemeral address: 0xe1bCF3CAc83534a055f7254C1FD88B21159fCc67
-Expiration: 2022-10-27T16:03:29.191Z`)
+Expiration: 2022-10-27T16:03:29.191Z`
+
+export const dclLogin = ethers.utils.toUtf8Bytes(dlcText)
 
 // Ethereum personal sign 0x v3 order
 export const zeroExV3Order = new Uint8Array([
@@ -47,3 +49,43 @@ export const zeroExV3Order = new Uint8Array([
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ])
+
+// Messages for testing remove-iep191prefix
+
+export const removeIep191Prefix_test1_raw = `1915 Robert Frost
+The Road Not Taken
+  
+Two roads diverged in a yellow wood,
+And sorry I could not travel both
+And be one traveler, long I stood
+And looked down one as far as I could
+To where it bent in the undergrowth
+  
+Then took the other, as just as fair,
+And having perhaps the better claim,
+Because it was grassy and wanted wear
+Though as for that the passing there
+Had worn them really about the same,
+  
+And both that morning equally lay
+In leaves no step had trodden black.
+Oh, I kept the first for another day!
+Yet knowing how way leads on to way,
+I doubted if I should ever come back.
+  
+I shall be telling this with a sigh
+Somewhere ages and ages hence:
+Two roads diverged in a wood, and I—
+I took the one less traveled by,
+And that has made all the difference.
+  
+\u2601 \u2600 \u2602`
+export const removeIep191Prefix_test2_raw = dlcText
+export const removeIep191Prefix_test3_raw = '1915 Robe' // 9 chars
+export const removeIep191Prefix_test4_raw =
+  '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789' // 99 chars
+
+export const removeIep191Prefix_test1_prefixed = prefixEIP191Message(removeIep191Prefix_test1_raw)
+export const removeIep191Prefix_test2_prefixed = prefixEIP191Message(dlcText)
+export const removeIep191Prefix_test3_prefixed = prefixEIP191Message(removeIep191Prefix_test3_raw)
+export const removeIep191Prefix_test4_prefixed = prefixEIP191Message(removeIep191Prefix_test4_raw)

--- a/packages/provider/tests/remove-eip191prefix.spec.ts
+++ b/packages/provider/tests/remove-eip191prefix.spec.ts
@@ -2,33 +2,33 @@ import chaiAsPromised from 'chai-as-promised'
 import * as chai from 'chai'
 
 import {
-  removeIep191Prefix_test1_prefixed,
-  removeIep191Prefix_test1_raw,
-  removeIep191Prefix_test2_prefixed,
-  removeIep191Prefix_test2_raw,
-  removeIep191Prefix_test3_prefixed,
-  removeIep191Prefix_test3_raw,
-  removeIep191Prefix_test4_prefixed,
-  removeIep191Prefix_test4_raw,
-  removeIep191Prefix_test5_prefixed,
-  removeIep191Prefix_test5_raw
+  trimEIP191Prefix_test1_prefixed,
+  trimEIP191Prefix_test1_raw,
+  trimEIP191Prefix_test2_prefixed,
+  trimEIP191Prefix_test2_raw,
+  trimEIP191Prefix_test3_prefixed,
+  trimEIP191Prefix_test3_raw,
+  trimEIP191Prefix_test4_prefixed,
+  trimEIP191Prefix_test4_raw,
+  trimEIP191Prefix_test5_prefixed,
+  trimEIP191Prefix_test5_raw
 } from './messages'
-import { removeEIP191Prefix } from '../src/utils'
+import { trimEIP191Prefix } from '../src/utils'
 import { ethers } from 'ethers'
 const { expect } = chai.use(chaiAsPromised)
 
-describe('removing eip191prefix', () => {
-  it('should remove prefix', () => {
-    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test1_prefixed))).equal(removeIep191Prefix_test1_raw)
+describe('trimming eip191prefix', () => {
+  it('should trim prefix', () => {
+    expect(ethers.utils.toUtf8String(trimEIP191Prefix(trimEIP191Prefix_test1_prefixed))).equal(trimEIP191Prefix_test1_raw)
   })
 
   it('should handle eip191 exempt messages (by returning early)', () => {
-    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test2_prefixed))).equal(removeIep191Prefix_test2_raw)
+    expect(ethers.utils.toUtf8String(trimEIP191Prefix(trimEIP191Prefix_test2_prefixed))).equal(trimEIP191Prefix_test2_raw)
   })
 
-  it('should remove prefix for case where max prefix char as number is bigger than the length of the message', () => {
-    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test3_prefixed))).equal(removeIep191Prefix_test3_raw)
-    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test4_prefixed))).equal(removeIep191Prefix_test4_raw)
-    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test5_prefixed))).equal(removeIep191Prefix_test5_raw)
+  it('should trim prefix for case where max prefix char as number is bigger than the length of the message', () => {
+    expect(ethers.utils.toUtf8String(trimEIP191Prefix(trimEIP191Prefix_test3_prefixed))).equal(trimEIP191Prefix_test3_raw)
+    expect(ethers.utils.toUtf8String(trimEIP191Prefix(trimEIP191Prefix_test4_prefixed))).equal(trimEIP191Prefix_test4_raw)
+    expect(ethers.utils.toUtf8String(trimEIP191Prefix(trimEIP191Prefix_test5_prefixed))).equal(trimEIP191Prefix_test5_raw)
   })
 })

--- a/packages/provider/tests/remove-eip191prefix.spec.ts
+++ b/packages/provider/tests/remove-eip191prefix.spec.ts
@@ -1,0 +1,31 @@
+import chaiAsPromised from 'chai-as-promised'
+import * as chai from 'chai'
+
+import {
+  removeIep191Prefix_test1_prefixed,
+  removeIep191Prefix_test1_raw,
+  removeIep191Prefix_test2_prefixed,
+  removeIep191Prefix_test2_raw,
+  removeIep191Prefix_test3_prefixed,
+  removeIep191Prefix_test3_raw,
+  removeIep191Prefix_test4_prefixed,
+  removeIep191Prefix_test4_raw
+} from './messages'
+import { removeEIP191Prefix } from '../src/utils'
+import { ethers } from 'ethers'
+const { expect } = chai.use(chaiAsPromised)
+
+describe('removing eip191prefix', () => {
+  it('should remove prefix', () => {
+    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test1_prefixed))).equal(removeIep191Prefix_test1_raw)
+  })
+
+  it('should handle eip191 exempt messages (by returning early)', () => {
+    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test2_prefixed))).equal(removeIep191Prefix_test2_raw)
+  })
+
+  it('should remove prefix for case where max prefix char as number is bigger than the length of the message', () => {
+    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test3_prefixed))).equal(removeIep191Prefix_test3_raw)
+    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test4_prefixed))).equal(removeIep191Prefix_test4_raw)
+  })
+})

--- a/packages/provider/tests/remove-eip191prefix.spec.ts
+++ b/packages/provider/tests/remove-eip191prefix.spec.ts
@@ -9,7 +9,9 @@ import {
   removeIep191Prefix_test3_prefixed,
   removeIep191Prefix_test3_raw,
   removeIep191Prefix_test4_prefixed,
-  removeIep191Prefix_test4_raw
+  removeIep191Prefix_test4_raw,
+  removeIep191Prefix_test5_prefixed,
+  removeIep191Prefix_test5_raw
 } from './messages'
 import { removeEIP191Prefix } from '../src/utils'
 import { ethers } from 'ethers'
@@ -27,5 +29,6 @@ describe('removing eip191prefix', () => {
   it('should remove prefix for case where max prefix char as number is bigger than the length of the message', () => {
     expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test3_prefixed))).equal(removeIep191Prefix_test3_raw)
     expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test4_prefixed))).equal(removeIep191Prefix_test4_raw)
+    expect(ethers.utils.toUtf8String(removeEIP191Prefix(removeIep191Prefix_test5_prefixed))).equal(removeIep191Prefix_test5_raw)
   })
 })


### PR DESCRIPTION
A utility function to trim EIP-191 signed message prefixes for the purposes of displaying a clean signing request on a frontend.