### PR TITLE
Updating initWallet to use connected network configs if they exist

### DIFF
--- a/packages/provider/src/client.ts
+++ b/packages/provider/src/client.ts
@@ -54,10 +54,14 @@ export class SequenceClientSession {
   }
 
   getSession(): WalletSession | undefined {
-    const session = this.store.getItem(SequenceClientSession.SESSION_LOCALSTORE_KEY)
+    try {
+      const session = this.store.getItem(SequenceClientSession.SESSION_LOCALSTORE_KEY)
 
-    if (session) {
-      return JSON.parse(session)
+      if (session) {
+        return JSON.parse(session)
+      }
+    } catch (err) {
+      console.error('Error parsing session', err)
     }
 
     return undefined


### PR DESCRIPTION
Previously dapp side would just use the default network config which pointed to production rpcUrls, etc. So there was a disconnect between the what the specified wallet was using and the dapp, so a dev project access key that would work on wallet side would not work on the dapp side production services. 

This corrects it by making sure to merge in the connected sessions network config when returning providers 