### PR TITLE
Don't stash globalThis.fetch as it conflicts with mocking in test environments

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,8 +2,6 @@ export * from './api.gen'
 
 import { API as ApiRpc } from './api.gen'
 
-const fetch = globalThis.fetch
-
 export class SequenceAPIClient extends ApiRpc {
   constructor(
     hostname: string,

--- a/packages/guard/src/signer.ts
+++ b/packages/guard/src/signer.ts
@@ -5,8 +5,6 @@ import { encodeTypedDataDigest, TypedData } from '@0xsequence/utils'
 import { ethers } from 'ethers'
 import { AuthMethodsReturn, Guard, RecoveryCode as GuardRecoveryCode } from './guard.gen'
 
-const fetch = globalThis.fetch
-
 export class GuardSigner implements signers.SapientSigner {
   private guard: Guard
 

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -2,8 +2,6 @@ export * from './indexer.gen'
 
 import { Indexer as IndexerRpc } from './indexer.gen'
 
-const fetch = globalThis.fetch
-
 export class SequenceIndexer extends IndexerRpc {
   constructor(
     hostname: string,

--- a/packages/marketplace/src/index.ts
+++ b/packages/marketplace/src/index.ts
@@ -2,8 +2,6 @@ export * from './marketplace.gen'
 
 import { Marketplace as MarketplaceRpc } from './marketplace.gen'
 
-const fetch = globalThis.fetch
-
 export class MarketplaceIndexer extends MarketplaceRpc {
   constructor(
     hostname: string,

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -2,8 +2,6 @@ export * from './metadata.gen'
 
 import { Metadata as MetadataRpc, Collections as CollectionsRpc } from './metadata.gen'
 
-const fetch = globalThis.fetch
-
 export class SequenceMetadata extends MetadataRpc {
   constructor(
     hostname: string = 'https://metadata.sequence.app',

--- a/packages/relayer/src/rpc-relayer/index.ts
+++ b/packages/relayer/src/rpc-relayer/index.ts
@@ -26,8 +26,6 @@ export function isRpcRelayerOptions(obj: any): obj is RpcRelayerOptions {
   return obj.url !== undefined && typeof obj.url === 'string' && obj.provider !== undefined && isAbstractProvider(obj.provider)
 }
 
-const fetch = globalThis.fetch
-
 // TODO: rename to SequenceRelayer
 export class RpcRelayer implements Relayer {
   private readonly service: proto.Relayer

--- a/packages/waas/src/auth.ts
+++ b/packages/waas/src/auth.ts
@@ -131,8 +131,6 @@ export function defaultArgsOrFail(
   return preconfig as Required<SequenceConfig> & Required<WaaSConfigKey> & ExtendedSequenceConfig
 }
 
-const fetch = globalThis.fetch
-
 const jwksDev = {
   keys: [
     {
@@ -868,7 +866,7 @@ export class SequenceWaaS {
 
   // Special version of fetch that keeps track of the last seen Date header
   async fetch(input: RequestInfo, init?: RequestInit) {
-    const res = await globalThis.fetch(input, init)
+    const res = await fetch(input, init)
     const headerValue = res.headers.get('date')
     if (headerValue) {
       this.lastDate = new Date(headerValue)


### PR DESCRIPTION
Initially we were using the cross-fetch npm package to support fetch in both browser and node.

Then we switched to this logic which attempts to use global.fetch (the node env) if global exists:

`const fetch = typeof global === 'object' ? global.fetch : window.fetch`

Then finally we switched to: 

`const fetch = globalThis.fetch`

which is redundant since calling fetch is essentially just calling (globalThis.)fetch but by setting a fetch constant it had the side effect of stashing the fetch function locally. Stashing the fetch was never the intention/desire but the side effect is that we can no longer mock fetch calls within a testing environment