### PR TITLE
Create networkNames.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "watch": "preconstruct watch",
     "clean": "rimraf ./node_modules",
     "changeset": "changeset",
-    "changeset:version": "changeset version && pnpm update-version",
+    "changeset:version": "changeset version && pnpm update-version && pnpm update-network-names-doc",
     "changeset:publish": "pnpm build && changeset publish",
     "changeset:snapshot": "changeset && changeset version --snapshot && pnpm i && pnpm build && changeset publish --tag snapshot && git tag | grep '0\\.0\\.0' | xargs git tag -d && echo && echo -n 'Published sequence.js snapshot ' && grep '^## ' packages/0xsequence/CHANGELOG.md | head -n 1 | cut -c 4-",
     "update-version": "node ./scripts/update-version",
+    "update-network-names-doc": "ts-node ./scripts/update-network-names-doc.ts",
     "test": "pnpm -r --workspace-concurrency=1 test",
     "test:parallel": "pnpm -r test",
     "lint": "eslint -c .eslintrc.js 'packages/**/src/**/*.{ts,tsx}'",
@@ -28,7 +29,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "pnpm lint",
-      "pre-push": "pnpm lint && pnpm build && pnpm test:parallel"
+      "pre-push": "pnpm lint && pnpm build && pnpm test:parallel && pnpm update-network-names-doc"
     }
   },
   "devDependencies": {
@@ -102,5 +103,6 @@
       "got@<11.8.5": ">=11.8.5",
       "glob-parent@<5.1.2": ">=5.1.2"
     }
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/packages/network/networkNames.md
+++ b/packages/network/networkNames.md
@@ -1,0 +1,61 @@
+# Network Names
+
+Though networks have proper full names, we sometimes need to refer to a chain by a name slug.
+
+A name slug is the name, sometimes simplified, and in kebab-case. This maximizes compatibility in the event that you want to use chain names as url paths, or filenames.
+
+You can use this file as a reference to look up the correct network name slug a network's full name or its chain ID.
+
+| Network Name | Chain ID | Name Slug |
+| --- | --- | --- |
+| Ethereum | 1 | mainnet |
+| Optimism | 10 | optimism |
+| Telos | 40 | telos |
+| Telos Testnet | 41 | telos-testnet |
+| BNB Smart Chain | 56 | bsc |
+| BNB Smart Chain Testnet | 97 | bsc-testnet |
+| Gnosis Chain | 100 | gnosis |
+| Polygon | 137 | polygon |
+| XR1 | 273 | xr1 |
+| Polygon zkEVM | 1101 | polygon-zkevm |
+| Moonbeam | 1284 | moonbeam |
+| Moonbase Alpha | 1287 | moonbase-alpha |
+| Soneium | 1868 | soneium |
+| Soneium Minato (Testnet) | 1946 | soneium-minato |
+| B3 Sepolia | 1993 | b3-sepolia |
+| XR Sepolia | 2730 | xr-sepolia |
+| LAOS | 6283 | laos |
+| The Root Network | 7668 | rootnet |
+| The Root Network Porcini Testnet | 7672 | rootnet-porcini |
+| B3 | 8333 | b3 |
+| Base (Coinbase) | 8453 | base |
+| MONAD Testnet | 10143 | monad-testnet |
+| Immutable zkEVM | 13371 | immutable-zkevm |
+| Immutable zkEVM Testnet | 13473 | immutable-zkevm-testnet |
+| Oasys Homeverse | 19011 | homeverse |
+| Hardhat (local testnet) | 31337 | hardhat |
+| Hardhat (local testnet) | 31338 | hardhat2 |
+| APE Chain Testnet | 33111 | apechain-testnet |
+| APE Chain | 33139 | apechain |
+| Oasys Homeverse Testnet | 40875 | homeverse-testnet |
+| Arbitrum One | 42161 | arbitrum |
+| Arbitrum Nova | 42170 | arbitrum-nova |
+| ETHERLINK | 42793 | etherlink |
+| Avalanche Testnet | 43113 | avalanche-testnet |
+| Avalanche | 43114 | avalanche |
+| SOMNIA Testnet | 50312 | somnia-testnet |
+| LAOS Sigma Testnet | 62850 | laos-sigma-testnet |
+| Polygon Amoy | 80002 | amoy |
+| Blast | 81457 | blast |
+| Base Sepolia | 84532 | base-sepolia |
+| Borne Testnet | 94984 | borne-testnet |
+| ETHERLINK Testnet | 128123 | etherlink-testnet |
+| Arbitrum Sepolia | 421614 | arbitrum-sepolia |
+| Xai | 660279 | xai |
+| Sepolia | 11155111 | sepolia |
+| Optimism Sepolia | 11155420 | optimism-sepolia |
+| TOY (Testnet) | 21000000 | toy-testnet |
+| SKALE Nebula Gaming Hub Testnet | 37084624 | skale-nebula-testnet |
+| Blast Sepolia | 168587773 | blast-sepolia |
+| SKALE Nebula Gaming Hub | 1482601649 | skale-nebula |
+| Xai Sepolia | 37714555429 | xai-sepolia |

--- a/packages/network/networkNames.template.md
+++ b/packages/network/networkNames.template.md
@@ -1,0 +1,9 @@
+# Network Names
+
+Though networks have proper full names, we sometimes need to refer to a chain by a name slug.
+
+A name slug is the name, sometimes simplified, and in kebab-case. This maximizes compatibility in the event that you want to use chain names as url paths, or filenames.
+
+You can use this file as a reference to look up the correct network name slug a network's full name or its chain ID.
+
+<!-- tables start here -->

--- a/scripts/update-network-names-doc.ts
+++ b/scripts/update-network-names-doc.ts
@@ -1,0 +1,30 @@
+const fs = require('fs')
+const path = require('path')
+const { networks } = require("@0xsequence/network/constants");
+
+const networkPath = path.resolve(__dirname, '../packages/network')
+const templatePath = path.join(networkPath, 'networkNames.template.md')
+const outputPath = path.join(networkPath, 'networkNames.md')
+const template = fs.readFileSync(templatePath, 'utf8')
+
+const networkObjs = Object.values(networks) as Array<{
+  deprecated?: boolean, 
+  chainId: number, 
+  name: string, 
+  title?: string
+}>;
+
+const activeNetworkObjs = networkObjs.filter(v => !v.deprecated).sort((a, b) => a.chainId - b.chainId)
+
+const lines: string[] = [];
+lines.push(`| Network Name | Chain ID | Name Slug |`);
+lines.push(`| --- | --- | --- |`);
+for (const n of activeNetworkObjs) {
+  lines.push(`| ${n.title} | ${n.chainId} | ${n.name} |`);
+}
+
+const doc = template.replace("<!-- tables start here -->", lines.join("\n"));
+
+fs.writeFileSync(outputPath, doc, 'utf8')
+
+console.log(`Updated network/networkNames.md`)


### PR DESCRIPTION
Since we're improving boilerplate configuration, we recommend users use network name slugs in they .env configs.
There's no simple reference to look up those names right now. We could maybe find a better home for this information, but this is a good place to start IMHO