### PR TITLE
provider utils, expose isValidMessageSignature and isValidTypedDataSi…

### DIFF
--- a/packages/0xsequence/src/utils.ts
+++ b/packages/0xsequence/src/utils.ts
@@ -2,8 +2,8 @@ export * from '@0xsequence/utils'
 
 export {
   isValidSignature,
-  // isValidMessageSignature,
-  // isValidTypedDataSignature,
+  isValidMessageSignature,
+  isValidTypedDataSignature,
   // recoverWalletConfig,
   isWalletUpToDate
 } from '@0xsequence/provider'

--- a/packages/core/src/v1/index.ts
+++ b/packages/core/src/v1/index.ts
@@ -1,5 +1,15 @@
+import { WalletContext } from '../commons/context'
 
 export * as config from './config'
 export * as signature from './signature'
 
 export const version = 1
+
+export const DeployedWalletContext: WalletContext = {
+  version: version,
+  factory: '0xf9D09D634Fb818b05149329C1dcCFAeA53639d96',
+  guestModule: '0x02390F3E6E5FD1C6786CB78FD3027C117a9955A7',
+  mainModule: '0xd01F11855bCcb95f88D7A48492F66410d4637313',
+  mainModuleUpgradable: '0x7EFE6cE415956c5f80C6530cC6cc81b4808F6118',
+  walletCreationCode: '',
+}

--- a/packages/core/src/v2/index.ts
+++ b/packages/core/src/v2/index.ts
@@ -1,3 +1,4 @@
+import { WalletContext } from '../commons/context'
 
 export * as config from "./config"
 export * as signature from "./signature"
@@ -13,3 +14,12 @@ export const coders = {
 }
 
 export const version = 2
+
+export const DeployedWalletContext: WalletContext = {
+  version: version,
+  factory: '0xFaA5c0b14d1bED5C888Ca655B9a8A5911F78eF4A',
+  guestModule: '0xfea230Ee243f88BC698dD8f1aE93F8301B6cdfaE',
+  mainModule: '0xfBf8f1A5E00034762D928f46d438B947f5d4065d',
+  mainModuleUpgradable: '0x4222dcA3974E39A8b41c411FeDDE9b09Ae14b911',
+  walletCreationCode: '',
+}

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -2,7 +2,7 @@ import { ethers, BytesLike } from 'ethers'
 import { Web3Provider } from './provider'
 import { messageIsExemptFromEIP191Prefix } from './eip191exceptions'
 import { AccountStatus } from '@0xsequence/account'
-import { commons } from '@0xsequence/core'
+import { commons, allVersions } from '@0xsequence/core'
 import { encodeMessageDigest, TypedData, encodeTypedDataDigest } from '@0xsequence/utils'
 
 const eip191prefix = ethers.utils.toUtf8Bytes('\x19Ethereum Signed Message:\n')
@@ -69,9 +69,10 @@ export const isValidSignature = async (
   digest: Uint8Array,
   sig: string,
   provider: Web3Provider | ethers.providers.Web3Provider,
-  contexts: { [key: number]: commons.context.WalletContext }
+  contexts?: { [key: number]: commons.context.WalletContext }
 ): Promise<boolean> => {
-  const reader = new commons.reader.OnChainReader(provider, contexts)
+  const deployedContexts = allVersions.map(v => v.DeployedWalletContext)
+  const reader = new commons.reader.OnChainReader(provider, contexts || deployedContexts)
   return reader.isValidSignature(address, digest, sig)
 }
 
@@ -81,11 +82,12 @@ export const isValidMessageSignature = async (
   message: string | Uint8Array,
   signature: string,
   provider: Web3Provider | ethers.providers.Web3Provider,
-  contexts: { [key: number]: commons.context.WalletContext }
+  contexts?: { [key: number]: commons.context.WalletContext }
 ): Promise<boolean> => {
+  const deployedContexts = allVersions.map(v => v.DeployedWalletContext)
   const prefixed = prefixEIP191Message(message)
   const digest = encodeMessageDigest(prefixed)
-  return isValidSignature(address, digest, signature, provider, contexts)
+  return isValidSignature(address, digest, signature, provider, contexts || deployedContexts)
 }
 
 // Verify typedData signature
@@ -94,9 +96,10 @@ export const isValidTypedDataSignature = (
   typedData: TypedData,
   signature: string,
   provider: Web3Provider | ethers.providers.Web3Provider,
-  contexts: { [key: number]: commons.context.WalletContext }
+  contexts?: { [key: number]: commons.context.WalletContext }
 ): Promise<boolean> => {
-  return isValidSignature(address, encodeTypedDataDigest(typedData), signature, provider, contexts)
+  const deployedContexts = allVersions.map(v => v.DeployedWalletContext)
+  return isValidSignature(address, encodeTypedDataDigest(typedData), signature, provider, contexts || deployedContexts)
 }
 
 // export const recoverWalletConfig = async (

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -3,6 +3,7 @@ import { Web3Provider } from './provider'
 import { messageIsExemptFromEIP191Prefix } from './eip191exceptions'
 import { AccountStatus } from '@0xsequence/account'
 import { commons } from '@0xsequence/core'
+import { encodeMessageDigest, TypedData, encodeTypedDataDigest } from '@0xsequence/utils'
 
 const eip191prefix = ethers.utils.toUtf8Bytes('\x19Ethereum Signed Message:\n')
 
@@ -74,29 +75,29 @@ export const isValidSignature = async (
   return reader.isValidSignature(address, digest, sig)
 }
 
-// export const isValidMessageSignature = async (
-//   address: string,
-//   message: string | Uint8Array,
-//   signature: string,
-//   provider: Web3Provider | ethers.providers.Web3Provider,
-//   chainId?: number,
-//   walletContext?: WalletContext
-// ): Promise<boolean> => {
-//   const prefixed = prefixEIP191Message(message)
-//   const digest = encodeMessageDigest(prefixed)
-//   return isValidSignature(address, digest, signature, provider, chainId, walletContext)
-// }
+// Verify message signature
+export const isValidMessageSignature = async (
+  address: string,
+  message: string | Uint8Array,
+  signature: string,
+  provider: Web3Provider | ethers.providers.Web3Provider,
+  contexts: { [key: number]: commons.context.WalletContext }
+): Promise<boolean> => {
+  const prefixed = prefixEIP191Message(message)
+  const digest = encodeMessageDigest(prefixed)
+  return isValidSignature(address, digest, signature, provider, contexts)
+}
 
-// export const isValidTypedDataSignature = (
-//   address: string,
-//   typedData: TypedData,
-//   signature: string,
-//   provider: Web3Provider | ethers.providers.Web3Provider,
-//   chainId?: number,
-//   walletContext?: WalletContext
-// ): Promise<boolean> => {
-//   return isValidSignature(address, encodeTypedDataDigest(typedData), signature, provider, chainId, walletContext)
-// }
+// Verify typedData signature
+export const isValidTypedDataSignature = (
+  address: string,
+  typedData: TypedData,
+  signature: string,
+  provider: Web3Provider | ethers.providers.Web3Provider,
+  contexts: { [key: number]: commons.context.WalletContext }
+): Promise<boolean> => {
+  return isValidSignature(address, encodeTypedDataDigest(typedData), signature, provider, contexts)
+}
 
 // export const recoverWalletConfig = async (
 //   address: string,

--- a/packages/tests/src/context/v1.ts
+++ b/packages/tests/src/context/v1.ts
@@ -1,6 +1,4 @@
 import { ethers } from "ethers"
-import { v1 } from '../builds'
-import { deployContract } from "../singletonFactory"
 import { isContract } from "../utils"
 
 // These are the Sequence v1 contracts


### PR DESCRIPTION
add back sequence.utils.isValidMessageSignature and sequence.utils.isValidTypedDataSignature which can be used to validate signatures for any kind of wallet, EOA, smart wallet, and Sequence of course.

for a better developer experience, I've also included the DeployWalletContext constants for v1 and v2, and use these as defaults for the "contexts" argument if not provided