### PR TITLE
Add immutable wallet proxy hook

### DIFF
--- a/packages/abi/src/wallet/index.ts
+++ b/packages/abi/src/wallet/index.ts
@@ -4,8 +4,10 @@ import * as erc6492 from './erc6492'
 import * as factory from './factory'
 import * as mainModule from './mainModule'
 import * as mainModuleUpgradable from './mainModuleUpgradable'
+import * as moduleHooks from './moduleHooks'
 import * as sequenceUtils from './sequenceUtils'
 import * as requireFreshSigner from './libs/requireFreshSigners'
+import * as walletProxyHook from './walletProxyHook'
 
 export const walletContracts = {
   erc6492,
@@ -14,6 +16,8 @@ export const walletContracts = {
   factory,
   mainModule,
   mainModuleUpgradable,
+  moduleHooks,
   sequenceUtils,
-  requireFreshSigner
+  requireFreshSigner,
+  walletProxyHook
 }

--- a/packages/abi/src/wallet/moduleHooks.ts
+++ b/packages/abi/src/wallet/moduleHooks.ts
@@ -1,0 +1,248 @@
+export const abi = [
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: '_signature',
+        type: 'bytes4'
+      }
+    ],
+    name: 'HookAlreadyExists',
+    type: 'error'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: '_signature',
+        type: 'bytes4'
+      }
+    ],
+    name: 'HookDoesNotExist',
+    type: 'error'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_sender',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: '_self',
+        type: 'address'
+      }
+    ],
+    name: 'OnlySelfAuth',
+    type: 'error'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes4',
+        name: '_signature',
+        type: 'bytes4'
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: '_implementation',
+        type: 'address'
+      }
+    ],
+    name: 'DefinedHook',
+    type: 'event'
+  },
+  {
+    stateMutability: 'payable',
+    type: 'fallback'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: '_signature',
+        type: 'bytes4'
+      },
+      {
+        internalType: 'address',
+        name: '_implementation',
+        type: 'address'
+      }
+    ],
+    name: 'addHook',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256[]',
+        name: '',
+        type: 'uint256[]'
+      },
+      {
+        internalType: 'uint256[]',
+        name: '',
+        type: 'uint256[]'
+      },
+      {
+        internalType: 'bytes',
+        name: '',
+        type: 'bytes'
+      }
+    ],
+    name: 'onERC1155BatchReceived',
+    outputs: [
+      {
+        internalType: 'bytes4',
+        name: '',
+        type: 'bytes4'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      },
+      {
+        internalType: 'bytes',
+        name: '',
+        type: 'bytes'
+      }
+    ],
+    name: 'onERC1155Received',
+    outputs: [
+      {
+        internalType: 'bytes4',
+        name: '',
+        type: 'bytes4'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      },
+      {
+        internalType: 'bytes',
+        name: '',
+        type: 'bytes'
+      }
+    ],
+    name: 'onERC721Received',
+    outputs: [
+      {
+        internalType: 'bytes4',
+        name: '',
+        type: 'bytes4'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: '_signature',
+        type: 'bytes4'
+      }
+    ],
+    name: 'readHook',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: '_signature',
+        type: 'bytes4'
+      }
+    ],
+    name: 'removeHook',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: '_interfaceID',
+        type: 'bytes4'
+      }
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'pure',
+    type: 'function'
+  },
+  {
+    stateMutability: 'payable',
+    type: 'receive'
+  }
+] as const

--- a/packages/abi/src/wallet/walletProxyHook.ts
+++ b/packages/abi/src/wallet/walletProxyHook.ts
@@ -1,0 +1,9 @@
+export const abi = [
+  {
+    type: 'function',
+    name: 'PROXY_getImplementation',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view'
+  }
+] as const

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -413,7 +413,8 @@ export class Account {
     }
 
     // On immutable chains, we add the WalletProxyHook
-    if (chainId === ChainId.IMMUTABLE_ZKEVM || chainId === ChainId.IMMUTABLE_ZKEVM_TESTNET) {
+    const { proxyImplementationHook } = this.contexts[status.config.version]
+    if (proxyImplementationHook && (chainId === ChainId.IMMUTABLE_ZKEVM || chainId === ChainId.IMMUTABLE_ZKEVM_TESTNET)) {
       const provider = this.providerFor(chainId)
       if (provider) {
         const hook = new ethers.Contract(this.address, walletContracts.walletProxyHook.abi, provider)
@@ -431,7 +432,7 @@ export class Account {
             to: this.address,
             data: hooksInterface.encodeFunctionData(hooksInterface.getFunction('addHook')!, [
               '0x90611127',
-              '0x1f56dbAD5e8319F0DE9a323E24A31b5077dEB1a4'
+              proxyImplementationHook,
             ]),
             gasLimit: 50000, // Expected ~28k gas. Buffer added
             delegateCall: false,

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -402,13 +402,45 @@ export class Account {
     status: AccountStatus,
     chainId: ethers.BigNumberish
   ): Promise<commons.transaction.Transactionish> {
+    txs = Array.isArray(txs) ? txs : [txs]
     // if onchain wallet config is not up to date
     // then we should append an extra transaction that updates it
     // to the latest "lazy" state
     if (status.onChain.imageHash !== status.imageHash) {
       const wallet = this.walletForStatus(chainId, status)
       const updateConfig = await wallet.buildUpdateConfigurationTransaction(status.config)
-      return [Array.isArray(txs) ? txs : [txs], updateConfig.transactions].flat()
+      txs = [...txs, ...updateConfig.transactions]
+    }
+
+    // On immutable chains, we add the WalletProxyHook
+    if (chainId === ChainId.IMMUTABLE_ZKEVM || chainId === ChainId.IMMUTABLE_ZKEVM_TESTNET) {
+      const provider = this.providerFor(chainId)
+      if (provider) {
+        const hook = new ethers.Contract(this.address, walletContracts.walletProxyHook.abi, provider)
+        let implementation
+        try {
+          implementation = await hook.PROXY_getImplementation()
+        } catch (e) {
+          // Handle below
+          console.log('Error getting implementation address', e)
+        }
+        if (!implementation || implementation === ethers.ZeroAddress) {
+          console.log('Adding wallet proxy hook')
+          const hooksInterface = new ethers.Interface(walletContracts.moduleHooks.abi)
+          const tx: commons.transaction.Transaction = {
+            to: this.address,
+            data: hooksInterface.encodeFunctionData(hooksInterface.getFunction('addHook')!, [
+              '0x90611127',
+              '0x1f56dbAD5e8319F0DE9a323E24A31b5077dEB1a4'
+            ]),
+            gasLimit: 50000, // Expected ~28k gas. Buffer added
+            delegateCall: false,
+            revertOnError: false,
+            value: 0
+          }
+          txs = [tx, ...txs]
+        }
+      }
     }
 
     return txs

--- a/packages/core/src/commons/context.ts
+++ b/packages/core/src/commons/context.ts
@@ -12,6 +12,8 @@ export type WalletContext = {
   guestModule: string
 
   walletCreationCode: string
+
+  proxyImplementationHook?: string;
 }
 
 export function addressOf(context: WalletContext, imageHash: ethers.BytesLike) {

--- a/packages/core/src/v2/index.ts
+++ b/packages/core/src/v2/index.ts
@@ -21,5 +21,6 @@ export const DeployedWalletContext: WalletContext = {
   guestModule: '0xfea230Ee243f88BC698dD8f1aE93F8301B6cdfaE',
   mainModule: '0xfBf8f1A5E00034762D928f46d438B947f5d4065d',
   mainModuleUpgradable: '0x4222dcA3974E39A8b41c411FeDDE9b09Ae14b911',
-  walletCreationCode: '0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3'
+  walletCreationCode: '0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3',
+  proxyImplementationHook: '0x1f56dbAD5e8319F0DE9a323E24A31b5077dEB1a4',
 }

--- a/packages/tests/src/context/v2.ts
+++ b/packages/tests/src/context/v2.ts
@@ -43,6 +43,7 @@ export async function deployV2Context(signer: ethers.Signer): Promise<coreV2.con
     guestModule: await guestModule.getAddress(),
     universalSigValidator: await universalSigValidator.getAddress(),
 
-    walletCreationCode: '0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3'
+    walletCreationCode: '0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3',
+    proxyImplementationHook: '0x1f56dbAD5e8319F0DE9a323E24A31b5077dEB1a4'
   }
 }


### PR DESCRIPTION
Requires: https://github.com/0xsequence/wallet-contracts/pull/191

Immutable ERC721/1155s have an [OperatorAllowlist](https://github.com/immutable/contracts/blob/main/contracts/allowlist/OperatorAllowlistUpgradeable.sol#L153) that prevent contracts owning tokens. For wallets to own tokens they must have an approved bytecode and implementation address returned by a `PROXY_getImplementation()` function. 

This PR adds the `PROXY_getImplementation()` function to a wallet via the hooks module. This is added whenever the user interacts with an immutable chain. The hook is only added once. 