### PR TITLE
Address comparison and attestation fix

### DIFF
--- a/packages/wallet/core/src/envelope.ts
+++ b/packages/wallet/core/src/envelope.ts
@@ -33,12 +33,15 @@ export type Signed<T extends Payload.Payload> = Envelope<T> & {
 
 export function signatureForLeaf(envelope: Signed<Payload.Payload>, leaf: Config.Leaf) {
   if (Config.isSignerLeaf(leaf)) {
-    return envelope.signatures.find((sig) => isSignature(sig) && sig.address === leaf.address)
+    return envelope.signatures.find((sig) => isSignature(sig) && Address.isEqual(sig.address, leaf.address))
   }
 
   if (Config.isSapientSignerLeaf(leaf)) {
     return envelope.signatures.find(
-      (sig) => isSapientSignature(sig) && sig.imageHash === leaf.imageHash && sig.signature.address === leaf.address,
+      (sig) =>
+        isSapientSignature(sig) &&
+        sig.imageHash === leaf.imageHash &&
+        Address.isEqual(sig.signature.address, leaf.address),
     )
   }
 
@@ -89,7 +92,7 @@ export function addSignature(
     const prev = envelope.signatures.find(
       (sig) =>
         isSapientSignature(sig) &&
-        sig.signature.address === signature.signature.address &&
+        Address.isEqual(sig.signature.address, signature.signature.address) &&
         sig.imageHash === signature.imageHash,
     ) as SapientSignature | undefined
 
@@ -110,9 +113,9 @@ export function addSignature(
     envelope.signatures.push(signature)
   } else if (isSignature(signature)) {
     // Find if the signature already exists in envelope
-    const prev = envelope.signatures.find((sig) => isSignature(sig) && sig.address === signature.address) as
-      | Signature
-      | undefined
+    const prev = envelope.signatures.find(
+      (sig) => isSignature(sig) && Address.isEqual(sig.address, signature.address),
+    ) as Signature | undefined
 
     if (prev) {
       // If the signatures are identical, then we can do nothing

--- a/packages/wallet/core/src/signers/passkey.ts
+++ b/packages/wallet/core/src/signers/passkey.ts
@@ -203,7 +203,9 @@ export class Passkey implements SapientSigner, Witnessable {
     // Flatten and remove duplicates
     const flattened = signers
       .flat()
-      .filter((v, i, self) => self.findIndex((t) => t.wallet === v.wallet && t.imageHash === v.imageHash) === i)
+      .filter(
+        (v, i, self) => self.findIndex((t) => Address.isEqual(t.wallet, v.wallet) && t.imageHash === v.imageHash) === i,
+      )
 
     // If there are no signers, return undefined
     if (flattened.length === 0) {

--- a/packages/wallet/core/src/signers/session/explicit.ts
+++ b/packages/wallet/core/src/signers/session/explicit.ts
@@ -1,11 +1,11 @@
 import { Payload, Permission, SessionSignature, Utils } from '@0xsequence/wallet-primitives'
 import { AbiParameters, Address, Bytes, Hash, Hex, Provider, Secp256k1 } from 'ox'
-import { SignerInterface } from './session.js'
+import { SessionSigner } from './session.js'
 import { MemoryPkStore, PkStore } from '../pk/index.js'
 
 export type ExplicitParams = Omit<Permission.SessionPermissions, 'signer'>
 
-export class Explicit implements SignerInterface {
+export class Explicit implements SessionSigner {
   private readonly _privateKey: PkStore
 
   public readonly address: Address.Address

--- a/packages/wallet/core/src/signers/session/implicit.ts
+++ b/packages/wallet/core/src/signers/session/implicit.ts
@@ -1,11 +1,11 @@
 import { Attestation, Payload, Signature as SequenceSignature, SessionSignature } from '@0xsequence/wallet-primitives'
 import { AbiFunction, Address, Bytes, Hex, Provider, Secp256k1, Signature } from 'ox'
 import { MemoryPkStore, PkStore } from '../pk/index.js'
-import { SignerInterface } from './session.js'
+import { SessionSigner } from './session.js'
 
 export type AttestationParams = Omit<Attestation.Attestation, 'approvedSigner'>
 
-export class Implicit implements SignerInterface {
+export class Implicit implements SessionSigner {
   private readonly _privateKey: PkStore
   private readonly _identitySignature: SequenceSignature.RSY
   public readonly address: Address.Address

--- a/packages/wallet/core/src/signers/session/session.ts
+++ b/packages/wallet/core/src/signers/session/session.ts
@@ -1,7 +1,7 @@
 import { Address, Provider } from 'ox'
 import { Payload, SessionSignature } from '@0xsequence/wallet-primitives'
 
-export interface SignerInterface {
+export interface SessionSigner {
   address: Address.Address
 
   /// Check if the signer supports the call

--- a/packages/wallet/core/src/signers/session/session.ts
+++ b/packages/wallet/core/src/signers/session/session.ts
@@ -2,7 +2,7 @@ import { Address, Provider } from 'ox'
 import { Payload, SessionSignature } from '@0xsequence/wallet-primitives'
 
 export interface SessionSigner {
-  address: Address.Address
+  address: Address.Address | Promise<Address.Address>
 
   /// Check if the signer supports the call
   supportedCall: (

--- a/packages/wallet/core/src/state/local/index.ts
+++ b/packages/wallet/core/src/state/local/index.ts
@@ -271,7 +271,7 @@ export class Provider implements ProviderInterface {
         if (Config.isSapientSignerLeaf(leaf)) {
           const sapientSignature = signaturesOfSigners.find(
             ({ signer, imageHash }: { signer: Address.Address; imageHash?: Hex.Hex }) => {
-              return imageHash && signer === leaf.address && imageHash === leaf.imageHash
+              return imageHash && Address.isEqual(signer, leaf.address) && imageHash === leaf.imageHash
             },
           )?.signature
 
@@ -281,7 +281,7 @@ export class Provider implements ProviderInterface {
           }
         }
 
-        const signature = signaturesOfSigners.find(({ signer }) => signer === leaf.address)?.signature
+        const signature = signaturesOfSigners.find(({ signer }) => Address.isEqual(signer, leaf.address))?.signature
         if (!signature) {
           return undefined
         }

--- a/packages/wallet/primitives-cli/src/subcommands/signature.ts
+++ b/packages/wallet/primitives-cli/src/subcommands/signature.ts
@@ -1,5 +1,5 @@
 import { Config, Signature } from '@0xsequence/wallet-primitives'
-import { Bytes, Hex, Signature as OxSignature } from 'ox'
+import { Address, Bytes, Hex, Signature as OxSignature } from 'ox'
 import { type CommandModule } from 'yargs'
 import { fromPosOrStdin } from '../utils.js'
 import { PossibleElements } from './config.js'
@@ -43,7 +43,7 @@ export async function doEncode(
   const allSignatures = signatures.map((s) => {
     const values = s.split(':')
     return {
-      address: values[0],
+      address: Address.from(values[0] as `0x${string}`),
       type: values[1],
       values: values.slice(2),
     }
@@ -52,7 +52,7 @@ export async function doEncode(
   const fullTopology = Signature.fillLeaves(config.topology, (leaf) => {
     if (Config.isSignerLeaf(leaf)) {
       // Type must be 1271, eth_sign, or hash
-      const candidate = allSignatures.find((s) => s.address === leaf.address)
+      const candidate = allSignatures.find((s) => Address.isEqual(s.address, leaf.address))
 
       if (!candidate) {
         return undefined
@@ -92,7 +92,7 @@ export async function doEncode(
     }
 
     if (Config.isSapientSignerLeaf(leaf)) {
-      const candidate = allSignatures.find((s) => s.address === leaf.address)
+      const candidate = allSignatures.find((s) => Address.isEqual(s.address, leaf.address))
       if (!candidate) {
         return undefined
       }

--- a/packages/wallet/primitives/src/config.ts
+++ b/packages/wallet/primitives/src/config.ts
@@ -149,11 +149,11 @@ export function findSignerLeaf(
   } else if (isNode(configuration)) {
     return findSignerLeaf(configuration[0], address) || findSignerLeaf(configuration[1], address)
   } else if (isSignerLeaf(configuration)) {
-    if (configuration.address === address) {
+    if (Address.isEqual(configuration.address, address)) {
       return configuration
     }
   } else if (isSapientSignerLeaf(configuration)) {
-    if (configuration.address === address) {
+    if (Address.isEqual(configuration.address, address)) {
       return configuration
     }
   }

--- a/packages/wallet/primitives/src/session-config.ts
+++ b/packages/wallet/primitives/src/session-config.ts
@@ -166,7 +166,7 @@ export function getImplicitBlacklistLeaf(topology: SessionsTopology): ImplicitBl
 
 export function getSessionPermissions(topology: SessionsTopology, address: Address.Address): SessionPermissions | null {
   if (isSessionPermissions(topology)) {
-    if (topology.signer === address) {
+    if (Address.isEqual(topology.signer, address)) {
       return topology
     }
   }
@@ -426,7 +426,7 @@ export function removeExplicitSession(
   signerAddress: `0x${string}`,
 ): SessionsTopology | null {
   if (isSessionPermissions(topology)) {
-    if (topology.signer === signerAddress) {
+    if (Address.isEqual(topology.signer, signerAddress)) {
       return null
     }
     // Return the leaf unchanged
@@ -642,7 +642,7 @@ export function addToImplicitBlacklist(topology: SessionsTopology, address: Addr
     throw new Error('No blacklist found')
   }
   const { blacklist } = blacklistNode
-  if (blacklist.some((addr) => addr === address)) {
+  if (blacklist.some((addr) => Address.isEqual(addr, address))) {
     return topology
   }
   blacklist.push(address)

--- a/packages/wallet/wdk/src/identity/signer.ts
+++ b/packages/wallet/wdk/src/identity/signer.ts
@@ -14,7 +14,7 @@ export class IdentitySigner implements Signers.Signer {
     if (!Address.validate(this.authKey.identitySigner)) {
       throw new Error('No signer address found')
     }
-    return this.authKey.identitySigner
+    return Address.checksum(this.authKey.identitySigner)
   }
 
   async sign(

--- a/packages/wallet/wdk/src/sequence/handlers/authcode-pkce.ts
+++ b/packages/wallet/wdk/src/sequence/handlers/authcode-pkce.ts
@@ -82,10 +82,12 @@ export class AuthCodePkceHandler extends IdentityHandler implements Handler {
     _imageHash: Hex.Hex | undefined,
     request: BaseSignatureRequest,
   ): Promise<SignerUnavailable | SignerReady | SignerActionable> {
-    const signer = await this.getAuthKeySigner(address)
+    // Normalize address
+    const normalizedAddress = Address.checksum(address)
+    const signer = await this.getAuthKeySigner(normalizedAddress)
     if (signer) {
       return {
-        address,
+        address: normalizedAddress,
         handler: this,
         status: 'ready',
         handle: async () => {
@@ -96,12 +98,12 @@ export class AuthCodePkceHandler extends IdentityHandler implements Handler {
     }
 
     return {
-      address,
+      address: normalizedAddress,
       handler: this,
       status: 'actionable',
       message: 'request-redirect',
       handle: async () => {
-        const url = await this.commitAuth(window.location.pathname, false, request.id, address.toString())
+        const url = await this.commitAuth(window.location.pathname, false, request.id, normalizedAddress)
         window.location.href = url
         return true
       },

--- a/packages/wallet/wdk/src/sequence/manager.ts
+++ b/packages/wallet/wdk/src/sequence/manager.ts
@@ -55,7 +55,7 @@ export type ManagerOptions = {
 
   stateProvider?: State.Provider
   networks?: Network.Network[]
-  relayers?: Relayer.Relayer[]
+  relayers?: Relayer.Relayer[] | (() => Relayer.Relayer[])
 
   defaultGuardTopology?: Config.Topology
   defaultRecoverySettings?: RecoverySettings

--- a/packages/wallet/wdk/src/sequence/sessions.ts
+++ b/packages/wallet/wdk/src/sequence/sessions.ts
@@ -8,7 +8,7 @@ import {
   Signature as SequenceSignature,
   SessionConfig,
 } from '@0xsequence/wallet-primitives'
-import { Address, Bytes, Hex } from 'ox'
+import { Address, Bytes, Hash, Hex } from 'ox'
 import { IdentityType } from '../identity/index.js'
 import { AuthCodePkceHandler } from './handlers/authcode-pkce.js'
 import { IdentityHandler, identityTypeToHex } from './handlers/identity.js'
@@ -70,10 +70,8 @@ export class Sessions {
     if (handler instanceof IdentityHandler) {
       identityType = handler.identityType
       if (handler instanceof AuthCodePkceHandler) {
-        Hex.assert(handler.issuer)
-        Hex.assert(handler.audience)
-        issuerHash = handler.issuer
-        audienceHash = handler.audience
+        issuerHash = Hash.keccak256(Hex.fromString(handler.issuer))
+        audienceHash = Hash.keccak256(Hex.fromString(handler.audience))
       }
     }
     const attestation: Attestation.Attestation = {

--- a/packages/wallet/wdk/src/sequence/signatures.ts
+++ b/packages/wallet/wdk/src/sequence/signatures.ts
@@ -1,6 +1,6 @@
 import { Envelope } from '@0xsequence/wallet-core'
 import { Config, Payload } from '@0xsequence/wallet-primitives'
-import { Hex } from 'ox'
+import { Address, Hex } from 'ox'
 import { v7 as uuidv7 } from 'uuid'
 import { Shared } from './manager.js'
 import {
@@ -81,9 +81,9 @@ export class Signatures {
         // We may have a signature for this signer already
         const signed = request.envelope.signatures.some((sig) => {
           if (Envelope.isSapientSignature(sig)) {
-            return sig.signature.address === sak.address && sig.imageHash === sak.imageHash
+            return Address.isEqual(sig.signature.address, sak.address) && sig.imageHash === sak.imageHash
           }
-          return sig.address === sak.address
+          return Address.isEqual(sig.address, sak.address)
         })
 
         if (!sak.kind) {
@@ -180,7 +180,7 @@ export class Signatures {
       const pendingRequests = await this.shared.databases.signatures.list()
       const pendingConfigUpdatesToClear = pendingRequests.filter(
         (sig) =>
-          sig.wallet === request.wallet &&
+          Address.isEqual(sig.wallet, request.wallet) &&
           sig.envelope.payload.type === 'config-update' &&
           sig.envelope.configuration.checkpoint <= request.envelope.configuration.checkpoint,
       )

--- a/packages/wallet/wdk/src/sequence/signers.ts
+++ b/packages/wallet/wdk/src/sequence/signers.ts
@@ -33,7 +33,7 @@ export class Signers {
 
     // Some signers are known by the configuration of the wallet development kit, specifically
     // some of the sapient signers, who always share the same address
-    if (this.shared.sequence.extensions.recovery === address) {
+    if (Address.isEqual(this.shared.sequence.extensions.recovery, address)) {
       return Kinds.Recovery
     }
 

--- a/packages/wallet/wdk/src/sequence/wallets.ts
+++ b/packages/wallet/wdk/src/sequence/wallets.ts
@@ -629,7 +629,7 @@ export class Wallets {
       }
 
       const wallet = await args.selectWallet(wallets.map((w) => w.wallet))
-      if (!wallets.some((w) => w.wallet === wallet)) {
+      if (!wallets.some((w) => Address.isEqual(w.wallet, wallet))) {
         throw new Error('wallet-not-found')
       }
 
@@ -651,7 +651,7 @@ export class Wallets {
       }
 
       const wallet = await args.selectWallet(wallets.map((w) => w.wallet))
-      if (!wallets.some((w) => w.wallet === wallet)) {
+      if (!wallets.some((w) => Address.isEqual(w.wallet, wallet))) {
         throw new Error('wallet-not-found')
       }
 

--- a/packages/wallet/wdk/test/sessions.test.ts
+++ b/packages/wallet/wdk/test/sessions.test.ts
@@ -4,7 +4,6 @@ import { Signers as CoreSigners, Wallet as CoreWallet, Envelope, Relayer, State 
 import { Attestation, Constants, Payload, Permission } from '../../primitives/src/index.js'
 import { Sequence } from '../src/index.js'
 import { CAN_RUN_LIVE, EMITTER_ABI, EMITTER_ADDRESS, PRIVATE_KEY, RPC_URL } from './constants'
-import { SignerActionable } from '../src/sequence/index.js'
 
 describe('Sessions (via Manager)', () => {
   // Shared components
@@ -195,10 +194,10 @@ describe('Sessions (via Manager)', () => {
       // Sign and complete the request
       const sigRequest = await wdk.manager.getSignatureRequest(requestId)
       const identitySigner = sigRequest.signers.find((s) => s.address === wdk.identitySignerAddress)
-      if (!identitySigner || identitySigner.status !== 'actionable') {
-        throw new Error(`Identity signer not found or not ready: ${identitySigner?.status}`)
+      if (!identitySigner || (identitySigner.status !== 'actionable' && identitySigner.status !== 'ready')) {
+        throw new Error(`Identity signer not found or not ready/actionable: ${identitySigner?.status}`)
       }
-      const handled = await (identitySigner as SignerActionable).handle()
+      const handled = await identitySigner.handle()
       if (!handled) {
         throw new Error('Failed to handle identity signer')
       }
@@ -256,10 +255,10 @@ describe('Sessions (via Manager)', () => {
       // Sign the request (Wallet UI action)
       const sigRequest = await wdk.manager.getSignatureRequest(requestId)
       const identitySigner = sigRequest.signers[0]
-      if (!identitySigner || identitySigner.status !== 'actionable') {
-        throw new Error(`Identity signer not found or not actionable: ${identitySigner?.status}`)
+      if (!identitySigner || (identitySigner.status !== 'actionable' && identitySigner.status !== 'ready')) {
+        throw new Error(`Identity signer not found or not ready/actionable: ${identitySigner?.status}`)
       }
-      const handled = await (identitySigner as SignerActionable).handle()
+      const handled = await identitySigner.handle()
       if (!handled) {
         throw new Error('Failed to handle identity signer')
       }


### PR DESCRIPTION
* Prefer `Address.isEqual` when comparing addresses
* Rename `Signers.Session.SignerInterface` to `Signers.Session.SessionSigner`
* Fix attestation encoding (wasn't hashing strings)
* Fix relayer opt type (didn't support functions)
* Allow ready or actionable identity signers for session tests
* Ensure nitro signers return a checksum address as the identity instrument requires thi