### PR TITLE
No longer expose test environment Hardhat ChainIds and NetworkConfigs

### DIFF
--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -175,25 +175,25 @@ export const allNetworks = validateAndSortNetworks([
   {
     ...networks[ChainId.TELOS],
     ...genUrls('telos')
-  },
-  {
-    ...networks[ChainId.HARDHAT],
-    rpcUrl: 'http://localhost:8545',
-    relayer: {
-      url: 'http://localhost:3000',
-      provider: {
-        url: 'http://localhost:8545'
-      }
-    }
-  },
-  {
-    ...networks[ChainId.HARDHAT_2],
-    rpcUrl: 'http://localhost:9545',
-    relayer: {
-      url: 'http://localhost:3000',
-      provider: {
-        url: 'http://localhost:9545'
-      }
-    }
   }
+  // {
+  //   ...networks[ChainId.HARDHAT],
+  //   rpcUrl: 'http://localhost:8545',
+  //   relayer: {
+  //     url: 'http://localhost:3000',
+  //     provider: {
+  //       url: 'http://localhost:8545'
+  //     }
+  //   }
+  // },
+  // {
+  //   ...networks[ChainId.HARDHAT_2],
+  //   rpcUrl: 'http://localhost:9545',
+  //   relayer: {
+  //     url: 'http://localhost:3000',
+  //     provider: {
+  //       url: 'http://localhost:9545'
+  //     }
+  //   }
+  // }
 ])

--- a/packages/network/src/constants.ts
+++ b/packages/network/src/constants.ts
@@ -59,11 +59,11 @@ export enum ChainId {
   XR_SEPOLIA = 2730,
 
   // TELOS
-  TELOS = 40,
+  TELOS = 40
 
   // HARDHAT TESTNETS
-  HARDHAT = 31337,
-  HARDHAT_2 = 31338
+  // HARDHAT = 31337,
+  // HARDHAT_2 = 31338
 }
 
 export enum NetworkType {
@@ -672,26 +672,26 @@ export const networks: Record<ChainId, NetworkMetadata> = {
       name: 'TLOS',
       decimals: 18
     }
-  },
-
-  [ChainId.HARDHAT]: {
-    chainId: ChainId.HARDHAT,
-    name: 'hardhat',
-    title: 'Hardhat (local testnet)',
-    nativeToken: {
-      symbol: 'ETH',
-      name: 'Ether',
-      decimals: 18
-    }
-  },
-  [ChainId.HARDHAT_2]: {
-    chainId: ChainId.HARDHAT_2,
-    name: 'hardhat2',
-    title: 'Hardhat (local testnet)',
-    nativeToken: {
-      symbol: 'ETH',
-      name: 'Ether',
-      decimals: 18
-    }
   }
+
+  // [ChainId.HARDHAT]: {
+  //   chainId: ChainId.HARDHAT,
+  //   name: 'hardhat',
+  //   title: 'Hardhat (local testnet)',
+  //   nativeToken: {
+  //     symbol: 'ETH',
+  //     name: 'Ether',
+  //     decimals: 18
+  //   }
+  // },
+  // [ChainId.HARDHAT_2]: {
+  //   chainId: ChainId.HARDHAT_2,
+  //   name: 'hardhat2',
+  //   title: 'Hardhat (local testnet)',
+  //   nativeToken: {
+  //     symbol: 'ETH',
+  //     name: 'Ether',
+  //     decimals: 18
+  //   }
+  // }
 }


### PR DESCRIPTION
We currently expose `ChainId.HARDHAT` and `ChainId.HARDHAT_2` chainIds as well as their associated NetworkMetadata and NetworkConfigs.

This is confusing for users who import the `allNetworks` constant and see these local test configs.

We should only be adding these configurations in our test suite. 