### PR TITLE
Update the newNetworks filter statement to return a boolean

### DIFF
--- a/packages/provider/src/init.ts
+++ b/packages/provider/src/init.ts
@@ -90,7 +90,7 @@ export const initWallet = (projectAccessKey: string, partialConfig?: Partial<Pro
   // Find any new networks that aren't already defined in sequence.js
   // and add them to the list of networks, (they must have a rpcUrl and chainId)
   const newNetworks = (config.networks?.filter(n => {
-    n.rpcUrl !== undefined && n.chainId !== undefined && !allNetworks.find(an => an.chainId === n.chainId)
+    return n.rpcUrl !== undefined && n.chainId !== undefined && !allNetworks.find(an => an.chainId === n.chainId)
   }) ?? []) as NetworkConfig[]
 
   // Override any information about the networks using the config


### PR DESCRIPTION
`newNetworks` will always be `[]` without this