### PR TITLE
Account children

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c .eslintrc.js 'packages/**/src/**/*.{ts,tsx}'",
     "lint:fix": "eslint -c .eslintrc.js --fix 'packages/**/src/**/*.{ts,tsx}'",
     "lint:tests": "eslint -c .eslintrc.js 'packages/**/tests/**/*.{ts,tsx}'",
-    "lint:tests:fix": "eslint -c .eslintrc.js 'packages/**/tests/**/*.{ts,tsx}'",
+    "lint:tests:fix": "eslint -c .eslintrc.js --fix 'packages/**/tests/**/*.{ts,tsx}'",
     "format": "prettier --write \"packages/**/src/**/*.ts\" \"packages/**/tests/**/*.ts\"",
     "audit:fix": "pnpm audit --fix",
     "typecheck": "tsc --noEmit",

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -758,8 +758,10 @@ export class Account {
     pstatus?: AccountStatus,
     callback?: (bundle: commons.transaction.IntendedTransactionBundle) => void
   ): Promise<ethers.providers.TransactionResponse> {
-    const firstChainId = Array.isArray(signedBundle) ? signedBundle[0].chainId : signedBundle.chainId
-    const status = pstatus || (await this.status(firstChainId))
+    if (!Array.isArray(signedBundle)) {
+      return this.sendSignedTransactions([signedBundle], chainId, quote, pstatus, callback)
+    }
+    const status = pstatus || (await this.status(signedBundle[0].chainId))
     this.mustBeFullyMigrated(status)
 
     const decoratedBundle = await this.decorateTransactions(signedBundle, status)

--- a/packages/account/src/orchestrator/wrapper.ts
+++ b/packages/account/src/orchestrator/wrapper.ts
@@ -1,0 +1,92 @@
+import { commons } from '@0xsequence/core'
+import { signers, Status } from '@0xsequence/signhub'
+import { Wallet } from '@0xsequence/wallet'
+import { ethers } from 'ethers'
+import { Account } from '../account'
+
+export type AccountWrapperDecorateMetadata = {
+  chainId?: ethers.BigNumberish
+}
+
+// Implements a wrapper for using Sequence accounts as nested signers
+// in the signhub orchestrator. It only works for nested signatures.
+export class AccountOrchestratorWrapper implements signers.SapientSigner {
+  constructor(public account: Account) {}
+
+  async getAddress(): Promise<string> {
+    return this.account.address
+  }
+
+  getChainIdFromMetadata(metadata: Object): ethers.BigNumberish {
+    let { chainId } = metadata as AccountWrapperDecorateMetadata
+    try {
+      chainId = ethers.BigNumber.from(chainId)
+    } catch (err) {
+      // Invalid metadata object
+      throw new Error('AccountOrchestratorWrapper only supports account status callbacks')
+    }
+    return chainId
+  }
+
+  async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined> {
+    const chainId = this.getChainIdFromMetadata(metadata)
+    const status = await this.account.status(chainId)
+    return this.account.buildBootstrapTransactions(status, chainId)
+  }
+
+  async predecorateTransactions(
+    txs: commons.transaction.Transactionish,
+    metadata: Object
+  ): Promise<commons.transaction.Transactionish> {
+    const chainId = this.getChainIdFromMetadata(metadata)
+    const status = await this.account.status(chainId)
+    return this.account.predecorateTransactions(txs, status, chainId)
+  }
+
+  async decorateTransactions(
+    bundle: commons.transaction.IntendedTransactionBundle,
+    metadata: Object
+  ): Promise<commons.transaction.IntendedTransactionBundle> {
+    const chainId = this.getChainIdFromMetadata(metadata)
+    const status = await this.account.status(chainId)
+    return this.account.decorateTransactions(bundle, status)
+  }
+
+  async requestSignature(
+    _id: string,
+    message: ethers.utils.BytesLike,
+    metadata: Object,
+    callbacks: {
+      onSignature: (signature: ethers.utils.BytesLike) => void
+      onRejection: (error: string) => void
+      onStatus: (situation: string) => void
+    }
+  ): Promise<boolean> {
+    console.log('Signing digest for account orchestrator')
+    if (!commons.isAccountSignRequestMetadata(metadata)) {
+      throw new Error('AccountOrchestratorWrapper only supports account metadata requests')
+    }
+
+    const { chainId, decorate } = metadata
+    // EIP-6492 not supported on nested signatures
+    // Default to throw instead of ignore. Ignoring should be explicit
+    const cantValidateBehavior = metadata.cantValidateBehavior ?? 'throw'
+
+    // For Sequence nested signatures we must use `signDigest` and not `signMessage`
+    // otherwise the account will hash the digest and the signature will be invalid.
+    try {
+      callbacks.onSignature(await this.account.signDigest(message, chainId, decorate, cantValidateBehavior))
+    } catch (err) {
+      callbacks.onRejection('Unable to sign account')
+      return false
+    }
+
+    return true
+  }
+
+  notifyStatusChange(_i: string, _s: Status, _m: Object): void {}
+
+  suffix(): ethers.utils.BytesLike {
+    return [3]
+  }
+}

--- a/packages/account/src/orchestrator/wrapper.ts
+++ b/packages/account/src/orchestrator/wrapper.ts
@@ -3,12 +3,11 @@ import { signers, Status } from '@0xsequence/signhub'
 import { ethers } from 'ethers'
 import { Account } from '../account'
 
-export type AccountWrapperDecorateMetadata = {
-  chainId?: ethers.BigNumberish
+export type MetadataWithChainId = {
+  chainId: ethers.BigNumberish
 }
 
-// Implements a wrapper for using Sequence accounts as nested signers
-// in the signhub orchestrator. It only works for nested signatures.
+// Implements a wrapper for using Sequence accounts as nested signers in the signhub orchestrator.
 export class AccountOrchestratorWrapper implements signers.SapientSigner {
   constructor(public account: Account) {}
 
@@ -16,15 +15,14 @@ export class AccountOrchestratorWrapper implements signers.SapientSigner {
     return this.account.address
   }
 
-  getChainIdFromMetadata(metadata: Object): ethers.BigNumberish {
-    let { chainId } = metadata as AccountWrapperDecorateMetadata
+  getChainIdFromMetadata(metadata: Object): ethers.BigNumber {
     try {
-      chainId = ethers.BigNumber.from(chainId)
+      const { chainId } = metadata as MetadataWithChainId
+      return ethers.BigNumber.from(chainId)
     } catch (err) {
       // Invalid metadata object
-      throw new Error('AccountOrchestratorWrapper only supports account status callbacks')
+      throw new Error('AccountOrchestratorWrapper only supports metadata with chain id')
     }
-    return chainId
   }
 
   async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined> {

--- a/packages/account/src/signer.ts
+++ b/packages/account/src/signer.ts
@@ -157,7 +157,7 @@ export class AccountSigner implements ethers.Signer {
             nonceSpace: this.options.nonceSpace
           }
         : undefined
-    )
+    ) as Promise<ethers.providers.TransactionResponse> // Will always have a transaction response
   }
 
   getBalance(blockTag?: ethers.providers.BlockTag | undefined): Promise<ethers.BigNumber> {

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -3,6 +3,19 @@ import { commons } from '..'
 import { Config } from './config'
 
 /**
+ * Request metadata, used by the account to pass additional information through the orchestrator.
+ */
+export type AccountSignRequestMetadata = {
+  chainId: ethers.BigNumberish,
+  decorate?: boolean,
+  cantValidateBehavior?: 'ignore' | 'eip6492' | 'throw'
+}
+
+export function isAccountSignRequestMetadata(obj: any): obj is AccountSignRequestMetadata {
+  return obj && obj.chainId !== undefined
+}
+
+/**
  * Request metadata, used by the wallet to pass additional information through the orchestrator.
  */
 export type WalletSignRequestMetadata = {

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -20,7 +20,6 @@ export type WalletSignRequestMetadata = {
 
   message?: ethers.utils.BytesLike
   transactions?: commons.transaction.Transaction[]
-  useEip6492?: boolean // If true, EIP6492 can be used
 
   // This is used only when a Sequence wallet is nested in another Sequence wallet
   // it contains the original metadata of the parent wallet.

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -3,19 +3,6 @@ import { commons } from '..'
 import { Config } from './config'
 
 /**
- * Request metadata, used by the account to pass additional information through the orchestrator.
- */
-export type AccountSignRequestMetadata = {
-  chainId: ethers.BigNumberish,
-  decorate?: boolean,
-  cantValidateBehavior?: 'ignore' | 'eip6492' | 'throw'
-}
-
-export function isAccountSignRequestMetadata(obj: any): obj is AccountSignRequestMetadata {
-  return obj && obj.chainId !== undefined
-}
-
-/**
  * Request metadata, used by the wallet to pass additional information through the orchestrator.
  */
 export type WalletSignRequestMetadata = {
@@ -37,6 +24,9 @@ export type WalletSignRequestMetadata = {
   // This is used only when a Sequence wallet is nested in another Sequence wallet
   // it contains the original metadata of the parent wallet.
   parent?: WalletSignRequestMetadata
+
+  decorate?: boolean,
+  cantValidateBehavior?: 'ignore' | 'eip6492' | 'throw'
 }
 
 export function isWalletSignRequestMetadata(obj: any): obj is WalletSignRequestMetadata {

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -20,7 +20,7 @@ export type WalletSignRequestMetadata = {
 
   message?: ethers.utils.BytesLike
   transactions?: commons.transaction.Transaction[]
-  useEip6492?: true // If true, EIP6492 can be used
+  useEip6492?: boolean // If true, EIP6492 can be used
 
   // This is used only when a Sequence wallet is nested in another Sequence wallet
   // it contains the original metadata of the parent wallet.

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -18,13 +18,13 @@ export type WalletSignRequestMetadata = {
   //       how close are we to the threshold. This can be used to display
   //       a progress bar or something similar.
 
-  message?: ethers.utils.BytesLike,
-  transactions?: commons.transaction.Transaction[],
-  useEip6492?: true, // If true, EIP6492 can be used
+  message?: ethers.utils.BytesLike
+  transactions?: commons.transaction.Transaction[]
+  useEip6492?: true // If true, EIP6492 can be used
 
   // This is used only when a Sequence wallet is nested in another Sequence wallet
   // it contains the original metadata of the parent wallet.
-  parent?: WalletSignRequestMetadata,
+  parent?: WalletSignRequestMetadata
 }
 
 export function isWalletSignRequestMetadata(obj: any): obj is WalletSignRequestMetadata {
@@ -35,8 +35,8 @@ export function isWalletSignRequestMetadata(obj: any): obj is WalletSignRequestM
  * Request metadata, used by the wallet to pass additional information through the orchestrator.
  */
 export type WalletDeployMetadata = {
-  includeChildren: boolean, // Whether to include children in deployment, default false
-  ignoreDeployed: boolean, // Whether to ignore already deployed wallets, default false
+  includeChildren: boolean // Whether to include children in deployment, default false
+  ignoreDeployed: boolean // Whether to ignore already deployed wallets, default false
 }
 
 export function isWalletDeployMetadata(obj: any): obj is WalletDeployMetadata {

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -3,8 +3,7 @@ import { commons } from '..'
 import { Config } from './config'
 
 /**
- * Request metadata, used to by the wallet to pass additional information to the
- * orchestrator.
+ * Request metadata, used by the wallet to pass additional information through the orchestrator.
  */
 export type WalletSignRequestMetadata = {
   address: string
@@ -19,14 +18,27 @@ export type WalletSignRequestMetadata = {
   //       how close are we to the threshold. This can be used to display
   //       a progress bar or something similar.
 
-  message?: ethers.utils.BytesLike
-  transactions?: commons.transaction.Transaction[]
+  message?: ethers.utils.BytesLike,
+  transactions?: commons.transaction.Transaction[],
+  useEip6492?: true, // If true, EIP6492 can be used
 
   // This is used only when a Sequence wallet is nested in another Sequence wallet
   // it contains the original metadata of the parent wallet.
-  parent?: WalletSignRequestMetadata
+  parent?: WalletSignRequestMetadata,
 }
 
 export function isWalletSignRequestMetadata(obj: any): obj is WalletSignRequestMetadata {
   return obj && obj.address && obj.digest && obj.chainId !== undefined && obj.config
+}
+
+/**
+ * Request metadata, used by the wallet to pass additional information through the orchestrator.
+ */
+export type WalletDeployMetadata = {
+  includeChildren: boolean, // Whether to include children in deployment, default false
+  ignoreDeployed: boolean, // Whether to ignore already deployed wallets, default false
+}
+
+export function isWalletDeployMetadata(obj: any): obj is WalletDeployMetadata {
+  return obj && obj.includeChildren !== undefined && obj.ignoreDeployed !== undefined
 }

--- a/packages/core/src/commons/orchestrator.ts
+++ b/packages/core/src/commons/orchestrator.ts
@@ -35,10 +35,6 @@ export function isWalletSignRequestMetadata(obj: any): obj is WalletSignRequestM
  * Request metadata, used by the wallet to pass additional information through the orchestrator.
  */
 export type WalletDeployMetadata = {
-  includeChildren: boolean // Whether to include children in deployment, default false
-  ignoreDeployed: boolean // Whether to ignore already deployed wallets, default false
-}
-
-export function isWalletDeployMetadata(obj: any): obj is WalletDeployMetadata {
-  return obj && obj.includeChildren !== undefined && obj.ignoreDeployed !== undefined
+  includeChildren?: boolean // Whether to include children in deployment, default false
+  ignoreDeployed?: boolean // Whether to ignore already deployed wallets, default false
 }

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -30,6 +30,10 @@ export class GuardSigner implements signers.SapientSigner {
     return this.address
   }
 
+  buildDeployTransaction(_metadata: Object): Promise<commons.transaction.TransactionBundle | null> {
+    throw new Error('Guard client cannot be deployed.')
+  }
+
   async decorateTransactions(
     bundle: commons.transaction.IntendedTransactionBundle,
   ): Promise<commons.transaction.IntendedTransactionBundle> {

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -34,10 +34,18 @@ export class GuardSigner implements signers.SapientSigner {
     throw new Error('Guard client cannot be deployed.')
   }
 
+  async predecorateTransactions(
+    txs: commons.transaction.Transactionish,
+    _metadata: Object
+  ): Promise<commons.transaction.Transactionish> {
+    return txs
+  }
+
   async decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle
+    bundle: commons.transaction.IntendedTransactionBundle,
+    _metadata: Object
   ): Promise<commons.transaction.IntendedTransactionBundle> {
-    return Promise.resolve(bundle)
+    return bundle
   }
 
   async requestSignature(

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -34,11 +34,10 @@ export class GuardSigner implements signers.SapientSigner {
     throw new Error('Guard client cannot be deployed.')
   }
 
-  async predecorateTransactions(
-    txs: commons.transaction.Transactionish,
+  async predecorateSignedTransactions(
     _metadata: Object
-  ): Promise<commons.transaction.Transactionish> {
-    return txs
+  ): Promise<commons.transaction.SignedTransactionBundle[]> {
+    return []
   }
 
   async decorateTransactions(

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -30,7 +30,7 @@ export class GuardSigner implements signers.SapientSigner {
     return this.address
   }
 
-  buildDeployTransaction(_metadata: Object): Promise<commons.transaction.TransactionBundle | null> {
+  buildDeployTransaction(_metadata: Object): Promise<commons.transaction.TransactionBundle | undefined> {
     throw new Error('Guard client cannot be deployed.')
   }
 

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -35,7 +35,7 @@ export class GuardSigner implements signers.SapientSigner {
   }
 
   async decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle,
+    bundle: commons.transaction.IntendedTransactionBundle
   ): Promise<commons.transaction.IntendedTransactionBundle> {
     return Promise.resolve(bundle)
   }

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -30,6 +30,12 @@ export class GuardSigner implements signers.SapientSigner {
     return this.address
   }
 
+  async decorateTransactions(
+    bundle: commons.transaction.IntendedTransactionBundle,
+  ): Promise<commons.transaction.IntendedTransactionBundle> {
+    return Promise.resolve(bundle)
+  }
+
   async requestSignature(
     id: string,
     _message: BytesLike,

--- a/packages/provider/src/transports/wallet-request-handler.ts
+++ b/packages/provider/src/transports/wallet-request-handler.ts
@@ -424,7 +424,7 @@ export class WalletRequestHandler implements ExternalProvider, JsonRpcHandler, P
           if (this.prompter === null) {
             // prompter is null, so we'll send from here
             const txnResponse = await account.sendTransaction(transactionParams, chainId ?? this.defaultChainId())
-            txnHash = txnResponse.hash
+            txnHash = txnResponse?.hash ?? ''
           } else {
             // prompt user to provide the response
             txnHash = await this.prompter.promptSendTransaction(transactionParams, chainId, this.connectOptions)

--- a/packages/provider/tests/signer.spec.ts
+++ b/packages/provider/tests/signer.spec.ts
@@ -40,11 +40,11 @@ let defaultChainId: number
 
 let callback: (chainId: number) => void
 
-let onDefaultChainIdChanged = (cb: (chainId: number) => void) => {
+const onDefaultChainIdChanged = (cb: (chainId: number) => void) => {
   callback = cb
 }
 
-let setDefaultChainId = (chainId: number) => {
+const setDefaultChainId = (chainId: number) => {
   defaultChainId = chainId
   callback(chainId)
 }
@@ -84,7 +84,7 @@ describe('SequenceSigner', () => {
 
   describe('client proxy methods', () => {
     describe('getWalletConfig', () => {
-      let returnWalletConfig = {
+      const returnWalletConfig = {
         version: 1,
         threshold: 5,
         signers: [

--- a/packages/signhub/package.json
+++ b/packages/signhub/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "nyc yarn test"
   },
   "dependencies": {
+    "@0xsequence/core": "workspace:*",
     "ethers": "^5.5.2"
   },
   "peerDependencies": {},

--- a/packages/signhub/src/orchestrator.ts
+++ b/packages/signhub/src/orchestrator.ts
@@ -90,11 +90,11 @@ export class Orchestrator {
     ])
   }
 
-  async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | null> {
-    let bundle: commons.transaction.TransactionBundle | null = null
+  async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined> {
+    let bundle: commons.transaction.TransactionBundle | undefined
     for (const signer of this.signers) {
       const newBundle = await signer.buildDeployTransaction(metadata)
-      if (bundle === null) {
+      if (bundle === undefined) {
         // Use first bundle as base
         bundle = newBundle
       } else if (newBundle?.transactions) {

--- a/packages/signhub/src/orchestrator.ts
+++ b/packages/signhub/src/orchestrator.ts
@@ -106,10 +106,11 @@ export class Orchestrator {
   }
 
   async decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle
+    bundle: commons.transaction.IntendedTransactionBundle,
+    metadata?: Object
   ): Promise<commons.transaction.IntendedTransactionBundle> {
     for (const signer of this.signers) {
-      bundle = await signer.decorateTransactions(bundle)
+      bundle = await signer.decorateTransactions(bundle, metadata ?? {})
     }
     return bundle
   }

--- a/packages/signhub/src/orchestrator.ts
+++ b/packages/signhub/src/orchestrator.ts
@@ -105,6 +105,16 @@ export class Orchestrator {
     return bundle
   }
 
+  async predecorateSignedTransactions(
+    metadata?: Object
+  ): Promise<commons.transaction.SignedTransactionBundle[]> {
+    const output: commons.transaction.SignedTransactionBundle[] = []
+    for (const signer of this.signers) {
+      output.push(...(await signer.predecorateSignedTransactions(metadata ?? {})))
+    }
+    return output
+  }
+
   async decorateTransactions(
     bundle: commons.transaction.IntendedTransactionBundle,
     metadata?: Object

--- a/packages/signhub/src/orchestrator.ts
+++ b/packages/signhub/src/orchestrator.ts
@@ -53,7 +53,10 @@ export class Orchestrator {
 
   private count = 0
 
-  constructor(signers: (ethers.Signer | SapientSigner)[], public tag: string = Orchestrator.randomTag()) {
+  constructor(
+    signers: (ethers.Signer | SapientSigner)[],
+    public tag: string = Orchestrator.randomTag()
+  ) {
     this.setSigners(signers)
   }
 

--- a/packages/signhub/src/orchestrator.ts
+++ b/packages/signhub/src/orchestrator.ts
@@ -1,7 +1,7 @@
-import { ethers } from "ethers"
-import { commons } from "@0xsequence/core"
-import { isSapientSigner, SapientSigner } from "./signers/signer"
-import { SignerWrapper } from "./signers/wrapper"
+import { ethers } from 'ethers'
+import { commons } from '@0xsequence/core'
+import { isSapientSigner, SapientSigner } from './signers/signer'
+import { SignerWrapper } from './signers/wrapper'
 
 export type Status = {
   ended: boolean
@@ -53,10 +53,7 @@ export class Orchestrator {
 
   private count = 0
 
-  constructor(
-    signers: (ethers.Signer | SapientSigner)[],
-    public tag: string = Orchestrator.randomTag()
-  ) {
+  constructor(signers: (ethers.Signer | SapientSigner)[], public tag: string = Orchestrator.randomTag()) {
     this.setSigners(signers)
   }
 
@@ -106,7 +103,7 @@ export class Orchestrator {
   }
 
   async decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle,
+    bundle: commons.transaction.IntendedTransactionBundle
   ): Promise<commons.transaction.IntendedTransactionBundle> {
     for (const signer of this.signers) {
       bundle = await signer.decorateTransactions(bundle)

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -6,7 +6,7 @@ export interface SapientSigner {
   getAddress(): Promise<string>
 
   // Note: This probably doesn't belong here as this isn't directly related to signing
-  buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | null>
+  buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined>
 
   /**
    * Modify the transaction bundle before it is sent.

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -5,6 +5,9 @@ import { Status } from "../orchestrator"
 export interface SapientSigner {
   getAddress(): Promise<string>
 
+  // Note: This probably doesn't belong here as this isn't directly related to signing
+  buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | null>
+
   /**
    * Modify the transaction bundle before it is sent.
    */
@@ -39,5 +42,10 @@ export interface SapientSigner {
 }
 
 export function isSapientSigner(signer: ethers.Signer | SapientSigner): signer is SapientSigner {
-  return (signer as SapientSigner).requestSignature !== undefined && (signer as SapientSigner).notifyStatusChange !== undefined
+  return (
+    (signer as SapientSigner).buildDeployTransaction !== undefined &&
+    (signer as SapientSigner).decorateTransactions !== undefined &&
+    (signer as SapientSigner).requestSignature !== undefined &&
+    (signer as SapientSigner).notifyStatusChange !== undefined
+  )
 }

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -8,12 +8,11 @@ export interface SapientSigner {
   buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined>
 
   /**
-   * Append transactions prior to decoration.
+   * Get signed transactions to be included in the next request.
    */
-  predecorateTransactions(
-    txs: commons.transaction.Transactionish,
+  predecorateSignedTransactions(
     metadata: Object
-  ): Promise<commons.transaction.Transactionish>
+  ): Promise<commons.transaction.SignedTransactionBundle[]>
 
   /**
    * Modify the transaction bundle before it is sent.

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -5,7 +5,6 @@ import { Status } from '../orchestrator'
 export interface SapientSigner {
   getAddress(): Promise<string>
 
-  // Note: This probably doesn't belong here as this isn't directly related to signing
   buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined>
 
   /**

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -46,7 +46,9 @@ export interface SapientSigner {
 
 export function isSapientSigner(signer: ethers.Signer | SapientSigner): signer is SapientSigner {
   return (
+    (signer as SapientSigner).getAddress !== undefined &&
     (signer as SapientSigner).buildDeployTransaction !== undefined &&
+    (signer as SapientSigner).predecorateSignedTransactions !== undefined &&
     (signer as SapientSigner).decorateTransactions !== undefined &&
     (signer as SapientSigner).requestSignature !== undefined &&
     (signer as SapientSigner).notifyStatusChange !== undefined

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -8,10 +8,19 @@ export interface SapientSigner {
   buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined>
 
   /**
+   * Append transactions prior to decoration.
+   */
+  predecorateTransactions(
+    txs: commons.transaction.Transactionish,
+    metadata: Object
+  ): Promise<commons.transaction.Transactionish>
+
+  /**
    * Modify the transaction bundle before it is sent.
    */
   decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle
+    bundle: commons.transaction.IntendedTransactionBundle,
+    metadata: Object
   ): Promise<commons.transaction.IntendedTransactionBundle>
 
   /**

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -1,6 +1,6 @@
-import { ethers } from "ethers"
-import { commons } from "@0xsequence/core"
-import { Status } from "../orchestrator"
+import { ethers } from 'ethers'
+import { commons } from '@0xsequence/core'
+import { Status } from '../orchestrator'
 
 export interface SapientSigner {
   getAddress(): Promise<string>
@@ -12,7 +12,7 @@ export interface SapientSigner {
    * Modify the transaction bundle before it is sent.
    */
   decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle,
+    bundle: commons.transaction.IntendedTransactionBundle
   ): Promise<commons.transaction.IntendedTransactionBundle>
 
   /**
@@ -32,11 +32,7 @@ export interface SapientSigner {
   /**
    * Notify the signer of a status change.
    */
-  notifyStatusChange(
-    id: string,
-    status: Status,
-    metadata: Object
-  ): void
+  notifyStatusChange(id: string, status: Status, metadata: Object): void
 
   suffix(): ethers.BytesLike
 }

--- a/packages/signhub/src/signers/signer.ts
+++ b/packages/signhub/src/signers/signer.ts
@@ -1,9 +1,20 @@
-import { ethers } from 'ethers'
-import { Status } from '../orchestrator'
+import { ethers } from "ethers"
+import { commons } from "@0xsequence/core"
+import { Status } from "../orchestrator"
 
 export interface SapientSigner {
   getAddress(): Promise<string>
 
+  /**
+   * Modify the transaction bundle before it is sent.
+   */
+  decorateTransactions(
+    bundle: commons.transaction.IntendedTransactionBundle,
+  ): Promise<commons.transaction.IntendedTransactionBundle>
+
+  /**
+   * Request a signature from the signer.
+   */
   requestSignature(
     id: string,
     message: ethers.BytesLike,
@@ -15,7 +26,14 @@ export interface SapientSigner {
     }
   ): Promise<boolean>
 
-  notifyStatusChange(id: string, status: Status, metadata: Object): void
+  /**
+   * Notify the signer of a status change.
+   */
+  notifyStatusChange(
+    id: string,
+    status: Status,
+    metadata: Object
+  ): void
 
   suffix(): ethers.BytesLike
 }

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -13,6 +13,11 @@ export class SignerWrapper implements SapientSigner {
     return this.signer.getAddress()
   }
 
+  async buildDeployTransaction(): Promise<commons.transaction.TransactionBundle | null> {
+    // Wrapped signers don't require deployment
+    return null
+  }
+
   async decorateTransactions(
     bundle: commons.transaction.IntendedTransactionBundle
   ): Promise<commons.transaction.IntendedTransactionBundle> {

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -18,8 +18,16 @@ export class SignerWrapper implements SapientSigner {
     return
   }
 
+  async predecorateTransactions(
+    txs: commons.transaction.Transactionish,
+    _metadata: Object
+  ): Promise<commons.transaction.Transactionish> {
+    return txs
+  }
+
   async decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle
+    bundle: commons.transaction.IntendedTransactionBundle,
+    _metadata: Object
   ): Promise<commons.transaction.IntendedTransactionBundle> {
     return bundle
   }

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -1,13 +1,10 @@
 import { ethers } from 'ethers'
-import { commons } from "@0xsequence/core"
+import { commons } from '@0xsequence/core'
 import { Status } from '../orchestrator'
 import { SapientSigner } from './signer'
 
 export class SignerWrapper implements SapientSigner {
-  constructor(
-    public signer: ethers.Signer,
-    public eoa: boolean = true
-  ) {}
+  constructor(public signer: ethers.Signer, public eoa: boolean = true) {}
 
   getAddress(): Promise<string> {
     return this.signer.getAddress()
@@ -21,7 +18,7 @@ export class SignerWrapper implements SapientSigner {
   async decorateTransactions(
     bundle: commons.transaction.IntendedTransactionBundle
   ): Promise<commons.transaction.IntendedTransactionBundle> {
-      return bundle
+    return bundle
   }
 
   async requestSignature(

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -13,9 +13,9 @@ export class SignerWrapper implements SapientSigner {
     return this.signer.getAddress()
   }
 
-  async buildDeployTransaction(): Promise<commons.transaction.TransactionBundle | null> {
+  async buildDeployTransaction(_metadata: Object): Promise<commons.transaction.TransactionBundle | undefined> {
     // Wrapped signers don't require deployment
-    return null
+    return
   }
 
   async decorateTransactions(

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -18,11 +18,10 @@ export class SignerWrapper implements SapientSigner {
     return
   }
 
-  async predecorateTransactions(
-    txs: commons.transaction.Transactionish,
+  async predecorateSignedTransactions(
     _metadata: Object
-  ): Promise<commons.transaction.Transactionish> {
-    return txs
+  ): Promise<commons.transaction.SignedTransactionBundle[]> {
+    return []
   }
 
   async decorateTransactions(

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+import { commons } from "@0xsequence/core"
 import { Status } from '../orchestrator'
 import { SapientSigner } from './signer'
 
@@ -10,6 +11,12 @@ export class SignerWrapper implements SapientSigner {
 
   getAddress(): Promise<string> {
     return this.signer.getAddress()
+  }
+
+  async decorateTransactions(
+    bundle: commons.transaction.IntendedTransactionBundle
+  ): Promise<commons.transaction.IntendedTransactionBundle> {
+      return bundle
   }
 
   async requestSignature(

--- a/packages/signhub/src/signers/wrapper.ts
+++ b/packages/signhub/src/signers/wrapper.ts
@@ -4,7 +4,10 @@ import { Status } from '../orchestrator'
 import { SapientSigner } from './signer'
 
 export class SignerWrapper implements SapientSigner {
-  constructor(public signer: ethers.Signer, public eoa: boolean = true) {}
+  constructor(
+    public signer: ethers.Signer,
+    public eoa: boolean = true
+  ) {}
 
   getAddress(): Promise<string> {
     return this.signer.getAddress()

--- a/packages/signhub/tests/orchestrator.spec.ts
+++ b/packages/signhub/tests/orchestrator.spec.ts
@@ -105,6 +105,11 @@ describe('Orchestrator', () => {
         buildDeployTransaction(metadata) {
           throw new Error('This is a broken signer.')
         },
+        async predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          throw new Error('This is a broken signer.')
+        },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
           metadata: Object
@@ -194,6 +199,11 @@ describe('Orchestrator', () => {
         buildDeployTransaction(metadata) {
           throw new Error('This is a reject signer.')
         },
+        async predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          throw new Error('This is a reject signer.')
+        },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
           metadata: Object
@@ -256,6 +266,11 @@ describe('Orchestrator', () => {
         buildDeployTransaction(metadata) {
           return Promise.resolve(undefined)
         },
+        predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return Promise.resolve([])
+        },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
           metadata: Object
@@ -296,6 +311,11 @@ describe('Orchestrator', () => {
         },
         buildDeployTransaction(metadata) {
           return Promise.resolve(undefined)
+        },
+        predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return Promise.resolve([])
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
@@ -342,6 +362,11 @@ describe('Orchestrator', () => {
         buildDeployTransaction(metadata) {
           return Promise.resolve(undefined)
         },
+        predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return Promise.resolve([])
+        },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
           metadata: Object
@@ -384,6 +409,11 @@ describe('Orchestrator', () => {
         },
         buildDeployTransaction(metadata) {
           return Promise.resolve(undefined)
+        },
+        predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return Promise.resolve([])
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
@@ -449,6 +479,11 @@ describe('Orchestrator', () => {
         },
         buildDeployTransaction(metadata) {
           return Promise.resolve(undefined)
+        },
+        predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return Promise.resolve([])
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
@@ -531,6 +566,11 @@ describe('Orchestrator', () => {
         async buildDeployTransaction(metadata: Object) {
           return undefined
         },
+        async predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return []
+        },
         async decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
           metadata: Object
@@ -593,6 +633,11 @@ describe('Orchestrator', () => {
             ]
           }
         },
+        async predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return []
+        },
         async decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle,
           metadata: Object
@@ -630,6 +675,11 @@ describe('Orchestrator', () => {
               }
             ]
           }
+        },
+        async predecorateSignedTransactions(
+          _metadata: Object
+        ): Promise<commons.transaction.SignedTransactionBundle[]> {
+          return []
         },
         async decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle

--- a/packages/signhub/tests/orchestrator.spec.ts
+++ b/packages/signhub/tests/orchestrator.spec.ts
@@ -1,5 +1,6 @@
 import * as chai from 'chai'
 import { ethers } from 'ethers'
+import { commons } from "@0xsequence/core"
 import { isSignerStatusPending, isSignerStatusRejected, isSignerStatusSigned, Orchestrator, Status } from '../src'
 import { SapientSigner } from '../src/signers'
 
@@ -100,6 +101,11 @@ describe('Orchestrator', () => {
       getAddress: async function (): Promise<string> {
         return brokenSignerEOA.address
       },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        throw new Error('This is a broken signer.')
+      },
       requestSignature: async function (
         id: string,
         message: ethers.utils.BytesLike,
@@ -180,6 +186,11 @@ describe('Orchestrator', () => {
       getAddress: async function (): Promise<string> {
         return rejectSignerEOA.address
       },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        throw new Error('This is a rejected signer.')
+      },
       requestSignature: async function (
         id: string,
         message: ethers.utils.BytesLike,
@@ -233,6 +244,11 @@ describe('Orchestrator', () => {
       getAddress: async function (): Promise<string> {
         return '0x1234'
       },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        return Promise.resolve(bundle)
+      },
       requestSignature: async function (
         id: string,
         message: ethers.utils.BytesLike,
@@ -264,6 +280,11 @@ describe('Orchestrator', () => {
     const signer: SapientSigner = {
       getAddress: async function (): Promise<string> {
         return '0x1234'
+      },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        return Promise.resolve(bundle)
       },
       requestSignature: async function (
         id: string,
@@ -301,6 +322,11 @@ describe('Orchestrator', () => {
       getAddress: async function (): Promise<string> {
         return '0x1234'
       },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        return Promise.resolve(bundle)
+      },
       requestSignature: async function (
         id: string,
         message: ethers.utils.BytesLike,
@@ -334,6 +360,11 @@ describe('Orchestrator', () => {
     const signer2: SapientSigner = {
       getAddress: async function (): Promise<string> {
         return '0x5678'
+      },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        return Promise.resolve(bundle)
       },
       requestSignature: async function (
         id: string,
@@ -390,6 +421,11 @@ describe('Orchestrator', () => {
     const signer: SapientSigner = {
       getAddress: async function (): Promise<string> {
         return '0x1234'
+      },
+      decorateTransactions(
+        bundle: commons.transaction.IntendedTransactionBundle,
+      ): Promise<commons.transaction.IntendedTransactionBundle> {
+        return Promise.resolve(bundle)
       },
       requestSignature: async function (
         id: string,

--- a/packages/signhub/tests/orchestrator.spec.ts
+++ b/packages/signhub/tests/orchestrator.spec.ts
@@ -106,7 +106,8 @@ describe('Orchestrator', () => {
           throw new Error('This is a broken signer.')
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           throw new Error('This is a broken signer.')
         },
@@ -194,7 +195,8 @@ describe('Orchestrator', () => {
           throw new Error('This is a reject signer.')
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           throw new Error('This is a rejected signer.')
         },
@@ -255,7 +257,8 @@ describe('Orchestrator', () => {
           return Promise.resolve(undefined)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -295,7 +298,8 @@ describe('Orchestrator', () => {
           return Promise.resolve(undefined)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -339,7 +343,8 @@ describe('Orchestrator', () => {
           return Promise.resolve(undefined)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -381,7 +386,8 @@ describe('Orchestrator', () => {
           return Promise.resolve(undefined)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -445,7 +451,8 @@ describe('Orchestrator', () => {
           return Promise.resolve(undefined)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -525,7 +532,8 @@ describe('Orchestrator', () => {
           return undefined
         },
         async decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           // Add a transaction on each call
           bundle.transactions.push({
@@ -586,7 +594,8 @@ describe('Orchestrator', () => {
           }
         },
         async decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle
+          bundle: commons.transaction.IntendedTransactionBundle,
+          metadata: Object
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return bundle
         },

--- a/packages/signhub/tests/orchestrator.spec.ts
+++ b/packages/signhub/tests/orchestrator.spec.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai'
 import { ethers } from 'ethers'
-import { commons } from "@0xsequence/core"
+import { commons } from '@0xsequence/core'
 import { isSignerStatusPending, isSignerStatusRejected, isSignerStatusSigned, Orchestrator, Status } from '../src'
 import { SapientSigner } from '../src/signers'
 
@@ -8,13 +8,8 @@ const { expect } = chai
 
 describe('Orchestrator', () => {
   describe('signMessage', () => {
-
     it('Should call all signers', async () => {
-      const signers = [
-        ethers.Wallet.createRandom(),
-        ethers.Wallet.createRandom(),
-        ethers.Wallet.createRandom()
-      ]
+      const signers = [ethers.Wallet.createRandom(), ethers.Wallet.createRandom(), ethers.Wallet.createRandom()]
 
       const orchestrator = new Orchestrator(signers)
       const signature = await orchestrator.signMessage({ message: '0x1234' })
@@ -27,11 +22,7 @@ describe('Orchestrator', () => {
     })
 
     it('Should call callback with status updates', async () => {
-      const signers = [
-        ethers.Wallet.createRandom(),
-        ethers.Wallet.createRandom(),
-        ethers.Wallet.createRandom()
-      ]
+      const signers = [ethers.Wallet.createRandom(), ethers.Wallet.createRandom(), ethers.Wallet.createRandom()]
 
       const orchestrator = new Orchestrator(signers)
 
@@ -115,7 +106,7 @@ describe('Orchestrator', () => {
           throw new Error('This is a broken signer.')
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           throw new Error('This is a broken signer.')
         },
@@ -123,26 +114,26 @@ describe('Orchestrator', () => {
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           throw new Error('This is a broken signer.')
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
-      const signers = [
-        ethers.Wallet.createRandom(),
-        brokenSigner,
-        ethers.Wallet.createRandom()
-      ]
+      const signers = [ethers.Wallet.createRandom(), brokenSigner, ethers.Wallet.createRandom()]
 
       const orchestrator = new Orchestrator(signers)
 
       let callbackCallsA = 0
-      orchestrator.subscribe(async (status) => {
+      orchestrator.subscribe(async status => {
         // Status should have all signers
         let numErrors = 0
         let numSignatures = 0
@@ -181,7 +172,7 @@ describe('Orchestrator', () => {
         const address = await signer.getAddress()
         const status = signature.signers[address]
 
-        if (address === await brokenSigner.getAddress()) {
+        if (address === (await brokenSigner.getAddress())) {
           if (isSignerStatusRejected(status)) {
             expect(status.error).to.contain('This is a broken signer.')
           } else {
@@ -203,7 +194,7 @@ describe('Orchestrator', () => {
           throw new Error('This is a reject signer.')
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           throw new Error('This is a rejected signer.')
         },
@@ -211,21 +202,22 @@ describe('Orchestrator', () => {
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           callbacks.onRejection('This is a rejected signer.')
           return true
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
-      const signers = [
-        ethers.Wallet.createRandom(),
-        rejectSigner
-      ]
+      const signers = [ethers.Wallet.createRandom(), rejectSigner]
 
       const orchestrator = new Orchestrator(signers)
 
@@ -241,7 +233,7 @@ describe('Orchestrator', () => {
         const address = await signer.getAddress()
         const status = signature.signers[address]
 
-        if (address === await rejectSigner.getAddress()) {
+        if (address === (await rejectSigner.getAddress())) {
           if (isSignerStatusRejected(status)) {
             expect(status.error).to.contain('This is a rejected signer.')
           } else {
@@ -263,7 +255,7 @@ describe('Orchestrator', () => {
           return Promise.resolve(null)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -271,7 +263,11 @@ describe('Orchestrator', () => {
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           expect(message).to.be.equal(ogMessage)
           callbacks.onSignature('0x5678')
@@ -279,7 +275,7 @@ describe('Orchestrator', () => {
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
@@ -299,7 +295,7 @@ describe('Orchestrator', () => {
           return Promise.resolve(null)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -307,7 +303,11 @@ describe('Orchestrator', () => {
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           expect(metadata).to.be.deep.equal({ test: 'test' })
           callbacks.onSignature('0x5678')
@@ -315,12 +315,12 @@ describe('Orchestrator', () => {
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
       const orchestrator = new Orchestrator([signer])
-      const signature = await orchestrator.signMessage({ message: ogMessage, metadata: { test: 'test' }})
+      const signature = await orchestrator.signMessage({ message: ogMessage, metadata: { test: 'test' } })
 
       expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
     })
@@ -339,7 +339,7 @@ describe('Orchestrator', () => {
           return Promise.resolve(null)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -347,7 +347,11 @@ describe('Orchestrator', () => {
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           expect(metadata).to.be.deep.equal({ test: 'test' })
           callbacks.onSignature('0x5678')
@@ -365,7 +369,7 @@ describe('Orchestrator', () => {
           }
         },
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
@@ -377,7 +381,7 @@ describe('Orchestrator', () => {
           return Promise.resolve(null)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -385,7 +389,11 @@ describe('Orchestrator', () => {
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           expect(metadata).to.be.deep.equal({ test: 'test' })
           callbacks.onSignature('0x9012')
@@ -403,7 +411,7 @@ describe('Orchestrator', () => {
           }
         },
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
@@ -437,7 +445,7 @@ describe('Orchestrator', () => {
           return Promise.resolve(null)
         },
         decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return Promise.resolve(bundle)
         },
@@ -446,8 +454,8 @@ describe('Orchestrator', () => {
           message: ethers.utils.BytesLike,
           metadata: any,
           callbacks: {
-            onSignature: (signature: ethers.utils.BytesLike) => void;
-            onRejection: (error: string) => void;
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
             onStatus: (situation: string) => void
           }
         ): Promise<boolean> {
@@ -465,14 +473,14 @@ describe('Orchestrator', () => {
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 2 ]
+          return [2]
         }
       }
 
       const orchestrator = new Orchestrator([signer], 'test')
-      const res1 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test1' }})
-      const res2 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test2' }})
-      const res3 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test3' }})
+      const res1 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test1' } })
+      const res2 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test2' } })
+      const res3 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test3' } })
 
       expect((res1.signers['0x1234'] as any).signature).to.be.equal('0x5678')
       expect((res2.signers['0x1234'] as any).signature).to.be.equal('0x5678')
@@ -517,25 +525,29 @@ describe('Orchestrator', () => {
           return null
         },
         async decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           // Add a transaction on each call
           bundle.transactions.push({
-            to: 'to',
+            to: 'to'
           })
           return bundle
         },
-        async requestSignature (
+        async requestSignature(
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           return true
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 0 ]
+          return [0]
         }
       }
 
@@ -543,11 +555,11 @@ describe('Orchestrator', () => {
       const bundle: commons.transaction.IntendedTransactionBundle = {
         intent: {
           id: '',
-          wallet: '',
+          wallet: ''
         },
         chainId: 0,
         transactions: [],
-        entrypoint: '',
+        entrypoint: ''
       }
 
       const output = await orchestrator.decorateTransactions(bundle)
@@ -565,28 +577,34 @@ describe('Orchestrator', () => {
         async buildDeployTransaction(metadata: Object) {
           return {
             entrypoint: 'entrypoint1',
-            transactions: [{
-              to: 'to1',
-              data: 'data1',
-            }]
+            transactions: [
+              {
+                to: 'to1',
+                data: 'data1'
+              }
+            ]
           }
         },
         async decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return bundle
         },
-        async requestSignature (
+        async requestSignature(
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           return true
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 0 ]
+          return [0]
         }
       }
       const signer2: SapientSigner = {
@@ -596,28 +614,34 @@ describe('Orchestrator', () => {
         async buildDeployTransaction(metadata: Object) {
           return {
             entrypoint: 'entrypoint2',
-            transactions: [{
-              to: 'to2',
-              data: 'data2',
-            }]
+            transactions: [
+              {
+                to: 'to2',
+                data: 'data2'
+              }
+            ]
           }
         },
         async decorateTransactions(
-          bundle: commons.transaction.IntendedTransactionBundle,
+          bundle: commons.transaction.IntendedTransactionBundle
         ): Promise<commons.transaction.IntendedTransactionBundle> {
           return bundle
         },
-        async requestSignature (
+        async requestSignature(
           id: string,
           message: ethers.utils.BytesLike,
           metadata: Object,
-          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void
+            onRejection: (error: string) => void
+            onStatus: (situation: string) => void
+          }
         ): Promise<boolean> {
           return true
         },
         notifyStatusChange: function (id: string, status: Status): void {},
         suffix: function () {
-          return [ 0 ]
+          return [0]
         }
       }
 

--- a/packages/signhub/tests/orchestrator.spec.ts
+++ b/packages/signhub/tests/orchestrator.spec.ts
@@ -7,489 +7,624 @@ import { SapientSigner } from '../src/signers'
 const { expect } = chai
 
 describe('Orchestrator', () => {
-  it('Should call all signers', async () => {
-    const signers = [ethers.Wallet.createRandom(), ethers.Wallet.createRandom(), ethers.Wallet.createRandom()]
+  describe('signMessage', () => {
 
-    const orchestrator = new Orchestrator(signers)
-    const signature = await orchestrator.signMessage({ message: '0x1234' })
+    it('Should call all signers', async () => {
+      const signers = [
+        ethers.Wallet.createRandom(),
+        ethers.Wallet.createRandom(),
+        ethers.Wallet.createRandom()
+      ]
 
-    expect(Object.keys(signature.signers)).to.have.lengthOf(signers.length)
+      const orchestrator = new Orchestrator(signers)
+      const signature = await orchestrator.signMessage({ message: '0x1234' })
 
-    for (const signer of signers) {
-      expect(signature.signers).to.have.property(signer.address)
-    }
-  })
-
-  it('Should call callback with status updates', async () => {
-    const signers = [ethers.Wallet.createRandom(), ethers.Wallet.createRandom(), ethers.Wallet.createRandom()]
-
-    const orchestrator = new Orchestrator(signers)
-
-    let callbackCallsA = 0
-    orchestrator.subscribe((status, metadata) => {
-      // Status should have all signers
-      let numErrors = 0
-      let numSignatures = 0
-      let numPending = 0
-      expect(Object.keys(status.signers)).to.have.lengthOf(signers.length, 'Should have all signers')
-      for (const signer of signers) {
-        expect(status.signers).to.have.property(signer.address)
-        const signerStatus = status.signers[signer.address]
-
-        if (isSignerStatusRejected(signerStatus)) {
-          numErrors++
-        }
-
-        if (isSignerStatusPending(signerStatus)) {
-          numPending++
-        }
-
-        if (isSignerStatusSigned(signerStatus)) {
-          numSignatures++
-        }
-      }
-
-      callbackCallsA++
-
-      expect(numErrors).to.be.equal(0, 'No errors should be present')
-      expect(numSignatures).to.be.equal(Math.max(callbackCallsA, 3), 'Should have max 3 signatures')
-      expect(numPending).to.be.equal(Math.min(signers.length - callbackCallsA, 0), 'Should have 0 pending')
-    })
-
-    let callbackCallsB = 0
-    await orchestrator.signMessage({
-      message: '0x1234',
-      callback: () => {
-        callbackCallsB++
-        return false
-      }
-    })
-
-    // 3 updates + 1 final
-    expect(callbackCallsA).to.be.equal(4)
-
-    // only the 3 updates
-    expect(callbackCallsB).to.be.equal(3)
-  })
-
-  it('getSigners should return all signers', async () => {
-    const signers = new Array(10).fill(0).map(() => ethers.Wallet.createRandom())
-    const orchestrator = new Orchestrator(signers)
-    const result = await orchestrator.getSigners()
-    expect(result).to.have.lengthOf(signers.length)
-    for (const signer of signers) {
-      expect(result).to.include(signer.address)
-    }
-  })
-
-  it('setSigners should update the signers', async () => {
-    const signers = new Array(10).fill(0).map(() => ethers.Wallet.createRandom())
-    const orchestrator = new Orchestrator(signers)
-
-    const newSigners = new Array(22).fill(0).map(() => ethers.Wallet.createRandom())
-    orchestrator.setSigners(newSigners)
-    const result = await orchestrator.getSigners()
-    expect(result).to.have.lengthOf(newSigners.length)
-    for (const signer of newSigners) {
-      expect(result).to.include(signer.address)
-    }
-  })
-
-  it('exception on signer should be interpreted as error', async () => {
-    const brokenSignerEOA = ethers.Wallet.createRandom()
-    const brokenSigner: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return brokenSignerEOA.address
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        throw new Error('This is a broken signer.')
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: Object,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        throw new Error('This is a broken signer.')
-      },
-      notifyStatusChange: function (id: string, status: Status): void {},
-      suffix: function () {
-        return [2]
-      }
-    }
-
-    const signers = [ethers.Wallet.createRandom(), brokenSigner, ethers.Wallet.createRandom()]
-
-    const orchestrator = new Orchestrator(signers)
-
-    let callbackCallsA = 0
-    orchestrator.subscribe(async status => {
-      // Status should have all signers
-      let numErrors = 0
-      let numSignatures = 0
-      let numPending = 0
-
-      expect(Object.keys(status.signers)).to.have.lengthOf(signers.length)
+      expect(Object.keys(signature.signers)).to.have.lengthOf(signers.length)
 
       for (const signer of signers) {
-        expect(status.signers).to.have.property(await signer.getAddress())
-        const signerStatus = status.signers[await signer.getAddress()]
-
-        if (isSignerStatusRejected(signerStatus)) {
-          numErrors++
-        }
-
-        if (isSignerStatusPending(signerStatus)) {
-          numPending++
-        }
-
-        if (isSignerStatusSigned(signerStatus)) {
-          numSignatures++
-        }
+        expect(signature.signers).to.have.property(signer.address)
       }
-
-      callbackCallsA++
-
-      expect(numErrors).to.be.equal(1)
-      expect(numSignatures).to.be.equal(Math.max(callbackCallsA, 3))
-      expect(numPending).to.be.equal(Math.min(signers.length - callbackCallsA, 0))
     })
 
-    const signature = await orchestrator.signMessage({ message: '0x1234' })
-    expect(Object.keys(signature.signers)).to.have.lengthOf(signers.length)
+    it('Should call callback with status updates', async () => {
+      const signers = [
+        ethers.Wallet.createRandom(),
+        ethers.Wallet.createRandom(),
+        ethers.Wallet.createRandom()
+      ]
 
-    for (const signer of signers) {
-      const address = await signer.getAddress()
-      const status = signature.signers[address]
+      const orchestrator = new Orchestrator(signers)
 
-      if (address === (await brokenSigner.getAddress())) {
-        if (isSignerStatusRejected(status)) {
-          expect(status.error).to.contain('This is a broken signer.')
-        } else {
-          expect.fail('Signer should be rejected')
-        }
-      } else {
-        expect(isSignerStatusSigned(status)).to.be.true
-      }
-    }
-  })
+      let callbackCallsA = 0
+      orchestrator.subscribe((status, metadata) => {
+        // Status should have all signers
+        let numErrors = 0
+        let numSignatures = 0
+        let numPending = 0
+        expect(Object.keys(status.signers)).to.have.lengthOf(signers.length, 'Should have all signers')
+        for (const signer of signers) {
+          expect(status.signers).to.have.property(signer.address)
+          const signerStatus = status.signers[signer.address]
 
-  it('Should manually reject a request', async () => {
-    const rejectSignerEOA = ethers.Wallet.createRandom()
-    const rejectSigner: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return rejectSignerEOA.address
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        throw new Error('This is a rejected signer.')
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: Object,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        callbacks.onRejection('This is a rejected signer.')
-        return true
-      },
-      notifyStatusChange: function (id: string, status: Status): void {},
-      suffix: function () {
-        return [2]
-      }
-    }
-
-    const signers = [ethers.Wallet.createRandom(), rejectSigner]
-
-    const orchestrator = new Orchestrator(signers)
-
-    let callbackCallsA = 0
-    orchestrator.subscribe(() => {
-      callbackCallsA++
-    })
-
-    const signature = await orchestrator.signMessage({ message: '0x1234' })
-    expect(Object.keys(signature.signers)).to.have.lengthOf(signers.length)
-
-    for (const signer of signers) {
-      const address = await signer.getAddress()
-      const status = signature.signers[address]
-
-      if (address === (await rejectSigner.getAddress())) {
-        if (isSignerStatusRejected(status)) {
-          expect(status.error).to.contain('This is a rejected signer.')
-        } else {
-          expect.fail('Signer should be rejected')
-        }
-      } else {
-        expect(isSignerStatusSigned(status)).to.be.true
-      }
-    }
-  })
-
-  it('Should pass the correct message to the signer', async () => {
-    const ogMessage = ethers.utils.randomBytes(99)
-    const signer: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return '0x1234'
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        return Promise.resolve(bundle)
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: Object,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        expect(message).to.be.equal(ogMessage)
-        callbacks.onSignature('0x5678')
-        return true
-      },
-      notifyStatusChange: function (id: string, status: Status): void {},
-      suffix: function () {
-        return [2]
-      }
-    }
-
-    const orchestrator = new Orchestrator([signer])
-    const signature = await orchestrator.signMessage({ message: ogMessage })
-
-    expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
-  })
-
-  it('Should pass metadata to signer', async () => {
-    const ogMessage = ethers.utils.randomBytes(99)
-    const signer: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return '0x1234'
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        return Promise.resolve(bundle)
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: Object,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        expect(metadata).to.be.deep.equal({ test: 'test' })
-        callbacks.onSignature('0x5678')
-        return true
-      },
-      notifyStatusChange: function (id: string, status: Status): void {},
-      suffix: function () {
-        return [2]
-      }
-    }
-
-    const orchestrator = new Orchestrator([signer])
-    const signature = await orchestrator.signMessage({ message: ogMessage, metadata: { test: 'test' } })
-
-    expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
-  })
-
-  it('Should pass updated metadata to signer', async () => {
-    const ogMessage = ethers.utils.randomBytes(99)
-
-    let firstCall = true
-    let errorOnNotify: any = undefined
-
-    const signer1: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return '0x1234'
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        return Promise.resolve(bundle)
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: Object,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        expect(metadata).to.be.deep.equal({ test: 'test' })
-        callbacks.onSignature('0x5678')
-        return true
-      },
-      notifyStatusChange: function (id: string, status: Status, metadata: Object): void {
-        try {
-          if (firstCall) {
-            expect(metadata).to.be.deep.equal({ test: 'test' })
-          } else {
-            expect(metadata).to.be.deep.equal({ hello: 'world' })
+          if (isSignerStatusRejected(signerStatus)) {
+            numErrors++
           }
-        } catch (e) {
-          errorOnNotify = e
-        }
-      },
-      suffix: function () {
-        return [2]
-      }
-    }
 
-    const signer2: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return '0x5678'
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        return Promise.resolve(bundle)
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: Object,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        expect(metadata).to.be.deep.equal({ test: 'test' })
-        callbacks.onSignature('0x9012')
-        return true
-      },
-      notifyStatusChange: function (id: string, status: Status, metadata: Object): void {
-        try {
-          if (firstCall) {
-            expect(metadata).to.be.deep.equal({ test: 'test' })
-          } else {
-            expect(metadata).to.be.deep.equal({ hello: 'world' })
+          if (isSignerStatusPending(signerStatus)) {
+            numPending++
           }
-        } catch (e) {
-          errorOnNotify = e
-        }
-      },
-      suffix: function () {
-        return [2]
-      }
-    }
 
-    const orchestrator = new Orchestrator([signer1, signer2])
-    const signature = await orchestrator.signMessage({
-      message: ogMessage,
-      metadata: { test: 'test' },
-      callback: (s: Status, onNewMetadata: (metadata: Object) => void) => {
-        if (firstCall) {
-          firstCall = false
-          onNewMetadata({ hello: 'world' })
+          if (isSignerStatusSigned(signerStatus)) {
+            numSignatures++
+          }
+        }
+
+        callbackCallsA++
+
+        expect(numErrors).to.be.equal(0, 'No errors should be present')
+        expect(numSignatures).to.be.equal(Math.max(callbackCallsA, 3), 'Should have max 3 signatures')
+        expect(numPending).to.be.equal(Math.min(signers.length - callbackCallsA, 0), 'Should have 0 pending')
+      })
+
+      let callbackCallsB = 0
+      await orchestrator.signMessage({
+        message: '0x1234',
+        callback: () => {
+          callbackCallsB++
           return false
         }
+      })
 
-        return true
+      // 3 updates + 1 final
+      expect(callbackCallsA).to.be.equal(4)
+
+      // only the 3 updates
+      expect(callbackCallsB).to.be.equal(3)
+    })
+
+    it('getSigners should return all signers', async () => {
+      const signers = new Array(10).fill(0).map(() => ethers.Wallet.createRandom())
+      const orchestrator = new Orchestrator(signers)
+      const result = await orchestrator.getSigners()
+      expect(result).to.have.lengthOf(signers.length)
+      for (const signer of signers) {
+        expect(result).to.include(signer.address)
       }
     })
 
-    expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
-    expect((signature.signers['0x5678'] as any).signature).to.be.equal('0x9012')
-    if (errorOnNotify) throw errorOnNotify
-  })
+    it('setSigners should update the signers', async () => {
+      const signers = new Array(10).fill(0).map(() => ethers.Wallet.createRandom())
+      const orchestrator = new Orchestrator(signers)
 
-  it('Should generate distinct and incremental ids', async () => {
-    const ogMessage = ethers.utils.randomBytes(99)
-    const signer: SapientSigner = {
-      getAddress: async function (): Promise<string> {
-        return '0x1234'
-      },
-      decorateTransactions(
-        bundle: commons.transaction.IntendedTransactionBundle,
-      ): Promise<commons.transaction.IntendedTransactionBundle> {
-        return Promise.resolve(bundle)
-      },
-      requestSignature: async function (
-        id: string,
-        message: ethers.utils.BytesLike,
-        metadata: any,
-        callbacks: {
-          onSignature: (signature: ethers.utils.BytesLike) => void
-          onRejection: (error: string) => void
-          onStatus: (situation: string) => void
-        }
-      ): Promise<boolean> {
-        if (metadata.tag === 'test1') {
-          expect(id).to.be.equal('test-0')
-        }
-        if (metadata.tag === 'test2') {
-          expect(id).to.be.equal('test-1')
-        }
-        if (metadata.tag === 'test3') {
-          expect(id).to.be.equal('test-2')
-        }
-        callbacks.onSignature('0x5678')
-        return true
-      },
-      notifyStatusChange: function (id: string, status: Status): void {},
-      suffix: function () {
-        return [2]
+      const newSigners = new Array(22).fill(0).map(() => ethers.Wallet.createRandom())
+      orchestrator.setSigners(newSigners)
+      const result = await orchestrator.getSigners()
+      expect(result).to.have.lengthOf(newSigners.length)
+      for (const signer of newSigners) {
+        expect(result).to.include(signer.address)
       }
-    }
-
-    const orchestrator = new Orchestrator([signer], 'test')
-    const res1 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test1' } })
-    const res2 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test2' } })
-    const res3 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test3' } })
-
-    expect((res1.signers['0x1234'] as any).signature).to.be.equal('0x5678')
-    expect((res2.signers['0x1234'] as any).signature).to.be.equal('0x5678')
-    expect((res3.signers['0x1234'] as any).signature).to.be.equal('0x5678')
-  })
-
-  it('Should auto-generate random tag', () => {
-    const orchestrator1 = new Orchestrator([])
-    const orchestrator2 = new Orchestrator([])
-
-    expect(orchestrator1.tag).to.not.be.equal(orchestrator2.tag)
-  })
-
-  it('Should only sign with candidates', async () => {
-    const message = ethers.utils.randomBytes(99)
-
-    const signer1 = ethers.Wallet.createRandom()
-    const signer2 = ethers.Wallet.createRandom()
-    const signer3 = ethers.Wallet.createRandom()
-    const signer4 = ethers.Wallet.createRandom()
-
-    const orchestrator = new Orchestrator([signer1, signer2, signer3, signer4])
-
-    const result = await orchestrator.signMessage({
-      message: message,
-      candidates: [signer1.address, signer3.address]
     })
 
-    expect(result.signers[signer1.address]).to.not.be.undefined
-    expect(result.signers[signer2.address]).to.be.undefined
-    expect(result.signers[signer3.address]).to.not.be.undefined
-    expect(result.signers[signer4.address]).to.be.undefined
+    it('exception on signer should be interpreted as error', async () => {
+      const brokenSignerEOA = ethers.Wallet.createRandom()
+      const brokenSigner: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return brokenSignerEOA.address
+        },
+        buildDeployTransaction(metadata) {
+          throw new Error('This is a broken signer.')
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          throw new Error('This is a broken signer.')
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          throw new Error('This is a broken signer.')
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const signers = [
+        ethers.Wallet.createRandom(),
+        brokenSigner,
+        ethers.Wallet.createRandom()
+      ]
+
+      const orchestrator = new Orchestrator(signers)
+
+      let callbackCallsA = 0
+      orchestrator.subscribe(async (status) => {
+        // Status should have all signers
+        let numErrors = 0
+        let numSignatures = 0
+        let numPending = 0
+
+        expect(Object.keys(status.signers)).to.have.lengthOf(signers.length)
+
+        for (const signer of signers) {
+          expect(status.signers).to.have.property(await signer.getAddress())
+          const signerStatus = status.signers[await signer.getAddress()]
+
+          if (isSignerStatusRejected(signerStatus)) {
+            numErrors++
+          }
+
+          if (isSignerStatusPending(signerStatus)) {
+            numPending++
+          }
+
+          if (isSignerStatusSigned(signerStatus)) {
+            numSignatures++
+          }
+        }
+
+        callbackCallsA++
+
+        expect(numErrors).to.be.equal(1)
+        expect(numSignatures).to.be.equal(Math.max(callbackCallsA, 3))
+        expect(numPending).to.be.equal(Math.min(signers.length - callbackCallsA, 0))
+      })
+
+      const signature = await orchestrator.signMessage({ message: '0x1234' })
+      expect(Object.keys(signature.signers)).to.have.lengthOf(signers.length)
+
+      for (const signer of signers) {
+        const address = await signer.getAddress()
+        const status = signature.signers[address]
+
+        if (address === await brokenSigner.getAddress()) {
+          if (isSignerStatusRejected(status)) {
+            expect(status.error).to.contain('This is a broken signer.')
+          } else {
+            expect.fail('Signer should be rejected')
+          }
+        } else {
+          expect(isSignerStatusSigned(status)).to.be.true
+        }
+      }
+    })
+
+    it('Should manually reject a request', async () => {
+      const rejectSignerEOA = ethers.Wallet.createRandom()
+      const rejectSigner: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return rejectSignerEOA.address
+        },
+        buildDeployTransaction(metadata) {
+          throw new Error('This is a reject signer.')
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          throw new Error('This is a rejected signer.')
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          callbacks.onRejection('This is a rejected signer.')
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const signers = [
+        ethers.Wallet.createRandom(),
+        rejectSigner
+      ]
+
+      const orchestrator = new Orchestrator(signers)
+
+      let callbackCallsA = 0
+      orchestrator.subscribe(() => {
+        callbackCallsA++
+      })
+
+      const signature = await orchestrator.signMessage({ message: '0x1234' })
+      expect(Object.keys(signature.signers)).to.have.lengthOf(signers.length)
+
+      for (const signer of signers) {
+        const address = await signer.getAddress()
+        const status = signature.signers[address]
+
+        if (address === await rejectSigner.getAddress()) {
+          if (isSignerStatusRejected(status)) {
+            expect(status.error).to.contain('This is a rejected signer.')
+          } else {
+            expect.fail('Signer should be rejected')
+          }
+        } else {
+          expect(isSignerStatusSigned(status)).to.be.true
+        }
+      }
+    })
+
+    it('Should pass the correct message to the signer', async () => {
+      const ogMessage = ethers.utils.randomBytes(99)
+      const signer: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x1234'
+        },
+        buildDeployTransaction(metadata) {
+          return Promise.resolve(null)
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return Promise.resolve(bundle)
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          expect(message).to.be.equal(ogMessage)
+          callbacks.onSignature('0x5678')
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const orchestrator = new Orchestrator([signer])
+      const signature = await orchestrator.signMessage({ message: ogMessage })
+
+      expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
+    })
+
+    it('Should pass metadata to signer', async () => {
+      const ogMessage = ethers.utils.randomBytes(99)
+      const signer: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x1234'
+        },
+        buildDeployTransaction(metadata) {
+          return Promise.resolve(null)
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return Promise.resolve(bundle)
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          expect(metadata).to.be.deep.equal({ test: 'test' })
+          callbacks.onSignature('0x5678')
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const orchestrator = new Orchestrator([signer])
+      const signature = await orchestrator.signMessage({ message: ogMessage, metadata: { test: 'test' }})
+
+      expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
+    })
+
+    it('Should pass updated metadata to signer', async () => {
+      const ogMessage = ethers.utils.randomBytes(99)
+
+      let firstCall = true
+      let errorOnNotify: any = undefined
+
+      const signer1: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x1234'
+        },
+        buildDeployTransaction(metadata) {
+          return Promise.resolve(null)
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return Promise.resolve(bundle)
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          expect(metadata).to.be.deep.equal({ test: 'test' })
+          callbacks.onSignature('0x5678')
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status, metadata: Object): void {
+          try {
+            if (firstCall) {
+              expect(metadata).to.be.deep.equal({ test: 'test' })
+            } else {
+              expect(metadata).to.be.deep.equal({ hello: 'world' })
+            }
+          } catch (e) {
+            errorOnNotify = e
+          }
+        },
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const signer2: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x5678'
+        },
+        buildDeployTransaction(metadata) {
+          return Promise.resolve(null)
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return Promise.resolve(bundle)
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          expect(metadata).to.be.deep.equal({ test: 'test' })
+          callbacks.onSignature('0x9012')
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status, metadata: Object): void {
+          try {
+            if (firstCall) {
+              expect(metadata).to.be.deep.equal({ test: 'test' })
+            } else {
+              expect(metadata).to.be.deep.equal({ hello: 'world' })
+            }
+          } catch (e) {
+            errorOnNotify = e
+          }
+        },
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const orchestrator = new Orchestrator([signer1, signer2])
+      const signature = await orchestrator.signMessage({
+        message: ogMessage,
+        metadata: { test: 'test' },
+        callback: (s: Status, onNewMetadata: (metadata: Object) => void) => {
+          if (firstCall) {
+            firstCall = false
+            onNewMetadata({ hello: 'world' })
+            return false
+          }
+
+          return true
+        }
+      })
+
+      expect((signature.signers['0x1234'] as any).signature).to.be.equal('0x5678')
+      expect((signature.signers['0x5678'] as any).signature).to.be.equal('0x9012')
+      if (errorOnNotify) throw errorOnNotify
+    })
+
+    it('Should generate distinct and incremental ids', async () => {
+      const ogMessage = ethers.utils.randomBytes(99)
+      const signer: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x1234'
+        },
+        buildDeployTransaction(metadata) {
+          return Promise.resolve(null)
+        },
+        decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return Promise.resolve(bundle)
+        },
+        requestSignature: async function (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: any,
+          callbacks: {
+            onSignature: (signature: ethers.utils.BytesLike) => void;
+            onRejection: (error: string) => void;
+            onStatus: (situation: string) => void
+          }
+        ): Promise<boolean> {
+          if (metadata.tag === 'test1') {
+            expect(id).to.be.equal('test-0')
+          }
+          if (metadata.tag === 'test2') {
+            expect(id).to.be.equal('test-1')
+          }
+          if (metadata.tag === 'test3') {
+            expect(id).to.be.equal('test-2')
+          }
+          callbacks.onSignature('0x5678')
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 2 ]
+        }
+      }
+
+      const orchestrator = new Orchestrator([signer], 'test')
+      const res1 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test1' }})
+      const res2 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test2' }})
+      const res3 = await orchestrator.signMessage({ message: ogMessage, metadata: { tag: 'test3' }})
+
+      expect((res1.signers['0x1234'] as any).signature).to.be.equal('0x5678')
+      expect((res2.signers['0x1234'] as any).signature).to.be.equal('0x5678')
+      expect((res3.signers['0x1234'] as any).signature).to.be.equal('0x5678')
+    })
+
+    it('Should auto-generate random tag', () => {
+      const orchestrator1 = new Orchestrator([])
+      const orchestrator2 = new Orchestrator([])
+
+      expect(orchestrator1.tag).to.not.be.equal(orchestrator2.tag)
+    })
+
+    it('Should only sign with candidates', async () => {
+      const message = ethers.utils.randomBytes(99)
+
+      const signer1 = ethers.Wallet.createRandom()
+      const signer2 = ethers.Wallet.createRandom()
+      const signer3 = ethers.Wallet.createRandom()
+      const signer4 = ethers.Wallet.createRandom()
+
+      const orchestrator = new Orchestrator([signer1, signer2, signer3, signer4])
+
+      const result = await orchestrator.signMessage({
+        message: message,
+        candidates: [signer1.address, signer3.address]
+      })
+
+      expect(result.signers[signer1.address]).to.not.be.undefined
+      expect(result.signers[signer2.address]).to.be.undefined
+      expect(result.signers[signer3.address]).to.not.be.undefined
+      expect(result.signers[signer4.address]).to.be.undefined
+    })
+  })
+  describe('decorateTransactions', () => {
+    it('Repeatedly decorate a bundle', async () => {
+      const signer: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x1'
+        },
+        async buildDeployTransaction(metadata: Object) {
+          return null
+        },
+        async decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          // Add a transaction on each call
+          bundle.transactions.push({
+            to: 'to',
+          })
+          return bundle
+        },
+        async requestSignature (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 0 ]
+        }
+      }
+
+      const orchestrator = new Orchestrator([signer, signer, signer])
+      const bundle: commons.transaction.IntendedTransactionBundle = {
+        intent: {
+          id: '',
+          wallet: '',
+        },
+        chainId: 0,
+        transactions: [],
+        entrypoint: '',
+      }
+
+      const output = await orchestrator.decorateTransactions(bundle)
+
+      expect(output?.transactions.length).to.be.equal(3)
+    })
+  })
+
+  describe('buildDeployTransaction', () => {
+    it('Should create a combined bundle', async () => {
+      const signer1: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x1'
+        },
+        async buildDeployTransaction(metadata: Object) {
+          return {
+            entrypoint: 'entrypoint1',
+            transactions: [{
+              to: 'to1',
+              data: 'data1',
+            }]
+          }
+        },
+        async decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return bundle
+        },
+        async requestSignature (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 0 ]
+        }
+      }
+      const signer2: SapientSigner = {
+        getAddress: async function (): Promise<string> {
+          return '0x2'
+        },
+        async buildDeployTransaction(metadata: Object) {
+          return {
+            entrypoint: 'entrypoint2',
+            transactions: [{
+              to: 'to2',
+              data: 'data2',
+            }]
+          }
+        },
+        async decorateTransactions(
+          bundle: commons.transaction.IntendedTransactionBundle,
+        ): Promise<commons.transaction.IntendedTransactionBundle> {
+          return bundle
+        },
+        async requestSignature (
+          id: string,
+          message: ethers.utils.BytesLike,
+          metadata: Object,
+          callbacks: { onSignature: (signature: ethers.utils.BytesLike) => void; onRejection: (error: string) => void; onStatus: (situation: string) => void }
+        ): Promise<boolean> {
+          return true
+        },
+        notifyStatusChange: function (id: string, status: Status): void {},
+        suffix: function () {
+          return [ 0 ]
+        }
+      }
+
+      const orchestrator = new Orchestrator([signer1, signer2])
+      const bundle = await orchestrator.buildDeployTransaction({})
+
+      expect(bundle?.transactions.length).to.be.equal(2)
+    })
   })
 })

--- a/packages/signhub/tests/orchestrator.spec.ts
+++ b/packages/signhub/tests/orchestrator.spec.ts
@@ -252,7 +252,7 @@ describe('Orchestrator', () => {
           return '0x1234'
         },
         buildDeployTransaction(metadata) {
-          return Promise.resolve(null)
+          return Promise.resolve(undefined)
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle
@@ -292,7 +292,7 @@ describe('Orchestrator', () => {
           return '0x1234'
         },
         buildDeployTransaction(metadata) {
-          return Promise.resolve(null)
+          return Promise.resolve(undefined)
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle
@@ -336,7 +336,7 @@ describe('Orchestrator', () => {
           return '0x1234'
         },
         buildDeployTransaction(metadata) {
-          return Promise.resolve(null)
+          return Promise.resolve(undefined)
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle
@@ -378,7 +378,7 @@ describe('Orchestrator', () => {
           return '0x5678'
         },
         buildDeployTransaction(metadata) {
-          return Promise.resolve(null)
+          return Promise.resolve(undefined)
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle
@@ -442,7 +442,7 @@ describe('Orchestrator', () => {
           return '0x1234'
         },
         buildDeployTransaction(metadata) {
-          return Promise.resolve(null)
+          return Promise.resolve(undefined)
         },
         decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle
@@ -522,7 +522,7 @@ describe('Orchestrator', () => {
           return '0x1'
         },
         async buildDeployTransaction(metadata: Object) {
-          return null
+          return undefined
         },
         async decorateTransactions(
           bundle: commons.transaction.IntendedTransactionBundle

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "pnpm test:concurrently 'pnpm test:run'",
     "test:run": "pnpm test:file tests/**/*.spec.ts",
-    "test:file": "NODE_OPTIONS='--loader tsx' mocha -timeout 30000",
+    "test:file": "NODE_OPTIONS='--loader tsx' mocha -timeout 300000",
     "test:concurrently": "concurrently -k --success first 'pnpm start:hardhat2 > /dev/null'",
     "start:hardhat2": "hardhat node --hostname 0.0.0.0 --port 7047 --config ./hardhat2.config.js",
     "typecheck": "tsc --noEmit"

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -16,12 +16,11 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
     return this.wallet.buildDeployTransaction(metadata as commons.WalletDeployMetadata | undefined)
   }
 
-  async predecorateTransactions(
-    txs: commons.transaction.Transactionish,
+  async predecorateSignedTransactions(
     _metadata: Object
-  ): Promise<commons.transaction.Transactionish> {
-    // Wallets don't predecorate
-    return txs
+  ): Promise<commons.transaction.SignedTransactionBundle[]> {
+    // Wallets do not predecorate as they have no off chain knowledge
+    return []
   }
 
   async decorateTransactions(

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -12,6 +12,11 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
     return this.wallet.address
   }
 
+  async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | null> {
+    const metadataOrEmpty = commons.isWalletDeployMetadata(metadata) ? metadata : undefined
+    return await this.wallet.buildDeployTransaction(metadataOrEmpty)
+  }
+
   async decorateTransactions(
     bundle: commons.transaction.IntendedTransactionBundle
   ): Promise<commons.transaction.IntendedTransactionBundle> {
@@ -34,7 +39,7 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
 
     // For Sequence nested signatures we must use `signDigest` and not `signMessage`
     // otherwise the wallet will hash the digest and the signature will be invalid.
-    callbacks.onSignature(await this.wallet.signDigest(message, { nested: metadata }))
+    callbacks.onSignature(await this.wallet.signDigest(message, { useEip6492: metadata.useEip6492, nested: metadata }))
 
     return true
   }

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -12,6 +12,12 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
     return this.wallet.address
   }
 
+  async decorateTransactions(
+    bundle: commons.transaction.IntendedTransactionBundle
+  ): Promise<commons.transaction.IntendedTransactionBundle> {
+    return this.wallet.decorateTransactions(bundle)
+  }
+
   async requestSignature(
     _id: string,
     message: ethers.utils.BytesLike,

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -13,8 +13,7 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
   }
 
   async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | null> {
-    const metadataOrEmpty = commons.isWalletDeployMetadata(metadata) ? metadata : undefined
-    return await this.wallet.buildDeployTransaction(metadataOrEmpty)
+    return await this.wallet.buildDeployTransaction(metadata as commons.WalletDeployMetadata | undefined)
   }
 
   async decorateTransactions(

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -16,8 +16,17 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
     return this.wallet.buildDeployTransaction(metadata as commons.WalletDeployMetadata | undefined)
   }
 
+  async predecorateTransactions(
+    txs: commons.transaction.Transactionish,
+    _metadata: Object
+  ): Promise<commons.transaction.Transactionish> {
+    // Wallets don't predecorate
+    return txs
+  }
+
   async decorateTransactions(
-    bundle: commons.transaction.IntendedTransactionBundle
+    bundle: commons.transaction.IntendedTransactionBundle,
+    _metadata: Object,
   ): Promise<commons.transaction.IntendedTransactionBundle> {
     return this.wallet.decorateTransactions(bundle)
   }

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -38,7 +38,7 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
 
     // For Sequence nested signatures we must use `signDigest` and not `signMessage`
     // otherwise the wallet will hash the digest and the signature will be invalid.
-    callbacks.onSignature(await this.wallet.signDigest(message, { useEip6492: metadata.useEip6492, nested: metadata }))
+    callbacks.onSignature(await this.wallet.signDigest(message, { nested: metadata }))
 
     return true
   }

--- a/packages/wallet/src/orchestrator/wrapper.ts
+++ b/packages/wallet/src/orchestrator/wrapper.ts
@@ -12,8 +12,8 @@ export class SequenceOrchestratorWrapper implements signers.SapientSigner {
     return this.wallet.address
   }
 
-  async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | null> {
-    return await this.wallet.buildDeployTransaction(metadata as commons.WalletDeployMetadata | undefined)
+  async buildDeployTransaction(metadata: Object): Promise<commons.transaction.TransactionBundle | undefined> {
+    return this.wallet.buildDeployTransaction(metadata as commons.WalletDeployMetadata | undefined)
   }
 
   async decorateTransactions(

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -55,10 +55,7 @@ export type WalletV1 = Wallet<v1.config.WalletConfig, v1.signature.Signature, v1
  * it doesn't have any knowledge of any on-chain state, instead it relies solely on the information
  * provided by the user. This building block is used to create higher level abstractions.
  *
- * Wallet can also be used to create Sequence wallets, but it's not recommended to use it directly
- *
- * @notice: TODO: This class is meant to replace the one in ../wallet.ts !!!
- *
+ * Wallet can also be used to create Sequence wallets, but it's not recommended to use it directly.
  */
 export class Wallet<
   Y extends commons.config.Config = commons.config.Config,

--- a/packages/wallet/tests/wallet.spec.ts
+++ b/packages/wallet/tests/wallet.spec.ts
@@ -103,7 +103,7 @@ describe('Wallet (primitive)', () => {
         await wallet.deploy({ includeChildren: true, ignoreDeployed: true })
         expect(await wallet.reader().isDeployed(wallet.address)).to.be.true
         expect(await nestedWallet.reader().isDeployed(wallet.address)).to.be.true
-      });
+      })
 
       //
       // Run tests using different combinations of signers
@@ -324,7 +324,7 @@ describe('Wallet (primitive)', () => {
             const digest = ethers.utils.keccak256(message)
 
             expect(await wallet.reader().isValidSignature(wallet.address, digest, signature)).to.be.true
-          });
+          })
 
           //
           // Run tests for deployed and undeployed wallets

--- a/packages/wallet/tests/wallet.spec.ts
+++ b/packages/wallet/tests/wallet.spec.ts
@@ -303,29 +303,6 @@ describe('Wallet (primitive)', () => {
             })
           }
 
-          it('Should sign and validate a message using EIP6492', async () => {
-            const wallet = Wallet.newWallet({
-              coders: coders,
-              context: contexts[version],
-              config,
-              orchestrator,
-              chainId: provider.network.chainId,
-              provider,
-              relayer
-            })
-
-            expect(await wallet.reader().isDeployed(wallet.address)).to.be.false
-
-            const message = ethers.utils.toUtf8Bytes(
-              `This is a random message: ${ethers.utils.hexlify(ethers.utils.randomBytes(96))}`
-            )
-
-            const signature = await wallet.signMessage(message, { useEip6492: true })
-            const digest = ethers.utils.keccak256(message)
-
-            expect(await wallet.reader().isValidSignature(wallet.address, digest, signature)).to.be.true
-          })
-
           //
           // Run tests for deployed and undeployed wallets
           // transactions should be decorated automatically

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,6 +652,9 @@ importers:
 
   packages/signhub:
     dependencies:
+      '@0xsequence/core':
+        specifier: workspace:*
+        version: link:../core
       ethers:
         specifier: ^5.5.2
         version: 5.7.2


### PR DESCRIPTION
* Adds orchestrator capability for accounts
* Child wallets and accounts can decorate transactions (deployments)
* Adds predecoration for child accounts (config updates)
* Can request deployment transactions through orchestrator
* Account's `sendSignedTransaction` can bundle multiple signed transactions
* Regression: `account.sendTransaction([], ...)` will now return undefined when nothing to send