### PR TITLE
Export network constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/runtime": "^7.21.0",
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.26.1",
-    "@preconstruct/cli": "^2.2.2",
+    "@preconstruct/cli": "^2.8.1",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^10.0.0",

--- a/packages/network/constants/package.json
+++ b/packages/network/constants/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/0xsequence-network-constants.cjs.js",
+  "module": "dist/0xsequence-network-constants.esm.js"
+}

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -26,6 +26,13 @@
   },
   "files": [
     "src",
-    "dist"
-  ]
+    "dist",
+    "constants"
+  ],
+  "preconstruct": {
+    "entrypoints": [
+      "index.ts",
+      "constants.ts"
+    ]
+  }
 }

--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -3,60 +3,7 @@ import { Indexer } from '@0xsequence/indexer'
 import { Relayer, RpcRelayerOptions } from '@0xsequence/relayer'
 import { findNetworkConfig, stringTemplate, validateAndSortNetworks } from './utils'
 import { isBigNumberish } from '@0xsequence/utils'
-
-export enum ChainId {
-  // Ethereum
-  MAINNET = 1,
-  ROPSTEN = 3,
-  RINKEBY = 4,
-  GOERLI = 5,
-  KOVAN = 42,
-
-  // Polygon
-  POLYGON = 137,
-  POLYGON_MUMBAI = 80001,
-  POLYGON_ZKEVM = 1101,
-
-  // BSC
-  BSC = 56,
-  BSC_TESTNET = 97,
-
-  // Optimism
-  OPTIMISM = 10,
-  OPTIMISM_TESTNET = 69,
-
-  // Arbitrum One
-  ARBITRUM = 42161,
-  ARBITRUM_GOERLI = 421613,
-
-  // Arbitrum Nova
-  ARBITRUM_NOVA = 42170,
-
-  // Avalanche
-  AVALANCHE = 43114,
-  AVALANCHE_TESTNET = 43113,
-
-  // Fantom
-  FANTOM = 250,
-  FANTOM_TESTNET = 4002,
-
-  // Gnosis Chain (XDAI)
-  GNOSIS = 100,
-
-  // AURORA
-  AURORA = 1313161554,
-  AURORA_TESTNET = 1313161556,
-
-  // BASE
-  BASE_GOERLI = 84531,
-
-  // HARDHAT TESTNETS
-  HARDHAT = 31337,
-  HARDHAT_2 = 31338,
-
-  // HOMEVERSE
-  HOMEVERSE_TESTNET = 40875
-}
+import { ChainId } from './constants'
 
 export interface NetworkConfig {
   title?: string
@@ -366,7 +313,7 @@ const genUrls = (network: string) => {
     relayer: {
       url: relayerURL(network),
       provider: {
-        url: rpcUrl,
+        url: rpcUrl
       }
     },
     indexerUrl: indexerURL(network)
@@ -420,7 +367,7 @@ export const allNetworks = validateAndSortNetworks([
   },
   {
     ...networks[ChainId.POLYGON_MUMBAI],
-    ...genUrls('mumbai'),
+    ...genUrls('mumbai')
   },
   {
     ...networks[ChainId.BSC_TESTNET],
@@ -444,7 +391,7 @@ export const allNetworks = validateAndSortNetworks([
     relayer: {
       url: 'http://localhost:3000',
       provider: {
-        url: 'http://localhost:8545',
+        url: 'http://localhost:8545'
       }
     }
   },
@@ -454,7 +401,7 @@ export const allNetworks = validateAndSortNetworks([
     relayer: {
       url: 'http://localhost:3000',
       provider: {
-        url: 'http://localhost:9545',
+        url: 'http://localhost:9545'
       }
     }
   }

--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -106,7 +106,8 @@ export const allNetworks = validateAndSortNetworks([
   },
   {
     ...networks[ChainId.RINKEBY],
-    ...genUrls('rinkeby')
+    ...genUrls('rinkeby'),
+    disabled: true
   },
   {
     ...networks[ChainId.GOERLI],

--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -3,17 +3,9 @@ import { Indexer } from '@0xsequence/indexer'
 import { Relayer, RpcRelayerOptions } from '@0xsequence/relayer'
 import { findNetworkConfig, stringTemplate, validateAndSortNetworks } from './utils'
 import { isBigNumberish } from '@0xsequence/utils'
-import { ChainId } from './constants'
+import { ChainId, NetworkMetadata, networks } from './constants'
 
-export interface NetworkConfig {
-  title?: string
-  name: string
-  chainId: number
-  testnet?: boolean
-
-  blockExplorer?: BlockExplorerConfig
-  ensAddress?: string
-
+export type NetworkConfig = NetworkMetadata & {
   rpcUrl: string
   provider?: providers.Provider
   indexerUrl?: string
@@ -37,256 +29,9 @@ export type BlockExplorerConfig = {
   txnHashUrl?: string
 }
 
-export const indexerURL = (network: string) => stringTemplate('https://${network}-indexer.sequence.app', { network: network })
-export const relayerURL = (network: string) => stringTemplate('https://${network}-relayer.sequence.app', { network: network })
-export const nodesURL = (network: string) => stringTemplate('https://nodes.sequence.app/${network}', { network: network })
-
-export const networks: Record<ChainId, Omit<NetworkConfig, 'rpcUrl'>> = {
-  [ChainId.MAINNET]: {
-    chainId: ChainId.MAINNET,
-    name: 'mainnet',
-    title: 'Ethereum',
-    blockExplorer: {
-      name: 'Etherscan',
-      rootUrl: 'https://etherscan.io/'
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
-  },
-  [ChainId.ROPSTEN]: {
-    chainId: ChainId.ROPSTEN,
-    name: 'ropsten',
-    title: 'Ropsten',
-    testnet: true,
-    blockExplorer: {
-      name: 'Etherscan (Ropsten)',
-      rootUrl: 'https://ropsten.etherscan.io/'
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
-  },
-  [ChainId.RINKEBY]: {
-    chainId: ChainId.RINKEBY,
-    name: 'rinkeby',
-    title: 'Rinkeby',
-    testnet: true,
-    blockExplorer: {
-      name: 'Etherscan (Rinkeby)',
-      rootUrl: 'https://rinkeby.etherscan.io/'
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    disabled: true
-  },
-  [ChainId.GOERLI]: {
-    chainId: ChainId.GOERLI,
-    name: 'goerli',
-    title: 'Goerli',
-    testnet: true,
-    blockExplorer: {
-      name: 'Etherscan (Goerli)',
-      rootUrl: 'https://goerli.etherscan.io/'
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
-  },
-  [ChainId.KOVAN]: {
-    chainId: ChainId.KOVAN,
-    name: 'kovan',
-    title: 'Kovan',
-    testnet: true,
-    blockExplorer: {
-      name: 'Etherscan (Kovan)',
-      rootUrl: 'https://kovan.etherscan.io/'
-    }
-  },
-  [ChainId.POLYGON]: {
-    chainId: ChainId.POLYGON,
-    name: 'polygon',
-    title: 'Polygon',
-    blockExplorer: {
-      name: 'Polygonscan',
-      rootUrl: 'https://polygonscan.com/'
-    },
-    // TODO: Remove default and auth chains from here
-    isDefaultChain: true,
-    isAuthChain: true
-  } as LegacyNetworkConfig,
-  [ChainId.POLYGON_MUMBAI]: {
-    chainId: ChainId.POLYGON_MUMBAI,
-    name: 'mumbai',
-    title: 'Polygon Mumbai',
-    testnet: true,
-    blockExplorer: {
-      name: 'Polygonscan (Mumbai)',
-      rootUrl: 'https://mumbai.polygonscan.com/'
-    }
-  },
-  [ChainId.POLYGON_ZKEVM]: {
-    chainId: ChainId.POLYGON_ZKEVM,
-    name: 'polygon-zkevm',
-    title: 'Polygon zkEVM',
-    blockExplorer: {
-      name: 'Polygonscan (zkEVM)',
-      rootUrl: 'https://zkevm.polygonscan.com/'
-    }
-  },
-  [ChainId.BSC]: {
-    chainId: ChainId.BSC,
-    name: 'bsc',
-    title: 'BNB Smart Chain',
-    blockExplorer: {
-      name: 'BSCScan',
-      rootUrl: 'https://bscscan.com/'
-    }
-  },
-  [ChainId.BSC_TESTNET]: {
-    chainId: ChainId.BSC_TESTNET,
-    name: 'bsc-testnet',
-    title: 'BNB Smart Chain Testnet',
-    testnet: true,
-    blockExplorer: {
-      name: 'BSCScan (Testnet)',
-      rootUrl: 'https://testnet.bscscan.com/'
-    }
-  },
-  [ChainId.OPTIMISM]: {
-    chainId: ChainId.OPTIMISM,
-    name: 'optimism',
-    title: 'Optimism',
-    blockExplorer: {
-      name: 'Etherscan (Optimism)',
-      rootUrl: 'https://optimistic.etherscan.io/'
-    }
-  },
-  [ChainId.OPTIMISM_TESTNET]: {
-    chainId: ChainId.OPTIMISM_TESTNET,
-    name: 'optimism-testnet',
-    title: 'Optimistic Kovan',
-    testnet: true,
-    blockExplorer: {
-      name: 'Etherscan (Optimism Testnet)',
-      rootUrl: 'https://kovan-optimistic.etherscan.io/'
-    }
-  },
-  [ChainId.ARBITRUM]: {
-    chainId: ChainId.ARBITRUM,
-    name: 'arbitrum',
-    title: 'Arbitrum One',
-    blockExplorer: {
-      name: 'Arbiscan',
-      rootUrl: 'https://arbiscan.io/'
-    }
-  },
-  [ChainId.ARBITRUM_GOERLI]: {
-    chainId: ChainId.ARBITRUM_GOERLI,
-    name: 'arbitrum-goerli',
-    title: 'Arbitrum Goerli',
-    testnet: true,
-    blockExplorer: {
-      name: 'Arbiscan (Testnet)',
-      rootUrl: 'https://testnet.arbiscan.io/'
-    }
-  },
-  [ChainId.ARBITRUM_NOVA]: {
-    chainId: ChainId.ARBITRUM_NOVA,
-    name: 'arbitrum-nova',
-    title: 'Arbitrum Nova',
-    blockExplorer: {
-      name: 'Nova Explorer',
-      rootUrl: 'https://nova-explorer.arbitrum.io/'
-    }
-  },
-  [ChainId.AVALANCHE]: {
-    chainId: ChainId.AVALANCHE,
-    name: 'avalanche',
-    title: 'Avalanche',
-    blockExplorer: {
-      name: 'Snowtrace',
-      rootUrl: 'https://snowtrace.io/'
-    }
-  },
-  [ChainId.AVALANCHE_TESTNET]: {
-    chainId: ChainId.AVALANCHE_TESTNET,
-    name: 'avalanche-testnet',
-    title: 'Avalanche Testnet',
-    testnet: true,
-    blockExplorer: {
-      name: 'Snowtrace (Testnet)',
-      rootUrl: 'https://testnet.snowtrace.io/'
-    }
-  },
-  [ChainId.FANTOM]: {
-    chainId: ChainId.FANTOM,
-    name: 'fantom',
-    title: 'Fantom',
-    blockExplorer: {
-      name: 'FTMScan',
-      rootUrl: 'https://ftmscan.com/'
-    }
-  },
-  [ChainId.FANTOM_TESTNET]: {
-    chainId: ChainId.FANTOM_TESTNET,
-    name: 'fantom-testnet',
-    title: 'Fantom Testnet',
-    testnet: true,
-    blockExplorer: {
-      name: 'FTMScan (Testnet)',
-      rootUrl: 'https://testnet.ftmscan.com/'
-    }
-  },
-  [ChainId.GNOSIS]: {
-    chainId: ChainId.GNOSIS,
-    name: 'gnosis',
-    title: 'Gnosis Chain',
-    blockExplorer: {
-      name: 'Gnosis Chain Explorer',
-      rootUrl: 'https://blockscout.com/xdai/mainnet/'
-    }
-  },
-  [ChainId.AURORA]: {
-    chainId: ChainId.AURORA,
-    name: 'aurora',
-    title: 'Aurora',
-    blockExplorer: {
-      name: 'Aurora Explorer',
-      rootUrl: 'https://aurorascan.dev/'
-    }
-  },
-  [ChainId.AURORA_TESTNET]: {
-    chainId: ChainId.AURORA_TESTNET,
-    name: 'aurora-testnet',
-    title: 'Aurora Testnet',
-    blockExplorer: {
-      name: 'Aurora Explorer (Testnet)',
-      rootUrl: 'https://testnet.aurorascan.dev/'
-    }
-  },
-  [ChainId.BASE_GOERLI]: {
-    chainId: ChainId.BASE_GOERLI,
-    name: 'base-goerli',
-    title: 'Base Goerli',
-    blockExplorer: {
-      name: 'Base Goerli Explorer',
-      rootUrl: 'https://goerli.basescan.org/'
-    }
-  },
-  [ChainId.HARDHAT]: {
-    chainId: ChainId.HARDHAT,
-    name: 'hardhat',
-    title: 'Hardhat (local testnet)'
-  },
-  [ChainId.HARDHAT_2]: {
-    chainId: ChainId.HARDHAT_2,
-    name: 'hardhat2',
-    title: 'Hardhat (local testnet)'
-  },
-  [ChainId.HOMEVERSE_TESTNET]: {
-    chainId: ChainId.HOMEVERSE_TESTNET,
-    name: 'homeverse-testnet',
-    title: 'Oasys Homeverse Testnet',
-    blockExplorer: {
-      name: 'Oasys Homeverse Explorer (Testnet)',
-      rootUrl: 'https://explorer.testnet.oasys.homeverse.games/'
-    }
-  }
-}
+export const indexerURL = (network: string) => stringTemplate('https://${network}-indexer.sequence.app', { network })
+export const relayerURL = (network: string) => stringTemplate('https://${network}-relayer.sequence.app', { network })
+export const nodesURL = (network: string) => stringTemplate('https://nodes.sequence.app/${network}', { network })
 
 export function findSupportedNetwork(chainIdOrName: string | ChainIdLike): NetworkConfig | undefined {
   return findNetworkConfig(allNetworks, chainIdOrName)
@@ -322,12 +67,14 @@ const genUrls = (network: string) => {
 
 export const allNetworks = validateAndSortNetworks([
   {
+    ...networks[ChainId.POLYGON],
+    ...genUrls('polygon'),
+    isDefaultChain: true,
+    isAuthChain: true
+  } as LegacyNetworkConfig,
+  {
     ...networks[ChainId.MAINNET],
     ...genUrls('mainnet')
-  },
-  {
-    ...networks[ChainId.POLYGON],
-    ...genUrls('polygon')
   },
   {
     ...networks[ChainId.BSC],

--- a/packages/network/src/constants.ts
+++ b/packages/network/src/constants.ts
@@ -1,0 +1,53 @@
+export enum ChainId {
+  // Ethereum
+  MAINNET = 1,
+  ROPSTEN = 3,
+  RINKEBY = 4,
+  GOERLI = 5,
+  KOVAN = 42,
+
+  // Polygon
+  POLYGON = 137,
+  POLYGON_MUMBAI = 80001,
+  POLYGON_ZKEVM = 1101,
+
+  // BSC
+  BSC = 56,
+  BSC_TESTNET = 97,
+
+  // Optimism
+  OPTIMISM = 10,
+  OPTIMISM_TESTNET = 69,
+
+  // Arbitrum One
+  ARBITRUM = 42161,
+  ARBITRUM_GOERLI = 421613,
+
+  // Arbitrum Nova
+  ARBITRUM_NOVA = 42170,
+
+  // Avalanche
+  AVALANCHE = 43114,
+  AVALANCHE_TESTNET = 43113,
+
+  // Fantom
+  FANTOM = 250,
+  FANTOM_TESTNET = 4002,
+
+  // Gnosis Chain (XDAI)
+  GNOSIS = 100,
+
+  // AURORA
+  AURORA = 1313161554,
+  AURORA_TESTNET = 1313161556,
+
+  // BASE
+  BASE_GOERLI = 84531,
+
+  // HARDHAT TESTNETS
+  HARDHAT = 31337,
+  HARDHAT_2 = 31338,
+
+  // HOMEVERSE
+  HOMEVERSE_TESTNET = 40875
+}

--- a/packages/network/src/constants.ts
+++ b/packages/network/src/constants.ts
@@ -44,10 +44,296 @@ export enum ChainId {
   // BASE
   BASE_GOERLI = 84531,
 
+  // HOMEVERSE
+  HOMEVERSE_TESTNET = 40875,
+
   // HARDHAT TESTNETS
   HARDHAT = 31337,
-  HARDHAT_2 = 31338,
+  HARDHAT_2 = 31338
+}
 
-  // HOMEVERSE
-  HOMEVERSE_TESTNET = 40875
+export enum NetworkType {
+  MAINNET = 'mainnet',
+  TESTNET = 'testnet'
+}
+
+export interface NetworkMetadata {
+  chainId: ChainId
+  type?: NetworkType
+  name: string
+  title?: string
+  blockExplorer?: {
+    name: string
+    rootUrl: string
+  }
+  ensAddress?: string
+  testnet?: boolean // Deprecated
+}
+
+export const networks: Record<ChainId, NetworkMetadata> = {
+  [ChainId.MAINNET]: {
+    chainId: ChainId.MAINNET,
+    type: NetworkType.MAINNET,
+    name: 'mainnet',
+    title: 'Ethereum',
+    blockExplorer: {
+      name: 'Etherscan',
+      rootUrl: 'https://etherscan.io/'
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
+  },
+  [ChainId.ROPSTEN]: {
+    chainId: ChainId.ROPSTEN,
+    type: NetworkType.TESTNET,
+    name: 'ropsten',
+    title: 'Ropsten',
+    testnet: true,
+    blockExplorer: {
+      name: 'Etherscan (Ropsten)',
+      rootUrl: 'https://ropsten.etherscan.io/'
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
+  },
+  [ChainId.RINKEBY]: {
+    chainId: ChainId.RINKEBY,
+    type: NetworkType.TESTNET,
+    name: 'rinkeby',
+    title: 'Rinkeby',
+    testnet: true,
+    blockExplorer: {
+      name: 'Etherscan (Rinkeby)',
+      rootUrl: 'https://rinkeby.etherscan.io/'
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
+  },
+  [ChainId.GOERLI]: {
+    chainId: ChainId.GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'goerli',
+    title: 'Goerli',
+    testnet: true,
+    blockExplorer: {
+      name: 'Etherscan (Goerli)',
+      rootUrl: 'https://goerli.etherscan.io/'
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
+  },
+  [ChainId.KOVAN]: {
+    chainId: ChainId.KOVAN,
+    type: NetworkType.TESTNET,
+    name: 'kovan',
+    title: 'Kovan',
+    testnet: true,
+    blockExplorer: {
+      name: 'Etherscan (Kovan)',
+      rootUrl: 'https://kovan.etherscan.io/'
+    }
+  },
+  [ChainId.POLYGON]: {
+    chainId: ChainId.POLYGON,
+    type: NetworkType.MAINNET,
+    name: 'polygon',
+    title: 'Polygon',
+    blockExplorer: {
+      name: 'Polygonscan',
+      rootUrl: 'https://polygonscan.com/'
+    }
+  },
+  [ChainId.POLYGON_MUMBAI]: {
+    chainId: ChainId.POLYGON_MUMBAI,
+    type: NetworkType.TESTNET,
+    name: 'mumbai',
+    title: 'Polygon Mumbai',
+    testnet: true,
+    blockExplorer: {
+      name: 'Polygonscan (Mumbai)',
+      rootUrl: 'https://mumbai.polygonscan.com/'
+    }
+  },
+  [ChainId.POLYGON_ZKEVM]: {
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: NetworkType.MAINNET,
+    name: 'polygon-zkevm',
+    title: 'Polygon zkEVM',
+    blockExplorer: {
+      name: 'Polygonscan (zkEVM)',
+      rootUrl: 'https://zkevm.polygonscan.com/'
+    }
+  },
+  [ChainId.BSC]: {
+    chainId: ChainId.BSC,
+    type: NetworkType.MAINNET,
+    name: 'bsc',
+    title: 'BNB Smart Chain',
+    blockExplorer: {
+      name: 'BSCScan',
+      rootUrl: 'https://bscscan.com/'
+    }
+  },
+  [ChainId.BSC_TESTNET]: {
+    chainId: ChainId.BSC_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'bsc-testnet',
+    title: 'BNB Smart Chain Testnet',
+    testnet: true,
+    blockExplorer: {
+      name: 'BSCScan (Testnet)',
+      rootUrl: 'https://testnet.bscscan.com/'
+    }
+  },
+  [ChainId.OPTIMISM]: {
+    chainId: ChainId.OPTIMISM,
+    type: NetworkType.MAINNET,
+    name: 'optimism',
+    title: 'Optimism',
+    blockExplorer: {
+      name: 'Etherscan (Optimism)',
+      rootUrl: 'https://optimistic.etherscan.io/'
+    }
+  },
+  [ChainId.OPTIMISM_TESTNET]: {
+    chainId: ChainId.OPTIMISM_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'optimism-testnet',
+    title: 'Optimistic Kovan',
+    testnet: true,
+    blockExplorer: {
+      name: 'Etherscan (Optimism Testnet)',
+      rootUrl: 'https://kovan-optimistic.etherscan.io/'
+    }
+  },
+  [ChainId.ARBITRUM]: {
+    chainId: ChainId.ARBITRUM,
+    type: NetworkType.MAINNET,
+    name: 'arbitrum',
+    title: 'Arbitrum One',
+    blockExplorer: {
+      name: 'Arbiscan',
+      rootUrl: 'https://arbiscan.io/'
+    }
+  },
+  [ChainId.ARBITRUM_GOERLI]: {
+    chainId: ChainId.ARBITRUM_GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'arbitrum-goerli',
+    title: 'Arbitrum Goerli',
+    testnet: true,
+    blockExplorer: {
+      name: 'Arbiscan (Testnet)',
+      rootUrl: 'https://testnet.arbiscan.io/'
+    }
+  },
+  [ChainId.ARBITRUM_NOVA]: {
+    chainId: ChainId.ARBITRUM_NOVA,
+    type: NetworkType.MAINNET,
+    name: 'arbitrum-nova',
+    title: 'Arbitrum Nova',
+    blockExplorer: {
+      name: 'Nova Explorer',
+      rootUrl: 'https://nova-explorer.arbitrum.io/'
+    }
+  },
+  [ChainId.AVALANCHE]: {
+    chainId: ChainId.AVALANCHE,
+    type: NetworkType.MAINNET,
+    name: 'avalanche',
+    title: 'Avalanche',
+    blockExplorer: {
+      name: 'Snowtrace',
+      rootUrl: 'https://snowtrace.io/'
+    }
+  },
+  [ChainId.AVALANCHE_TESTNET]: {
+    chainId: ChainId.AVALANCHE_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'avalanche-testnet',
+    title: 'Avalanche Testnet',
+    testnet: true,
+    blockExplorer: {
+      name: 'Snowtrace (Testnet)',
+      rootUrl: 'https://testnet.snowtrace.io/'
+    }
+  },
+  [ChainId.FANTOM]: {
+    chainId: ChainId.FANTOM,
+    type: NetworkType.MAINNET,
+    name: 'fantom',
+    title: 'Fantom',
+    blockExplorer: {
+      name: 'FTMScan',
+      rootUrl: 'https://ftmscan.com/'
+    }
+  },
+  [ChainId.FANTOM_TESTNET]: {
+    chainId: ChainId.FANTOM_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'fantom-testnet',
+    title: 'Fantom Testnet',
+    testnet: true,
+    blockExplorer: {
+      name: 'FTMScan (Testnet)',
+      rootUrl: 'https://testnet.ftmscan.com/'
+    }
+  },
+  [ChainId.GNOSIS]: {
+    chainId: ChainId.GNOSIS,
+    type: NetworkType.MAINNET,
+    name: 'gnosis',
+    title: 'Gnosis Chain',
+    blockExplorer: {
+      name: 'Gnosis Chain Explorer',
+      rootUrl: 'https://blockscout.com/xdai/mainnet/'
+    }
+  },
+  [ChainId.AURORA]: {
+    chainId: ChainId.AURORA,
+    type: NetworkType.MAINNET,
+    name: 'aurora',
+    title: 'Aurora',
+    blockExplorer: {
+      name: 'Aurora Explorer',
+      rootUrl: 'https://aurorascan.dev/'
+    }
+  },
+  [ChainId.AURORA_TESTNET]: {
+    chainId: ChainId.AURORA_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'aurora-testnet',
+    title: 'Aurora Testnet',
+    blockExplorer: {
+      name: 'Aurora Explorer (Testnet)',
+      rootUrl: 'https://testnet.aurorascan.dev/'
+    }
+  },
+  [ChainId.BASE_GOERLI]: {
+    chainId: ChainId.BASE_GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'base-goerli',
+    title: 'Base Goerli',
+    blockExplorer: {
+      name: 'Base Goerli Explorer',
+      rootUrl: 'https://goerli.basescan.org/'
+    }
+  },
+  [ChainId.HOMEVERSE_TESTNET]: {
+    chainId: ChainId.HOMEVERSE_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'homeverse-testnet',
+    title: 'Oasys Homeverse Testnet',
+    blockExplorer: {
+      name: 'Oasys Homeverse Explorer (Testnet)',
+      rootUrl: 'https://explorer.testnet.oasys.homeverse.games/'
+    }
+  },
+
+  [ChainId.HARDHAT]: {
+    chainId: ChainId.HARDHAT,
+    name: 'hardhat',
+    title: 'Hardhat (local testnet)'
+  },
+  [ChainId.HARDHAT_2]: {
+    chainId: ChainId.HARDHAT_2,
+    name: 'hardhat2',
+    title: 'Hardhat (local testnet)'
+  }
 }

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,3 +1,4 @@
+export * from './constants'
 export * from './config'
 export * from './json-rpc'
 export * from './json-rpc-provider'

--- a/packages/network/src/json-rpc-provider.ts
+++ b/packages/network/src/json-rpc-provider.ts
@@ -9,8 +9,7 @@ import {
   JsonRpcMiddleware,
   JsonRpcMiddlewareHandler
 } from './json-rpc'
-import { networks } from './config'
-import { ChainId } from './constants'
+import { ChainId, networks } from './constants'
 
 export interface JsonRpcProviderOptions {
   // ..

--- a/packages/network/src/json-rpc-provider.ts
+++ b/packages/network/src/json-rpc-provider.ts
@@ -9,7 +9,8 @@ import {
   JsonRpcMiddleware,
   JsonRpcMiddlewareHandler
 } from './json-rpc'
-import { networks, ChainId } from './config'
+import { networks } from './config'
+import { ChainId } from './constants'
 
 export interface JsonRpcProviderOptions {
   // ..

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^2.26.1
         version: 2.26.1
       '@preconstruct/cli':
-        specifier: ^2.2.2
-        version: 2.2.2
+        specifier: ^2.8.1
+        version: 2.8.1
       '@types/chai':
         specifier: ^4.2.22
         version: 4.3.4
@@ -227,10 +227,10 @@ importers:
         version: 1.10.0
       '@babel/plugin-transform-runtime':
         specifier: ^7.19.6
-        version: 7.19.6(@babel/core@7.21.4)
+        version: 7.19.6(@babel/core@7.22.9)
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.0(@babel/core@7.21.4)(webpack@5.75.0)
+        version: 9.1.0(@babel/core@7.22.9)(webpack@5.75.0)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -388,13 +388,13 @@ importers:
         version: 5.7.2
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.1
-        version: 2.2.1(ethers@5.7.2)(hardhat@2.14.0)
+        version: 2.2.1(ethers@5.7.2)(hardhat@2.17.0)
       '@nomiclabs/hardhat-web3':
         specifier: ^2.0.0
-        version: 2.0.0(hardhat@2.14.0)(web3@1.9.0)
+        version: 2.0.0(hardhat@2.17.0)(web3@1.10.0)
       '@typechain/ethers-v5':
         specifier: ^10.1.1
-        version: 10.2.0(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.1.1)(typescript@4.9.4)
+        version: 10.2.0(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.1.1)(typescript@5.1.6)
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
@@ -403,7 +403,7 @@ importers:
         version: 5.7.2
       typechain:
         specifier: ^8.1.1
-        version: 8.1.1(typescript@4.9.4)
+        version: 8.1.1(typescript@5.1.6)
 
   packages/estimator:
     dependencies:
@@ -512,7 +512,7 @@ importers:
         version: 1.8.1
       web3-provider-engine:
         specifier: ^16.0.4
-        version: 16.0.4(@babel/core@7.21.4)
+        version: 16.0.4(@babel/core@7.22.9)
 
   packages/network:
     dependencies:
@@ -776,13 +776,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
-  /@babel/code-frame@7.18.6:
-    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.18.6
-    dev: true
-
   /@babel/code-frame@7.21.4:
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
     engines: {node: '>=6.9.0'}
@@ -790,8 +783,20 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.5
+    dev: true
+
   /@babel/compat-data@7.21.4:
     resolution: {integrity: sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/compat-data@7.22.9:
+    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -818,11 +823,44 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core@7.22.9:
+    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4(supports-color@6.1.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator@7.21.4:
     resolution: {integrity: sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.22.9:
+    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
@@ -857,6 +895,34 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /@babel/helper-compilation-targets@7.21.4(@babel/core@7.22.9):
+    resolution: {integrity: sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.21.4
+      '@babel/core': 7.22.9
+      '@babel/helper-validator-option': 7.21.0
+      browserslist: 4.21.5
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.22.9
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.9
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: true
+
   /@babel/helper-create-class-features-plugin@7.20.5(@babel/core@7.21.4):
     resolution: {integrity: sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==}
     engines: {node: '>=6.9.0'}
@@ -883,13 +949,13 @@ packages:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-replace-supers': 7.20.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -921,8 +987,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.22.9):
+    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
+    peerDependencies:
+      '@babel/core': ^7.4.0-0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.22.9)
+      '@babel/helper-plugin-utils': 7.22.5
+      debug: 4.3.4(supports-color@6.1.0)
+      lodash.debounce: 4.0.8
+      resolve: 1.22.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-environment-visitor@7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-environment-visitor@7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -949,11 +1036,26 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-function-name@7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
+    dev: true
+
+  /@babel/helper-hoist-variables@7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.18.9:
@@ -967,7 +1069,7 @@ packages:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-module-imports@7.18.6:
@@ -982,6 +1084,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
+    dev: true
+
+  /@babel/helper-module-imports@7.22.5:
+    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-module-transforms@7.21.2:
@@ -1000,6 +1109,34 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.21.4):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.4
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: true
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: true
+
   /@babel/helper-optimise-call-expression@7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
@@ -1009,6 +1146,11 @@ packages:
 
   /@babel/helper-plugin-utils@7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-plugin-utils@7.22.5:
+    resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -1061,6 +1203,13 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
@@ -1075,8 +1224,20 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.5
+    dev: true
+
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -1085,8 +1246,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-option@7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option@7.22.5:
+    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -1113,11 +1284,31 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers@7.22.6:
+    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight@7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
@@ -1128,6 +1319,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.4
+    dev: true
+
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.4):
@@ -1667,20 +1866,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.21.4):
     resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
     engines: {node: '>=6.9.0'}
@@ -1693,6 +1878,18 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.21.4):
+    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.4
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.21.4)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.21.4):
@@ -1798,18 +1995,18 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-runtime@7.19.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-runtime@7.19.6(@babel/core@7.22.9):
     resolution: {integrity: sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.22.9
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.4)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.4)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.4)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.22.9)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.22.9)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.22.9)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -2028,6 +2225,13 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
+  /@babel/runtime@7.22.6:
+    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
+    dev: true
+
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
@@ -2035,6 +2239,15 @@ packages:
       '@babel/code-frame': 7.21.4
       '@babel/parser': 7.21.4
       '@babel/types': 7.21.4
+    dev: true
+
+  /@babel/template@7.22.5:
+    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/traverse@7.21.4:
@@ -2055,12 +2268,39 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse@7.22.8:
+    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+      debug: 4.3.4(supports-color@6.1.0)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.21.4:
     resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types@7.22.5:
+    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
     dev: true
 
@@ -2869,13 +3109,18 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/source-map@0.3.2:
-    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
@@ -2906,8 +3151,8 @@ packages:
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@manypkg/find-root@1.1.0:
@@ -3110,7 +3355,7 @@ packages:
       '@nomicfoundation/ethereumjs-rlp': 5.0.1
       '@nomicfoundation/ethereumjs-util': 9.0.1
       abstract-level: 1.0.3
-      bigint-crypto-utils: 3.2.2
+      bigint-crypto-utils: 3.3.0
       ethereum-cryptography: 0.1.3
     transitivePeerDependencies:
       - bufferutil
@@ -3184,7 +3429,7 @@ packages:
       debug: 4.3.4(supports-color@6.1.0)
       ethereum-cryptography: 0.1.3
       ethers: 5.7.2
-      js-sdsl: 4.4.0
+      js-sdsl: 4.4.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3513,25 +3758,25 @@ packages:
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
     dev: true
 
-  /@nomiclabs/hardhat-ethers@2.2.1(ethers@5.7.2)(hardhat@2.14.0):
+  /@nomiclabs/hardhat-ethers@2.2.1(ethers@5.7.2)(hardhat@2.17.0):
     resolution: {integrity: sha512-RHWYwnxryWR8hzRmU4Jm/q4gzvXpetUOJ4OPlwH2YARcDB+j79+yAYCwO0lN1SUOb4++oOTJEe6AWLEc42LIvg==}
     peerDependencies:
       ethers: ^5.0.0
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.14.0(ts-node@10.9.1)(typescript@4.9.4)
+      hardhat: 2.17.0(ts-node@10.9.1)(typescript@5.1.6)
     dev: true
 
-  /@nomiclabs/hardhat-web3@2.0.0(hardhat@2.14.0)(web3@1.9.0):
+  /@nomiclabs/hardhat-web3@2.0.0(hardhat@2.17.0)(web3@1.10.0):
     resolution: {integrity: sha512-zt4xN+D+fKl3wW2YlTX3k9APR3XZgPkxJYf36AcliJn3oujnKEVRZaHu0PhgLjO+gR+F/kiYayo9fgd2L8970Q==}
     peerDependencies:
       hardhat: ^2.0.0
       web3: ^1.0.0-beta.36
     dependencies:
       '@types/bignumber.js': 5.0.0
-      hardhat: 2.14.0(ts-node@10.9.1)(typescript@4.9.4)
-      web3: 1.9.0
+      hardhat: 2.17.0(ts-node@10.9.1)(typescript@5.1.6)
+      web3: 1.10.0
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -3541,12 +3786,13 @@ packages:
     dev: true
     optional: true
 
-  /@preconstruct/cli@2.2.2:
-    resolution: {integrity: sha512-7Zk8g/G+SPusoL1Ir3oslj19QDoFuAKeQO8B6fnNkRRgvIntxnylGZyC4wdKVX/eeDHwca1LNLT/GyjXx1f1nA==}
+  /@preconstruct/cli@2.8.1:
+    resolution: {integrity: sha512-PX5w+au06iY/QaT+9RLmRlIfavRCRoMTC/krwtNrgPEnubR9e6P+QlywrKmwiEvkzbR9AEzGnRZL8uNRDDMzrQ==}
+    hasBin: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       '@babel/core': 7.21.4
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.22.5
       '@babel/runtime': 7.21.0
       '@preconstruct/hook': 0.4.0
       '@rollup/plugin-alias': 3.1.9(rollup@2.79.1)
@@ -3556,17 +3802,17 @@ packages:
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
       builtin-modules: 3.3.0
       chalk: 4.1.2
-      dataloader: 2.1.0
+      dataloader: 2.2.2
       detect-indent: 6.1.0
       enquirer: 2.3.6
       estree-walker: 2.0.2
       fast-deep-equal: 2.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.0
       fs-extra: 9.1.0
       is-ci: 2.0.0
       is-reference: 1.2.1
       jest-worker: 26.6.2
-      magic-string: 0.25.9
+      magic-string: 0.30.1
       meow: 7.1.1
       ms: 2.1.3
       normalize-path: 3.0.0
@@ -3575,12 +3821,13 @@ packages:
       parse-glob: 3.0.4
       parse-json: 5.2.0
       quick-lru: 5.1.1
-      resolve: 1.22.1
+      resolve: 1.22.2
       resolve-from: 5.0.0
       rollup: 2.79.1
-      semver: 7.3.8
-      terser: 5.16.1
+      semver: 7.5.4
+      terser: 5.19.1
       v8-compile-cache: 2.3.0
+      zod: 3.21.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3589,8 +3836,8 @@ packages:
     resolution: {integrity: sha512-a7mrlPTM3tAFJyz43qb4pPVpUx8j8TzZBFsNFqcKcE/sEakNXRlQAuCT4RGZRf9dQiiUnBahzSIWawU4rENl+Q==}
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.21.4)
-      pirates: 4.0.5
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.21.4)
+      pirates: 4.0.6
       source-map-support: 0.5.21
     transitivePeerDependencies:
       - supports-color
@@ -3618,7 +3865,7 @@ packages:
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
-      resolve: 1.22.1
+      resolve: 1.22.2
       rollup: 2.79.1
     dev: true
 
@@ -3640,9 +3887,9 @@ packages:
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
-      deepmerge: 4.2.2
+      deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.1
+      resolve: 1.22.2
       rollup: 2.79.1
     dev: true
 
@@ -3834,7 +4081,7 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
-  /@typechain/ethers-v5@10.2.0(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.1.1)(typescript@4.9.4):
+  /@typechain/ethers-v5@10.2.0(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.1.1)(typescript@5.1.6):
     resolution: {integrity: sha512-ikaq0N/w9fABM+G01OFmU3U3dNnyRwEahkdvi9mqy1a3XwKiPZaF/lu54OcNaEWnpvEYyhhS0N7buCtLQqC92w==}
     peerDependencies:
       '@ethersproject/abi': ^5.0.0
@@ -3849,9 +4096,9 @@ packages:
       '@ethersproject/providers': 5.7.2
       ethers: 5.7.2
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@4.9.4)
-      typechain: 8.1.1(typescript@4.9.4)
-      typescript: 4.9.4
+      ts-essentials: 7.0.3(typescript@5.1.6)
+      typechain: 8.1.1(typescript@5.1.6)
+      typescript: 5.1.6
     dev: true
 
   /@types/async-eventemitter@0.2.1:
@@ -3867,7 +4114,7 @@ packages:
   /@types/bn.js@4.11.6:
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
     dependencies:
-      '@types/node': 18.16.1
+      '@types/node': 20.4.2
     dev: true
 
   /@types/bn.js@5.1.1:
@@ -3929,8 +4176,8 @@ packages:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
     dev: true
 
-  /@types/estree@1.0.0:
-    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
   /@types/ethereum-protocol@1.0.2:
@@ -3943,7 +4190,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.16.1
+      '@types/node': 20.4.2
     dev: true
 
   /@types/html-minifier-terser@6.1.0:
@@ -4006,6 +4253,10 @@ packages:
     resolution: {integrity: sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==}
     dev: true
 
+  /@types/node@20.4.2:
+    resolution: {integrity: sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==}
+    dev: true
+
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
@@ -4013,7 +4264,7 @@ packages:
   /@types/pbkdf2@3.1.0:
     resolution: {integrity: sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==}
     dependencies:
-      '@types/node': 18.16.1
+      '@types/node': 20.4.2
     dev: true
 
   /@types/prettier@2.7.2:
@@ -4023,7 +4274,7 @@ packages:
   /@types/readable-stream@2.3.15:
     resolution: {integrity: sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==}
     dependencies:
-      '@types/node': 18.16.1
+      '@types/node': 20.4.2
       safe-buffer: 5.1.2
     dev: true
 
@@ -4042,7 +4293,7 @@ packages:
   /@types/secp256k1@4.0.3:
     resolution: {integrity: sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==}
     dependencies:
-      '@types/node': 18.16.1
+      '@types/node': 20.4.2
     dev: true
 
   /@types/seedrandom@3.0.1:
@@ -4432,6 +4683,12 @@ packages:
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
     dev: true
 
   /acorn@8.8.1:
@@ -4920,14 +5177,14 @@ packages:
       - debug
     dev: true
 
-  /babel-loader@9.1.0(@babel/core@7.21.4)(webpack@5.75.0):
+  /babel-loader@9.1.0(@babel/core@7.22.9)(webpack@5.75.0):
     resolution: {integrity: sha512-Antt61KJPinUMwHwIIz9T5zfMgevnfZkEVWYDWlG888fgdvRRGD0JTuf/fFozQnfT+uq64sk1bmdHDy/mOEWnA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
       webpack: '>=5'
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.22.9
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
       webpack: 5.75.0(webpack-cli@4.10.0)
@@ -4946,6 +5203,19 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.22.9):
+    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.21.4
+      '@babel/core': 7.22.9
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.22.9)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.4):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
@@ -4958,6 +5228,18 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.22.9):
+    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.22.9)
+      core-js-compat: 3.30.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.4):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
@@ -4965,6 +5247,17 @@ packages:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.22.9):
+    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.22.9)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5044,8 +5337,8 @@ packages:
       bigint-mod-arith: 3.1.2
     dev: true
 
-  /bigint-crypto-utils@3.2.2:
-    resolution: {integrity: sha512-U1RbE3aX9ayCUVcIPHuPDPKcK3SFOXf93J1UK/iHlJuQB7bhagPIX06/CLpLEsDThJ7KA4Dhrnzynl+d2weTiw==}
+  /bigint-crypto-utils@3.3.0:
+    resolution: {integrity: sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -5293,6 +5586,17 @@ packages:
       update-browserslist-db: 1.0.11(browserslist@4.21.5)
     dev: true
 
+  /browserslist@4.21.9:
+    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001517
+      electron-to-chromium: 1.4.465
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.9)
+    dev: true
+
   /bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
@@ -5477,6 +5781,10 @@ packages:
 
   /caniuse-lite@1.0.30001481:
     resolution: {integrity: sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==}
+    dev: true
+
+  /caniuse-lite@1.0.30001517:
+    resolution: {integrity: sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==}
     dev: true
 
   /case@1.6.3:
@@ -6079,6 +6387,14 @@ packages:
       - encoding
     dev: true
 
+  /cross-fetch@3.1.8:
+    resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
     dependencies:
@@ -6093,7 +6409,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.1
+      semver: 5.7.2
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
@@ -6195,8 +6511,8 @@ packages:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
 
-  /dataloader@2.1.0:
-    resolution: {integrity: sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==}
+  /dataloader@2.2.2:
+    resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
     dev: true
 
   /date-fns@2.29.3:
@@ -6325,8 +6641,8 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
 
-  /deepmerge@4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+  /deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -6625,6 +6941,10 @@ packages:
 
   /electron-to-chromium@1.4.375:
     resolution: {integrity: sha512-czSmDyWG5qmb4TcwD5lhVDP6viDPtHfrIzw0CnzisRpziiUaq+ffptBHs70d9YkFtrxzaDvOmFPeVRVNwMt2rQ==}
+    dev: true
+
+  /electron-to-chromium@1.4.465:
+    resolution: {integrity: sha512-XQcuHvEJRMU97UJ75e170mgcITZoz0lIyiaVjk6R+NMTJ8KBIvUHYd1779swgOppUlzxR+JsLpq59PumaXS1jQ==}
     dev: true
 
   /elliptic@6.5.4:
@@ -7288,11 +7608,11 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /eth-block-tracker@4.4.3(@babel/core@7.21.4):
+  /eth-block-tracker@4.4.3(@babel/core@7.22.9):
     resolution: {integrity: sha512-A8tG4Z4iNg4mw5tP1Vung9N9IjgMNqpiMoJ/FouSFwNCGHv2X0mmOYwtQOJzki6XN7r7Tyo01S29p7b224I4jw==}
     dependencies:
-      '@babel/plugin-transform-runtime': 7.19.6(@babel/core@7.21.4)
-      '@babel/runtime': 7.21.0
+      '@babel/plugin-transform-runtime': 7.19.6(@babel/core@7.22.9)
+      '@babel/runtime': 7.22.6
       eth-query: 2.1.2
       json-rpc-random-id: 1.0.1
       pify: 3.0.0
@@ -7862,6 +8182,17 @@ packages:
       micromatch: 4.0.5
     dev: true
 
+  /fast-glob@3.3.0:
+    resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
@@ -8165,7 +8496,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -8635,9 +8966,9 @@ packages:
       - utf-8-validate
     dev: true
 
-  /hardhat@2.14.0(ts-node@10.9.1)(typescript@4.9.4):
-    resolution: {integrity: sha512-73jsInY4zZahMSVFurSK+5TNCJTXMv+vemvGia0Ac34Mm19fYp6vEPVGF3sucbumszsYxiTT2TbS8Ii2dsDSoQ==}
-    engines: {node: '>=14.0.0'}
+  /hardhat@2.17.0(ts-node@10.9.1)(typescript@5.1.6):
+    resolution: {integrity: sha512-CaEGa13tkJNe2/rdaBiive4pmdNShwxvdWVhr1zfb6aVpRhQt9VNO0l/UIBt/zzajz38ZFjvhfM2bj8LDXo9gw==}
+    engines: {node: '>=16.0.0'}
     hasBin: true
     peerDependencies:
       ts-node: '*'
@@ -8680,24 +9011,23 @@ packages:
       fp-ts: 1.19.3
       fs-extra: 7.0.1
       glob: 7.2.0
-      immutable: 4.3.0
+      immutable: 4.3.1
       io-ts: 1.10.4
       keccak: 3.0.3
       lodash: 4.17.21
       mnemonist: 0.38.5
       mocha: 10.2.0
       p-map: 4.0.0
-      qs: 6.11.1
       raw-body: 2.5.2
       resolve: 1.17.0
-      semver: 6.3.0
+      semver: 6.3.1
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       ts-node: 10.9.1(@types/node@18.16.1)(typescript@4.9.4)
       tsort: 0.0.1
-      typescript: 4.9.4
-      undici: 5.22.0
+      typescript: 5.1.6
+      undici: 5.22.1
       uuid: 8.3.2
       ws: 7.5.9
     transitivePeerDependencies:
@@ -9058,8 +9388,8 @@ packages:
     resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
     dev: true
 
-  /immutable@4.3.0:
-    resolution: {integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==}
+  /immutable@4.3.1:
+    resolution: {integrity: sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A==}
     dev: true
 
   /import-fresh@3.3.0:
@@ -9258,6 +9588,7 @@ packages:
 
   /is-ci@2.0.0:
     resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
+    hasBin: true
     dependencies:
       ci-info: 2.0.0
     dev: true
@@ -9269,14 +9600,14 @@ packages:
       ci-info: 3.8.0
     dev: true
 
-  /is-core-module@2.11.0:
-    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
+  /is-core-module@2.12.0:
+    resolution: {integrity: sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==}
     dependencies:
       has: 1.0.3
     dev: true
 
-  /is-core-module@2.12.0:
-    resolution: {integrity: sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==}
+  /is-core-module@2.12.1:
+    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -9500,7 +9831,7 @@ packages:
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.1
     dev: true
 
   /is-regex@1.1.4:
@@ -9714,7 +10045,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.16.1
+      '@types/node': 20.4.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -9734,6 +10065,10 @@ packages:
 
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
+    dev: true
+
+  /js-sdsl@4.4.1:
+    resolution: {integrity: sha512-6Gsx8R0RucyePbWqPssR8DyfuXmLBooYN5cZFZKjHGnQuaf7pEzhtpceagJxVu4LqhYY5EYA7nko3FmeHZ1KbA==}
     dev: true
 
   /js-sha3@0.5.7:
@@ -10199,8 +10534,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /lru-cache@9.1.1:
-    resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
+  /lru-cache@9.1.2:
+    resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
     dev: true
 
@@ -10216,6 +10551,13 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string@0.30.1:
+    resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /make-dir@3.1.0:
@@ -10816,6 +11158,18 @@ packages:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
     dev: true
 
+  /node-fetch@2.6.12:
+    resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
   /node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -10857,6 +11211,10 @@ packages:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
     dev: true
 
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: true
+
   /node-releases@2.0.8:
     resolution: {integrity: sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==}
     dev: true
@@ -10866,7 +11224,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.2
-      semver: 5.7.1
+      semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -10900,6 +11258,7 @@ packages:
   /npm-packlist@2.2.2:
     resolution: {integrity: sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==}
     engines: {node: '>=10'}
+    hasBin: true
     dependencies:
       glob: 7.2.3
       ignore-walk: 3.0.4
@@ -11305,7 +11664,7 @@ packages:
       got: 12.1.0
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /param-case@3.0.4:
@@ -11358,7 +11717,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -11427,7 +11786,7 @@ packages:
     resolution: {integrity: sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 9.1.1
+      lru-cache: 9.1.2
       minipass: 5.0.0
     dev: true
 
@@ -11504,8 +11863,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /pirates@4.0.5:
-    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
+  /pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
     dev: true
 
@@ -11757,13 +12116,6 @@ packages:
 
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
-    engines: {node: '>=0.6'}
-    dependencies:
-      side-channel: 1.0.4
-    dev: true
-
-  /qs@6.11.1:
-    resolution: {integrity: sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==}
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
@@ -12177,19 +12529,11 @@ packages:
       path-parse: 1.0.7
     dev: true
 
-  /resolve@1.22.1:
-    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
-    dependencies:
-      is-core-module: 2.11.0
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    dev: true
-
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.0
+      is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -12261,6 +12605,7 @@ packages:
   /rollup@2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -12379,7 +12724,7 @@ packages:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /semver@5.4.1:
@@ -12392,20 +12737,31 @@ packages:
     hasBin: true
     dev: true
 
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: true
+
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
     dev: true
 
-  /semver@7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
-    engines: {node: '>=10'}
-    dependencies:
-      lru-cache: 6.0.0
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
     dev: true
 
   /semver@7.5.0:
     resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -12714,7 +13070,7 @@ packages:
       js-sha3: 0.8.0
       memorystream: 0.3.1
       require-from-string: 2.0.2
-      semver: 5.7.1
+      semver: 5.7.2
       tmp: 0.0.33
     transitivePeerDependencies:
       - debug
@@ -12753,6 +13109,7 @@ packages:
 
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
 
   /spawn-command@0.0.2-1:
@@ -13179,7 +13536,7 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
-      terser: 5.16.1
+      terser: 5.19.1
       webpack: 5.75.0(webpack-cli@4.10.0)
     dev: true
 
@@ -13187,8 +13544,19 @@ packages:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
     engines: {node: '>=10'}
     dependencies:
-      '@jridgewell/source-map': 0.3.2
-      acorn: 8.8.1
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: true
+
+  /terser@5.19.1:
+    resolution: {integrity: sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -13320,12 +13688,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@4.9.4):
+  /ts-essentials@7.0.3(typescript@5.1.6):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 4.9.4
+      typescript: 5.1.6
     dev: true
 
   /ts-node@10.9.1(@types/node@18.16.1)(typescript@4.9.4):
@@ -13502,7 +13870,7 @@ packages:
     resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
     dev: true
 
-  /typechain@8.1.1(typescript@4.9.4):
+  /typechain@8.1.1(typescript@5.1.6):
     resolution: {integrity: sha512-uF/sUvnXTOVF2FHKhQYnxHk4su4JjZR8vr4mA2mBaRwHTbwh0jIlqARz9XJr1tA0l7afJGvEa1dTSi4zt039LQ==}
     hasBin: true
     peerDependencies:
@@ -13517,8 +13885,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.3.1
-      ts-essentials: 7.0.3(typescript@4.9.4)
-      typescript: 4.9.4
+      ts-essentials: 7.0.3(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13545,6 +13913,12 @@ packages:
   /typescript@4.9.4:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
+    dev: true
+
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
     dev: true
 
   /typeson-registry@1.0.0-alpha.39:
@@ -13598,8 +13972,8 @@ packages:
       busboy: 1.6.0
     dev: true
 
-  /undici@5.22.0:
-    resolution: {integrity: sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==}
+  /undici@5.22.1:
+    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
@@ -13691,6 +14065,17 @@ packages:
       browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.21.5
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
+  /update-browserslist-db@1.0.11(browserslist@4.21.9):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.9
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: true
@@ -13846,7 +14231,7 @@ packages:
     resolution: {integrity: sha512-0rvxpB8P8Shm4wX2EKOiMp7H2zq+HUE/UwodY0pCZXs9IffIKZq6vUti5OgkVCTakKo9e/fgO4X1fkwfjWxE3Q==}
     engines: {node: '>=6.0'}
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
       acorn-walk: 8.2.0
     dev: true
 
@@ -13883,6 +14268,20 @@ packages:
       defaults: 1.0.4
     dev: true
 
+  /web3-bzz@1.10.0:
+    resolution: {integrity: sha512-o9IR59io3pDUsXTsps5pO5hW1D5zBmg46iNc2t4j2DkaYHNdDLwk2IP9ukoM2wg47QILfPEJYzhTfkS/CcX0KA==}
+    engines: {node: '>=8.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 12.20.55
+      got: 12.1.0
+      swarm-js: 0.1.42
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /web3-bzz@1.8.1:
     resolution: {integrity: sha512-dJJHS84nvpoxv6ijTMkdUSlRr5beCXNtx4UZcrFLHBva8dT63QEtKdLyDt2AyMJJdVzTCk78uir/6XtVWrdS6w==}
     engines: {node: '>=8.0.0'}
@@ -13897,18 +14296,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /web3-bzz@1.9.0:
-    resolution: {integrity: sha512-9Zli9dikX8GdHwBb5/WPzpSVuy3EWMKY3P4EokCQra31fD7DLizqAAaTUsFwnK7xYkw5ogpHgelw9uKHHzNajg==}
+  /web3-core-helpers@1.10.0:
+    resolution: {integrity: sha512-pIxAzFDS5vnbXvfvLSpaA1tfRykAe9adw43YCKsEYQwH0gCLL0kMLkaCX3q+Q8EVmAh+e1jWL/nl9U0de1+++g==}
     engines: {node: '>=8.0.0'}
-    requiresBuild: true
     dependencies:
-      '@types/node': 12.20.55
-      got: 12.1.0
-      swarm-js: 0.1.42
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
+      web3-eth-iban: 1.10.0
+      web3-utils: 1.10.0
     dev: true
 
   /web3-core-helpers@1.8.1:
@@ -13919,12 +14312,15 @@ packages:
       web3-utils: 1.8.1
     dev: true
 
-  /web3-core-helpers@1.9.0:
-    resolution: {integrity: sha512-NeJzylAp9Yj9xAt2uTT+kyug3X0DLnfBdnAcGZuY6HhoNPDIfQRA9CkJjLngVRlGTLZGjNp9x9eR+RyZQgUlXg==}
+  /web3-core-method@1.10.0:
+    resolution: {integrity: sha512-4R700jTLAMKDMhQ+nsVfIXvH6IGJlJzGisIfMKWAIswH31h5AZz7uDUW2YctI+HrYd+5uOAlS4OJeeT9bIpvkA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      web3-eth-iban: 1.9.0
-      web3-utils: 1.9.0
+      '@ethersproject/transactions': 5.7.0
+      web3-core-helpers: 1.10.0
+      web3-core-promievent: 1.10.0
+      web3-core-subscriptions: 1.10.0
+      web3-utils: 1.10.0
     dev: true
 
   /web3-core-method@1.8.1:
@@ -13938,15 +14334,11 @@ packages:
       web3-utils: 1.8.1
     dev: true
 
-  /web3-core-method@1.9.0:
-    resolution: {integrity: sha512-sswbNsY2xRBBhGeaLt9c/eDc+0yDDhi6keUBAkgIRa9ueSx/VKzUY9HMqiV6bXDcGT2fJyejq74FfEB4lc/+/w==}
+  /web3-core-promievent@1.10.0:
+    resolution: {integrity: sha512-68N7k5LWL5R38xRaKFrTFT2pm2jBNFaM4GioS00YjAKXRQ3KjmhijOMG3TICz6Aa5+6GDWYelDNx21YAeZ4YTg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@ethersproject/transactions': 5.7.0
-      web3-core-helpers: 1.9.0
-      web3-core-promievent: 1.9.0
-      web3-core-subscriptions: 1.9.0
-      web3-utils: 1.9.0
+      eventemitter3: 4.0.4
     dev: true
 
   /web3-core-promievent@1.8.1:
@@ -13956,11 +14348,18 @@ packages:
       eventemitter3: 4.0.4
     dev: true
 
-  /web3-core-promievent@1.9.0:
-    resolution: {integrity: sha512-PHG1Mn23IGwMZhnPDN8dETKypqsFbHfiyRqP+XsVMPmTHkVfzDQTCBU/c2r6hUktBDoGKut5xZQpGfhFk71KbQ==}
+  /web3-core-requestmanager@1.10.0:
+    resolution: {integrity: sha512-3z/JKE++Os62APml4dvBM+GAuId4h3L9ckUrj7ebEtS2AR0ixyQPbrBodgL91Sv7j7cQ3Y+hllaluqjguxvSaQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      eventemitter3: 4.0.4
+      util: 0.12.5
+      web3-core-helpers: 1.10.0
+      web3-providers-http: 1.10.0
+      web3-providers-ipc: 1.10.0
+      web3-providers-ws: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: true
 
   /web3-core-requestmanager@1.8.1:
@@ -13977,18 +14376,12 @@ packages:
       - supports-color
     dev: true
 
-  /web3-core-requestmanager@1.9.0:
-    resolution: {integrity: sha512-hcJ5PCtTIJpj+8qWxoseqlCovDo94JJjTX7dZOLXgwp8ah7E3WRYozhGyZocerx+KebKyg1mCQIhkDpMwjfo9Q==}
+  /web3-core-subscriptions@1.10.0:
+    resolution: {integrity: sha512-HGm1PbDqsxejI075gxBc5OSkwymilRWZufIy9zEpnWKNmfbuv5FfHgW1/chtJP6aP3Uq2vHkvTDl3smQBb8l+g==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      util: 0.12.5
-      web3-core-helpers: 1.9.0
-      web3-providers-http: 1.9.0
-      web3-providers-ipc: 1.9.0
-      web3-providers-ws: 1.9.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      eventemitter3: 4.0.4
+      web3-core-helpers: 1.10.0
     dev: true
 
   /web3-core-subscriptions@1.8.1:
@@ -13999,12 +14392,20 @@ packages:
       web3-core-helpers: 1.8.1
     dev: true
 
-  /web3-core-subscriptions@1.9.0:
-    resolution: {integrity: sha512-MaIo29yz7hTV8X8bioclPDbHFOVuHmnbMv+D3PDH12ceJFJAXGyW8GL5KU1DYyWIj4TD1HM4WknyVA/YWBiiLA==}
+  /web3-core@1.10.0:
+    resolution: {integrity: sha512-fWySwqy2hn3TL89w5TM8wXF1Z2Q6frQTKHWmP0ppRQorEK8NcHJRfeMiv/mQlSKoTS1F6n/nv2uyZsixFycjYQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      eventemitter3: 4.0.4
-      web3-core-helpers: 1.9.0
+      '@types/bn.js': 5.1.1
+      '@types/node': 12.20.55
+      bignumber.js: 9.1.1
+      web3-core-helpers: 1.10.0
+      web3-core-method: 1.10.0
+      web3-core-requestmanager: 1.10.0
+      web3-utils: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: true
 
   /web3-core@1.8.1:
@@ -14023,20 +14424,12 @@ packages:
       - supports-color
     dev: true
 
-  /web3-core@1.9.0:
-    resolution: {integrity: sha512-DZ+TPmq/ZLlx4LSVzFgrHCP/QFpKDbGWO4HoquZSdu24cjk5SZ+FEU1SZB2OaK3/bgBh+25mRbmv8y56ysUu1w==}
+  /web3-eth-abi@1.10.0:
+    resolution: {integrity: sha512-cwS+qRBWpJ43aI9L3JS88QYPfFcSJJ3XapxOQ4j40v6mk7ATpA8CVK1vGTzpihNlOfMVRBkR95oAj7oL6aiDOg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 5.1.1
-      '@types/node': 12.20.55
-      bignumber.js: 9.1.1
-      web3-core-helpers: 1.9.0
-      web3-core-method: 1.9.0
-      web3-core-requestmanager: 1.9.0
-      web3-utils: 1.9.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      '@ethersproject/abi': 5.7.0
+      web3-utils: 1.10.0
     dev: true
 
   /web3-eth-abi@1.8.1:
@@ -14047,12 +14440,23 @@ packages:
       web3-utils: 1.8.1
     dev: true
 
-  /web3-eth-abi@1.9.0:
-    resolution: {integrity: sha512-0BLQ3FKMrzJkA930jOX3fMaybAyubk06HChclLpiR0NWmgWXm1tmBrJdkyRy2ZTZpmfuZc9xTFRfl0yZID1voA==}
+  /web3-eth-accounts@1.10.0:
+    resolution: {integrity: sha512-wiq39Uc3mOI8rw24wE2n15hboLE0E9BsQLdlmsL4Zua9diDS6B5abXG0XhFcoNsXIGMWXVZz4TOq3u4EdpXF/Q==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@ethersproject/abi': 5.7.0
-      web3-utils: 1.9.0
+      '@ethereumjs/common': 2.5.0
+      '@ethereumjs/tx': 3.3.2
+      eth-lib: 0.2.8
+      ethereumjs-util: 7.1.5
+      scrypt-js: 3.0.1
+      uuid: 9.0.0
+      web3-core: 1.10.0
+      web3-core-helpers: 1.10.0
+      web3-core-method: 1.10.0
+      web3-utils: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: true
 
   /web3-eth-accounts@1.8.1:
@@ -14075,20 +14479,18 @@ packages:
       - supports-color
     dev: true
 
-  /web3-eth-accounts@1.9.0:
-    resolution: {integrity: sha512-VeIZVevmnSll0AC1k5F/y398ZE89d1SRuYk8IewLUhL/tVAsFEsjl2SGgm0+aDcHmgPrkW+qsCJ+C7rWg/N4ZA==}
+  /web3-eth-contract@1.10.0:
+    resolution: {integrity: sha512-MIC5FOzP/+2evDksQQ/dpcXhSqa/2hFNytdl/x61IeWxhh6vlFeSjq0YVTAyIzdjwnL7nEmZpjfI6y6/Ufhy7w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@ethereumjs/common': 2.5.0
-      '@ethereumjs/tx': 3.3.2
-      eth-lib: 0.2.8
-      ethereumjs-util: 7.1.5
-      scrypt-js: 3.0.1
-      uuid: 9.0.0
-      web3-core: 1.9.0
-      web3-core-helpers: 1.9.0
-      web3-core-method: 1.9.0
-      web3-utils: 1.9.0
+      '@types/bn.js': 5.1.1
+      web3-core: 1.10.0
+      web3-core-helpers: 1.10.0
+      web3-core-method: 1.10.0
+      web3-core-promievent: 1.10.0
+      web3-core-subscriptions: 1.10.0
+      web3-eth-abi: 1.10.0
+      web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14111,18 +14513,18 @@ packages:
       - supports-color
     dev: true
 
-  /web3-eth-contract@1.9.0:
-    resolution: {integrity: sha512-+j26hpSaEtAdUed0TN5rnc+YZOcjPxMjFX4ZBKatvFkImdbVv/tzTvcHlltubSpgb2ZLyZ89lSL6phKYwd2zNQ==}
+  /web3-eth-ens@1.10.0:
+    resolution: {integrity: sha512-3hpGgzX3qjgxNAmqdrC2YUQMTfnZbs4GeLEmy8aCWziVwogbuqQZ+Gzdfrym45eOZodk+lmXyLuAdqkNlvkc1g==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/bn.js': 5.1.1
-      web3-core: 1.9.0
-      web3-core-helpers: 1.9.0
-      web3-core-method: 1.9.0
-      web3-core-promievent: 1.9.0
-      web3-core-subscriptions: 1.9.0
-      web3-eth-abi: 1.9.0
-      web3-utils: 1.9.0
+      content-hash: 2.5.2
+      eth-ens-namehash: 2.0.8
+      web3-core: 1.10.0
+      web3-core-helpers: 1.10.0
+      web3-core-promievent: 1.10.0
+      web3-eth-abi: 1.10.0
+      web3-eth-contract: 1.10.0
+      web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14145,21 +14547,12 @@ packages:
       - supports-color
     dev: true
 
-  /web3-eth-ens@1.9.0:
-    resolution: {integrity: sha512-LOJZeN+AGe9arhuExnrPPFYQr4WSxXEkpvYIlst/joOEUNLDwfndHnJIK6PI5mXaYSROBtTx6erv+HupzGo7vA==}
+  /web3-eth-iban@1.10.0:
+    resolution: {integrity: sha512-0l+SP3IGhInw7Q20LY3IVafYEuufo4Dn75jAHT7c2aDJsIolvf2Lc6ugHkBajlwUneGfbRQs/ccYPQ9JeMUbrg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      content-hash: 2.5.2
-      eth-ens-namehash: 2.0.8
-      web3-core: 1.9.0
-      web3-core-helpers: 1.9.0
-      web3-core-promievent: 1.9.0
-      web3-eth-abi: 1.9.0
-      web3-eth-contract: 1.9.0
-      web3-utils: 1.9.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      bn.js: 5.2.1
+      web3-utils: 1.10.0
     dev: true
 
   /web3-eth-iban@1.8.1:
@@ -14170,12 +14563,19 @@ packages:
       web3-utils: 1.8.1
     dev: true
 
-  /web3-eth-iban@1.9.0:
-    resolution: {integrity: sha512-jPAm77PuEs1kE/UrrBFJdPD2PN42pwfXA0gFuuw35bZezhskYML9W4QCxcqnUtceyEA4FUn7K2qTMuCk+23fog==}
+  /web3-eth-personal@1.10.0:
+    resolution: {integrity: sha512-anseKn98w/d703eWq52uNuZi7GhQeVjTC5/svrBWEKob0WZ5kPdo+EZoFN0sp5a5ubbrk/E0xSl1/M5yORMtpg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      bn.js: 5.2.1
-      web3-utils: 1.9.0
+      '@types/node': 12.20.55
+      web3-core: 1.10.0
+      web3-core-helpers: 1.10.0
+      web3-core-method: 1.10.0
+      web3-net: 1.10.0
+      web3-utils: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: true
 
   /web3-eth-personal@1.8.1:
@@ -14193,16 +14593,22 @@ packages:
       - supports-color
     dev: true
 
-  /web3-eth-personal@1.9.0:
-    resolution: {integrity: sha512-r9Ldo/luBqJlv1vCUEQnUS+C3a3ZdbYxVHyfDkj6RWMyCqqo8JE41HWE+pfa0RmB1xnGL2g8TbYcHcqItck/qg==}
+  /web3-eth@1.10.0:
+    resolution: {integrity: sha512-Z5vT6slNMLPKuwRyKGbqeGYC87OAy8bOblaqRTgg94CXcn/mmqU7iPIlG4506YdcdK3x6cfEDG7B6w+jRxypKA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/node': 12.20.55
-      web3-core: 1.9.0
-      web3-core-helpers: 1.9.0
-      web3-core-method: 1.9.0
-      web3-net: 1.9.0
-      web3-utils: 1.9.0
+      web3-core: 1.10.0
+      web3-core-helpers: 1.10.0
+      web3-core-method: 1.10.0
+      web3-core-subscriptions: 1.10.0
+      web3-eth-abi: 1.10.0
+      web3-eth-accounts: 1.10.0
+      web3-eth-contract: 1.10.0
+      web3-eth-ens: 1.10.0
+      web3-eth-iban: 1.10.0
+      web3-eth-personal: 1.10.0
+      web3-net: 1.10.0
+      web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14229,22 +14635,13 @@ packages:
       - supports-color
     dev: true
 
-  /web3-eth@1.9.0:
-    resolution: {integrity: sha512-c5gSWk9bLNr6VPATHmZ1n7LTIefIZQnJMzfnvkoBcIFGKJbGmsuRhv6lEXsKdAO/FlqYnSbaw3fOq1fVFiIOFQ==}
+  /web3-net@1.10.0:
+    resolution: {integrity: sha512-NLH/N3IshYWASpxk4/18Ge6n60GEvWBVeM8inx2dmZJVmRI6SJIlUxbL8jySgiTn3MMZlhbdvrGo8fpUW7a1GA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      web3-core: 1.9.0
-      web3-core-helpers: 1.9.0
-      web3-core-method: 1.9.0
-      web3-core-subscriptions: 1.9.0
-      web3-eth-abi: 1.9.0
-      web3-eth-accounts: 1.9.0
-      web3-eth-contract: 1.9.0
-      web3-eth-ens: 1.9.0
-      web3-eth-iban: 1.9.0
-      web3-eth-personal: 1.9.0
-      web3-net: 1.9.0
-      web3-utils: 1.9.0
+      web3-core: 1.10.0
+      web3-core-method: 1.10.0
+      web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14262,19 +14659,7 @@ packages:
       - supports-color
     dev: true
 
-  /web3-net@1.9.0:
-    resolution: {integrity: sha512-L+fDZFgrLM5Y15aonl2q6L+RvfaImAngmC0Jv45hV2FJ5IfRT0/2ob9etxZmvEBWvOpbqSvghfOhJIT3XZ37Pg==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      web3-core: 1.9.0
-      web3-core-method: 1.9.0
-      web3-utils: 1.9.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
-  /web3-provider-engine@16.0.4(@babel/core@7.21.4):
+  /web3-provider-engine@16.0.4(@babel/core@7.22.9):
     resolution: {integrity: sha512-f5WxJ9+LTF+4aJo4tCOXtQ6SDytBtLkhvV+qh/9gImHAuG9sMr6utY0mn/pro1Rx7O3hbztBxvQKjGMdOo8muw==}
     engines: {node: '>=12.0.0'}
     dependencies:
@@ -14282,7 +14667,7 @@ packages:
       async: 2.6.4
       backoff: 2.5.0
       clone: 2.1.2
-      eth-block-tracker: 4.4.3(@babel/core@7.21.4)
+      eth-block-tracker: 4.4.3(@babel/core@7.22.9)
       eth-json-rpc-filters: 4.2.2
       eth-json-rpc-infura: 5.1.0
       eth-json-rpc-middleware: 6.0.0
@@ -14307,6 +14692,18 @@ packages:
       - utf-8-validate
     dev: true
 
+  /web3-providers-http@1.10.0:
+    resolution: {integrity: sha512-eNr965YB8a9mLiNrkjAWNAPXgmQWfpBfkkn7tpEFlghfww0u3I0tktMZiaToJVcL2+Xq+81cxbkpeWJ5XQDwOA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      abortcontroller-polyfill: 1.7.5
+      cross-fetch: 3.1.8
+      es6-promise: 4.2.8
+      web3-core-helpers: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /web3-providers-http@1.8.1:
     resolution: {integrity: sha512-1Zyts4O9W/UNEPkp+jyL19Jc3D15S4yp8xuLTjVhcUEAlHo24NDWEKxtZGUuHk4HrKL2gp8OlsDbJ7MM+ESDgg==}
     engines: {node: '>=8.0.0'}
@@ -14319,16 +14716,12 @@ packages:
       - encoding
     dev: true
 
-  /web3-providers-http@1.9.0:
-    resolution: {integrity: sha512-5+dMNDAE0rRFz6SJpfnBqlVi2J5bB/Ivr2SanMt2YUrkxW5t8betZbzVwRkTbwtUvkqgj3xeUQzqpOttiv+IqQ==}
+  /web3-providers-ipc@1.10.0:
+    resolution: {integrity: sha512-OfXG1aWN8L1OUqppshzq8YISkWrYHaATW9H8eh0p89TlWMc1KZOL9vttBuaBEi96D/n0eYDn2trzt22bqHWfXA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      abortcontroller-polyfill: 1.7.5
-      cross-fetch: 3.1.5
-      es6-promise: 4.2.8
-      web3-core-helpers: 1.9.0
-    transitivePeerDependencies:
-      - encoding
+      oboe: 2.1.5
+      web3-core-helpers: 1.10.0
     dev: true
 
   /web3-providers-ipc@1.8.1:
@@ -14339,12 +14732,15 @@ packages:
       web3-core-helpers: 1.8.1
     dev: true
 
-  /web3-providers-ipc@1.9.0:
-    resolution: {integrity: sha512-cPXU93Du40HCylvjaa5x62DbnGqH+86HpK/+kMcFIzF6sDUBhKpag2tSbYhGbj7GMpfkmDTUiiMLdWnFV6+uBA==}
+  /web3-providers-ws@1.10.0:
+    resolution: {integrity: sha512-sK0fNcglW36yD5xjnjtSGBnEtf59cbw4vZzJ+CmOWIKGIR96mP5l684g0WD0Eo+f4NQc2anWWXG74lRc9OVMCQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      oboe: 2.1.5
-      web3-core-helpers: 1.9.0
+      eventemitter3: 4.0.4
+      web3-core-helpers: 1.10.0
+      websocket: 1.0.34
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /web3-providers-ws@1.8.1:
@@ -14358,14 +14754,17 @@ packages:
       - supports-color
     dev: true
 
-  /web3-providers-ws@1.9.0:
-    resolution: {integrity: sha512-JRVsnQZ7j2k1a2yzBNHe39xqk1ijOv01dfIBFw52VeEkSRzvrOcsPIM/ttSyBuJqt70ntMxXY0ekCrqfleKH/w==}
+  /web3-shh@1.10.0:
+    resolution: {integrity: sha512-uNUUuNsO2AjX41GJARV9zJibs11eq6HtOe6Wr0FtRUcj8SN6nHeYIzwstAvJ4fXA53gRqFMTxdntHEt9aXVjpg==}
     engines: {node: '>=8.0.0'}
+    requiresBuild: true
     dependencies:
-      eventemitter3: 4.0.4
-      web3-core-helpers: 1.9.0
-      websocket: 1.0.34
+      web3-core: 1.10.0
+      web3-core-method: 1.10.0
+      web3-core-subscriptions: 1.10.0
+      web3-net: 1.10.0
     transitivePeerDependencies:
+      - encoding
       - supports-color
     dev: true
 
@@ -14383,18 +14782,17 @@ packages:
       - supports-color
     dev: true
 
-  /web3-shh@1.9.0:
-    resolution: {integrity: sha512-bIBZlralgz4ICCrwkefB2nPPJWfx28NuHIpjB7d9ADKynElubQuqudYhKtSEkKXACuME/BJm0pIFJcJs/gDnMg==}
+  /web3-utils@1.10.0:
+    resolution: {integrity: sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg==}
     engines: {node: '>=8.0.0'}
-    requiresBuild: true
     dependencies:
-      web3-core: 1.9.0
-      web3-core-method: 1.9.0
-      web3-core-subscriptions: 1.9.0
-      web3-net: 1.9.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      bn.js: 5.2.1
+      ethereum-bloom-filters: 1.0.10
+      ethereumjs-util: 7.1.5
+      ethjs-unit: 0.1.6
+      number-to-bn: 1.7.0
+      randombytes: 2.1.0
+      utf8: 3.0.0
     dev: true
 
   /web3-utils@1.8.1:
@@ -14410,17 +14808,23 @@ packages:
       utf8: 3.0.0
     dev: true
 
-  /web3-utils@1.9.0:
-    resolution: {integrity: sha512-p++69rCNNfu2jM9n5+VD/g26l+qkEOQ1m6cfRQCbH8ZRrtquTmrirJMgTmyOoax5a5XRYOuws14aypCOs51pdQ==}
+  /web3@1.10.0:
+    resolution: {integrity: sha512-YfKY9wSkGcM8seO+daR89oVTcbu18NsVfvOngzqMYGUU0pPSQmE57qQDvQzUeoIOHAnXEBNzrhjQJmm8ER0rng==}
     engines: {node: '>=8.0.0'}
+    requiresBuild: true
     dependencies:
-      bn.js: 5.2.1
-      ethereum-bloom-filters: 1.0.10
-      ethereumjs-util: 7.1.5
-      ethjs-unit: 0.1.6
-      number-to-bn: 1.7.0
-      randombytes: 2.1.0
-      utf8: 3.0.0
+      web3-bzz: 1.10.0
+      web3-core: 1.10.0
+      web3-eth: 1.10.0
+      web3-eth-personal: 1.10.0
+      web3-net: 1.10.0
+      web3-shh: 1.10.0
+      web3-utils: 1.10.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /web3@1.8.1:
@@ -14435,25 +14839,6 @@ packages:
       web3-net: 1.8.1
       web3-shh: 1.8.1
       web3-utils: 1.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /web3@1.9.0:
-    resolution: {integrity: sha512-E9IvVy/d2ozfQQsCiV+zh/LmlZGv9fQxI0UedDVjm87yOKf4AYbBNEn1iWtHveiGzAk2CEMZMUzAZzaQNSSYog==}
-    engines: {node: '>=8.0.0'}
-    requiresBuild: true
-    dependencies:
-      web3-bzz: 1.9.0
-      web3-core: 1.9.0
-      web3-eth: 1.9.0
-      web3-eth-personal: 1.9.0
-      web3-net: 1.9.0
-      web3-shh: 1.9.0
-      web3-utils: 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -15089,6 +15474,10 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true
 
   /zstd-codec@0.1.4:


### PR DESCRIPTION
Moves ChainId, NetworkId and networks (NetworkMetadata) to constants.ts which is also exported as @0xsequence/network/constants

NetworkConfig type is now an intersection of NetworkMetadata constant and configurable options. 

I believe this is a good code organization win as well as allows for importing constant metadata into other projects like design-system which needs chainId and Network details for NetworkTag components and others without pulling in a dependency on ethers.js