### PR TITLE
Add extractProjectIdFromAccessKey in utils

### DIFF
--- a/packages/utils/src/access-key.ts
+++ b/packages/utils/src/access-key.ts
@@ -1,0 +1,23 @@
+export const extractProjectIdFromAccessKey = (accessKey: string): number => {
+    // Convert URL-safe base64 string to standard base64 string
+    const base64String = accessKey.replace(/-/g, '+').replace(/_/g, '/');
+    // Decode the base64 string to a binary string
+    const binaryString = atob(base64String);
+
+    // Convert the binary string to a byte array (Uint8Array)
+    const byteArray = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+        byteArray[i] = binaryString.charCodeAt(i);
+    }
+
+    if (byteArray[0] !== 1) {
+        throw new Error('UnsupportedVersion');
+    }
+
+    // Extract the project ID from bytes 2 to 9 (8 bytes)
+    const projectIdBytes = byteArray.slice(1, 9);
+    const projectId = projectIdBytes[7] | projectIdBytes[6]<<8 | projectIdBytes[5]<<16 | projectIdBytes[4]<<24 |
+        projectIdBytes[3]<<32 | projectIdBytes[2]<<40 | projectIdBytes[1]<<48 | projectIdBytes[0]<<56;
+
+    return projectId;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './access-key'
 export * from './base64'
 export * from './big-number'
 export * from './digest'

--- a/packages/utils/tests/access-key.spec.ts
+++ b/packages/utils/tests/access-key.spec.ts
@@ -1,0 +1,11 @@
+import { expect } from 'chai'
+import { extractProjectIdFromAccessKey } from '@0xsequence/utils'
+
+describe('access-key', function () {
+  it('extractProjectIdFromAccessKey', () => {
+    const accessKey = 'AQAAAAAAADVH8R2AGuQhwQ1y8NaEf1T7PJM'
+
+    const projectId = extractProjectIdFromAccessKey(accessKey)
+    expect(projectId).to.equal(13639)
+  })
+})


### PR DESCRIPTION
Add a new util method `extractProjectIdFromAccessKey` for easily extracting the Sequence Project ID from a provided Access Key.