### PR TITLE
Fixing package types exports to use dist/index.d.ts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
-      - run: pnpm typecheck
-      - run: pnpm lint
       - run: pnpm build
 
   tests:

--- a/packages/wallet/core/package.json
+++ b/packages/wallet/core/package.json
@@ -9,7 +9,7 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/wallet/primitives-cli/package.json
+++ b/packages/wallet/primitives-cli/package.json
@@ -10,7 +10,7 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/wallet/primitives/package.json
+++ b/packages/wallet/primitives/package.json
@@ -8,7 +8,7 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/wallet/wdk/package.json
+++ b/packages/wallet/wdk/package.json
@@ -9,7 +9,7 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
package.json type exports were previously set to "src/index.ts" for wallet packages, this was causing applications which use those packages to typecheck the entire library.