### PR TITLE
Mutate connectDetails.session.networks isDefaultChain to return the dapps connectOptions.networkId instead

### DIFF
--- a/packages/provider/src/transports/base-wallet-transport.ts
+++ b/packages/provider/src/transports/base-wallet-transport.ts
@@ -444,7 +444,7 @@ export abstract class BaseWalletTransport implements WalletTransport {
         this.notifyOpen({
           sessionId: this._sessionId,
           chainId: `${chainId}`,
-          session: await this.walletRequestHandler.walletSession()
+          session: await this.walletRequestHandler.walletSession(chainId)
         })
       }
     }

--- a/packages/provider/src/transports/wallet-request-handler.ts
+++ b/packages/provider/src/transports/wallet-request-handler.ts
@@ -180,6 +180,8 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
     // Build session response for connect details
     connectDetails.session = await this.walletSession()
 
+    this.updateConnectDetails(connectDetails, options)
+
     return connectDetails
   }
 
@@ -202,20 +204,24 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
     if (connectDetails.connected && !connectDetails.session) {
       connectDetails.session = await this.walletSession()
 
-      if (options?.networkId) {
-        const network = findNetworkConfig(connectDetails.session?.networks || [], options.networkId)
-
-        if (network) {
-          // Delete the isDefaultChain property from the session network
-          connectDetails.session?.networks?.forEach(n => delete n.isDefaultChain)
-
-          // Add the isDefaultChain property to the network with the given networkId
-          network.isDefaultChain = true
-        }
-      }
+      this.updateConnectDetails(connectDetails, options)
     }
 
     return promptConnectDetails
+  }
+
+  private updateConnectDetails = (connectDetails: ConnectDetails, options?: NetworkedConnectOptions) => {
+    if (options?.networkId) {
+      const network = findNetworkConfig(connectDetails.session?.networks || [], options.networkId)
+
+      if (network) {
+        // Delete the isDefaultChain property from the session network
+        connectDetails.session?.networks?.forEach(n => delete n.isDefaultChain)
+
+        // Add the isDefaultChain property to the network with the given networkId
+        network.isDefaultChain = true
+      }
+    }
   }
 
   // sendMessageRequest will unwrap the ProviderMessageRequest and send it to the JsonRpcHandler


### PR DESCRIPTION
When dapps initWallet they specify their own default chain id, however when they connect to the wallet, the wallet passes its own default chain id settings to the dapp. This causes problems!

When dapps connect they receive connectDetails back which includes the session from the wallet. This session contains networks of `NetworkConfig[]` with the `isDefaultChain: true` of the wallets default chain. This causes the dapp to override its own specified default network with the wallets.

If the dapp window is reloaded it is already in a connected state so it doesnt need to connect again and uses its own default chain. This fix is to ensure the dapp always stays on its own default chain even after a connect.

During connect we check to see if the dapp passes in connectOptions.networkId and if one is specified we mutate the wallets session.networks to change the returned defaultId.
