### PR TITLE
Simplify isValidSignature

### DIFF
--- a/packages/0xsequence/src/utils.ts
+++ b/packages/0xsequence/src/utils.ts
@@ -4,7 +4,6 @@ export {
   isValidSignature,
   isValidMessageSignature,
   isValidTypedDataSignature,
-  // recoverWalletConfig,
   isWalletUpToDate
 } from '@0xsequence/provider'
 

--- a/packages/core/src/commons/reader.ts
+++ b/packages/core/src/commons/reader.ts
@@ -27,8 +27,7 @@ export interface Reader {
   private isDeployedCache: Set<string> = new Set()
 
   constructor(
-    public readonly provider: ethers.providers.Provider,
-    public readonly contexts?: { [key: number]: commons.context.WalletContext }
+    public readonly provider: ethers.providers.Provider
   ) {}
 
   private module(address: string) {

--- a/packages/core/src/v1/index.ts
+++ b/packages/core/src/v1/index.ts
@@ -11,5 +11,5 @@ export const DeployedWalletContext: WalletContext = {
   guestModule: '0x02390F3E6E5FD1C6786CB78FD3027C117a9955A7',
   mainModule: '0xd01F11855bCcb95f88D7A48492F66410d4637313',
   mainModuleUpgradable: '0x7EFE6cE415956c5f80C6530cC6cc81b4808F6118',
-  walletCreationCode: '',
+  walletCreationCode: '0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3',
 }

--- a/packages/core/src/v2/index.ts
+++ b/packages/core/src/v2/index.ts
@@ -21,5 +21,5 @@ export const DeployedWalletContext: WalletContext = {
   guestModule: '0xfea230Ee243f88BC698dD8f1aE93F8301B6cdfaE',
   mainModule: '0xfBf8f1A5E00034762D928f46d438B947f5d4065d',
   mainModuleUpgradable: '0x4222dcA3974E39A8b41c411FeDDE9b09Ae14b911',
-  walletCreationCode: '',
+  walletCreationCode: '0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3',
 }

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -2,7 +2,7 @@ import { ethers, BytesLike } from 'ethers'
 import { Web3Provider } from './provider'
 import { messageIsExemptFromEIP191Prefix } from './eip191exceptions'
 import { AccountStatus } from '@0xsequence/account'
-import { commons, allVersions } from '@0xsequence/core'
+import { commons } from '@0xsequence/core'
 import { encodeMessageDigest, TypedData, encodeTypedDataDigest } from '@0xsequence/utils'
 
 const eip191prefix = ethers.utils.toUtf8Bytes('\x19Ethereum Signed Message:\n')
@@ -68,11 +68,9 @@ export const isValidSignature = async (
   address: string,
   digest: Uint8Array,
   sig: string,
-  provider: Web3Provider | ethers.providers.Web3Provider,
-  contexts?: { [key: number]: commons.context.WalletContext }
+  provider: Web3Provider | ethers.providers.Web3Provider
 ): Promise<boolean> => {
-  const deployedContexts = allVersions.map(v => v.DeployedWalletContext)
-  const reader = new commons.reader.OnChainReader(provider, contexts || deployedContexts)
+  const reader = new commons.reader.OnChainReader(provider)
   return reader.isValidSignature(address, digest, sig)
 }
 
@@ -81,13 +79,11 @@ export const isValidMessageSignature = async (
   address: string,
   message: string | Uint8Array,
   signature: string,
-  provider: Web3Provider | ethers.providers.Web3Provider,
-  contexts?: { [key: number]: commons.context.WalletContext }
+  provider: Web3Provider | ethers.providers.Web3Provider
 ): Promise<boolean> => {
-  const deployedContexts = allVersions.map(v => v.DeployedWalletContext)
   const prefixed = prefixEIP191Message(message)
   const digest = encodeMessageDigest(prefixed)
-  return isValidSignature(address, digest, signature, provider, contexts || deployedContexts)
+  return isValidSignature(address, digest, signature, provider)
 }
 
 // Verify typedData signature
@@ -95,34 +91,11 @@ export const isValidTypedDataSignature = (
   address: string,
   typedData: TypedData,
   signature: string,
-  provider: Web3Provider | ethers.providers.Web3Provider,
-  contexts?: { [key: number]: commons.context.WalletContext }
+  provider: Web3Provider | ethers.providers.Web3Provider
 ): Promise<boolean> => {
-  const deployedContexts = allVersions.map(v => v.DeployedWalletContext)
-  return isValidSignature(address, encodeTypedDataDigest(typedData), signature, provider, contexts || deployedContexts)
+  return isValidSignature(address, encodeTypedDataDigest(typedData), signature, provider)
 }
 
-// export const recoverWalletConfig = async (
-//   address: string,
-//   digest: BytesLike,
-//   signature: string | commons.signature.UnrecoveredSignature | commons.signature.Signature<commons.config.Config>,
-//   chainId: BigNumberish,
-//   walletContext?: WalletContext
-// ): Promise<commons.config.Config> => {
-//   const subDigest = packMessageData(address, chainId, digest)
-//   const config = await recoverConfig(subDigest, signature)
-
-//   if (walletContext) {
-//     const recoveredWalletAddress = addressOf(config, walletContext)
-//     if (config.address && config.address !== recoveredWalletAddress) {
-//       throw new Error('recovered address does not match the WalletConfig address, check the WalletContext')
-//     } else {
-//       config.address = recoveredWalletAddress
-//     }
-//   }
-
-//   return config
-// }
 
 export const isBrowserExtension = (): boolean =>
   window.location.protocol === 'chrome-extension:' || window.location.protocol === 'moz-extension:'

--- a/packages/provider/src/utils/index.ts
+++ b/packages/provider/src/utils/index.ts
@@ -59,7 +59,7 @@ export class WalletUtils {
   ): Promise<boolean> {
     const provider = this.wallet.getProvider(chainId)
     if (!provider) throw new Error(`unable to get provider for chainId ${chainId}`)
-    return isValidSignature(address, digest, signature, provider, await this.wallet.getWalletContext())
+    return isValidSignature(address, digest, signature, provider)
   }
 
   // Verify message signature
@@ -73,7 +73,7 @@ export class WalletUtils {
     if (!provider) throw new Error(`unable to get provider for chainId ${chainId}`)
     const prefixed = prefixEIP191Message(message)
     const digest = encodeMessageDigest(prefixed)
-    return isValidSignature(address, digest, signature, provider, await this.wallet.getWalletContext())
+    return isValidSignature(address, digest, signature, provider)
   }
 
   // Verify typedData signature


### PR DESCRIPTION
- Remove contexts from `Reader`, they aren't used
- Remove contexts from `isValidSignature*`, EIP6492 doesn't need them
- Add `walletCreationCode` to deployed contexts
- Remove `recoverWalletConfig`, now is part of core