### PR TITLE
Add support for onchain signatures

### DIFF
--- a/packages/abi/src/wallet/mainModule.ts
+++ b/packages/abi/src/wallet/mainModule.ts
@@ -136,5 +136,23 @@ export const abi = [
     ],
     payable: true,
     stateMutability: 'payable'
+  },
+  {
+    type: 'function',
+    name: 'setExtraImageHash',
+    constant: false,
+    inputs: [
+      {
+        type: 'bytes32',
+        name: 'imageHash'
+      },
+      {
+        type: 'uint256',
+        name: 'expiration'
+      }
+    ],
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable'
   }
 ]

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "nyc pnpm test"
   },
   "dependencies": {
+    "@0xsequence/abi": "workspace:*",
     "@0xsequence/core": "workspace:*",
     "@0xsequence/migration": "workspace:*",
     "@0xsequence/network": "workspace:*",

--- a/packages/core/src/commons/config.ts
+++ b/packages/core/src/commons/config.ts
@@ -12,6 +12,7 @@ export type SimpleConfig = {
   threshold: ethers.BigNumberish
   checkpoint: ethers.BigNumberish
   signers: SimpleSigner[]
+  subdigests?: string[]
 }
 
 export interface ConfigCoder<T extends Config = Config> {

--- a/packages/core/src/v1/config.ts
+++ b/packages/core/src/v1/config.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { walletContracts } from '@0xsequence/abi'
 import { commons } from '..'
 import { encodeSigners } from './signature'
+import { SimpleConfig } from '../commons/config'
 
 export type AddressMember = {
   weight: ethers.BigNumberish
@@ -49,13 +50,13 @@ export const ConfigCoder: commons.config.ConfigCoder<WalletConfig> = {
     return config.signers.map(s => ({ address: s.address, weight: ethers.BigNumber.from(s.weight).toNumber() }))
   },
 
-  fromSimple: (config: {
-    threshold: ethers.BigNumberish
-    checkpoint: ethers.BigNumberish
-    signers: { address: string; weight: ethers.BigNumberish }[]
-  }): WalletConfig => {
+  fromSimple: (config: SimpleConfig): WalletConfig => {
     if (!ethers.constants.Zero.eq(config.checkpoint)) {
       throw new Error('v1 wallet config does not support checkpoint')
+    }
+
+    if (config.subdigests && config.subdigests.length > 0) {
+      throw new Error('v1 wallet config does not support subdigests')
     }
 
     return {

--- a/packages/core/src/v2/config.ts
+++ b/packages/core/src/v2/config.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { walletContracts } from '@0xsequence/abi'
 import { commons } from '..'
 import { encodeSigners } from './signature'
+import { SimpleConfig } from '../commons/config'
 
 //
 // Tree typings - leaves
@@ -434,20 +435,10 @@ export const ConfigCoder: commons.config.ConfigCoder<WalletConfig> = {
     return signersOf(config.tree)
   },
 
-  fromSimple: (config: {
-    threshold: ethers.BigNumberish
-    checkpoint: ethers.BigNumberish
-    signers: { address: string; weight: ethers.BigNumberish }[]
-  }): WalletConfig => {
+  fromSimple: (config: SimpleConfig): WalletConfig => {
     return toWalletConfig({
-      threshold: config.threshold,
-      checkpoint: config.checkpoint,
-      members: config.signers.map(signer => {
-        return {
-          address: signer.address,
-          weight: signer.weight
-        }
-      })
+      ...config,
+      members: [...config.signers, ...(config.subdigests ?? []).map(subdigest => ({ subdigest }))]
     })
   },
 

--- a/packages/core/src/v2/signature.ts
+++ b/packages/core/src/v2/signature.ts
@@ -438,7 +438,7 @@ export function encodeTree(
   if (isSubdigestLeaf(topology)) {
     const include = subdigests.includes(topology.subdigest)
     return {
-      encoded: partEncoder.node(hashNode(topology)),
+      encoded: partEncoder.subdigest(topology.subdigest),
       weight: include ? ethers.constants.MaxUint256 : ethers.constants.Zero
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
 
   packages/account:
     dependencies:
+      '@0xsequence/abi':
+        specifier: workspace:*
+        version: link:../abi
       '@0xsequence/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Adds support for on-chain signatures by using an extra image hash with a single static subdigest.

Changes:
- Fixed simple config from subdigest support.
- Implemented `buildOnchainSignature` function in the account module.
- Updated wallet contract ABI and gas limit configurations to support new signature method.

This update aims to provide a solution for the problem of OpenSea (and other marketplaces) orders becoming invalid after configuration changes.