### PR TITLE
Avoid wallet deploy on v2 sdk

### DIFF
--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -229,7 +229,7 @@ export class Web3Signer extends Signer implements TypedDataSigner {
 
   // signMessage matches implementation from ethers JsonRpcSigner for compatibility, but with
   // multi-chain support.
-  async signMessage(message: BytesLike, chainId?: ChainIdLike, allSigners?: boolean, sequenceVerified?: boolean): Promise<string> {
+  async signMessage(message: BytesLike, chainId?: ChainIdLike, sequenceVerified: boolean = true): Promise<string> {
     const provider = await this.getSender(maybeChainId(chainId) || this.defaultChainId)
 
     const data = typeof message === 'string' ? ethers.utils.toUtf8Bytes(message) : message
@@ -251,8 +251,7 @@ export class Web3Signer extends Signer implements TypedDataSigner {
     types: Record<string, Array<TypedDataField>>,
     message: Record<string, any>,
     chainId?: ChainIdLike,
-    allSigners?: boolean,
-    sequenceVerified?: boolean
+    sequenceVerified: boolean = true
   ): Promise<string> {
     // Populate any ENS names (in-place)
     // const populated = await ethers.utils._TypedDataEncoder.resolveNames(domain, types, message, (name: string) => {

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -288,6 +288,11 @@ export class Wallet implements WalletProvider {
   }
 
   connect = async (options?: ConnectOptions): Promise<ConnectDetails> => {
+    if (options && options?.authorizeVersion === undefined) {
+      // Populate default authorize version if not provided
+      options.authorizeVersion = 2
+    }
+
     if (options?.refresh === true) {
       this.disconnect()
     }


### PR DESCRIPTION
- [ ] Default `signMessage` and `signTypedMessage` to `sequenceVerified = true`. This means that these signatures won't trigger a wallet deployment.
- [ ] Pass `authorizeVersion == 2` to the connect options, this way we don't deploy the wallet upon connect (polygon/mumbai)