### PR TITLE
Networks update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "turbo": "^2.5.4",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.14.0",
   "engines": {
     "node": ">=18"
   }

--- a/packages/wallet/core/package.json
+++ b/packages/wallet/core/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "exports": {

--- a/packages/wallet/dapp-client/package.json
+++ b/packages/wallet/dapp-client/package.json
@@ -29,7 +29,6 @@
     "vitest": "^3.2.1"
   },
   "dependencies": {
-    "@0xsequence/network": "^2.3.23",
     "@0xsequence/wallet-core": "workspace:^",
     "@0xsequence/wallet-primitives": "workspace:^",
     "ox": "^0.7.2"

--- a/packages/wallet/dapp-client/package.json
+++ b/packages/wallet/dapp-client/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "exports": {

--- a/packages/wallet/dapp-client/src/ChainSessionManager.ts
+++ b/packages/wallet/dapp-client/src/ChainSessionManager.ts
@@ -1,10 +1,9 @@
 import { Envelope, Relayer, Signers, State, Wallet } from '@0xsequence/wallet-core'
-import { Attestation, Constants, Extensions, Payload, SessionConfig } from '@0xsequence/wallet-primitives'
+import { Attestation, Constants, Extensions, Network, Payload, SessionConfig } from '@0xsequence/wallet-primitives'
 import { AbiFunction, Address, Hex, Provider, RpcTransport, Secp256k1 } from 'ox'
 
 import { DappTransport } from './DappTransport.js'
 
-import { ChainId } from '@0xsequence/network'
 import {
   AddExplicitSessionError,
   FeeOptionError,
@@ -67,7 +66,7 @@ export class ChainSessionManager {
   private wallet: Wallet | null = null
   private provider: Provider.Provider | null = null
   private relayer: Relayer.Standard.Rpc.RpcRelayer
-  private readonly chainId: ChainId
+  private readonly chainId: bigint
   public transport: DappTransport | null = null
   private sequenceStorage: SequenceStorage
   public isInitialized: boolean = false
@@ -85,7 +84,7 @@ export class ChainSessionManager {
    * @param canUseIndexedDb (Optional) A flag to enable or disable IndexedDB for caching.
    */
   constructor(
-    chainId: ChainId,
+    chainId: bigint,
     keyMachineUrl: string,
     transport: DappTransport,
     sequenceStorage: SequenceStorage,

--- a/packages/wallet/dapp-client/src/DappClient.ts
+++ b/packages/wallet/dapp-client/src/DappClient.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ChainId } from '@0xsequence/network'
 import { Relayer, Signers } from '@0xsequence/wallet-core'
 import { Address, Hex } from 'ox'
 
@@ -57,7 +56,7 @@ export class DappClient {
 
   public readonly origin: string
 
-  private chainSessionManagers: Map<ChainId, ChainSessionManager> = new Map()
+  private chainSessionManagers: Map<bigint, ChainSessionManager> = new Map()
   private transport: DappTransport
   private keymachineUrl: string
   private walletUrl: string
@@ -235,7 +234,7 @@ export class DappClient {
     this.userEmail = implicitSession.userEmail ?? null
 
     const explicitSessions = await this.sequenceStorage.getExplicitSessions()
-    const chainIdsToInitialize = new Set<ChainId>([
+    const chainIdsToInitialize = new Set<bigint>([
       implicitSession.chainId,
       ...explicitSessions.filter((s) => Address.isEqual(s.walletAddress, this.walletAddress!)).map((s) => s.chainId),
     ])
@@ -328,7 +327,7 @@ export class DappClient {
 
   /**
    * Initiates a connection with the wallet and creates a new session.
-   * @param chainId The primary chain ID for the new session. {@link ChainId}
+   * @param chainId The primary chain ID for the new session.
    * @param permissions (Optional) Permissions to request for an initial explicit session. {@link Signers.Session.ExplicitParams}
    * @param options (Optional) Connection options, such as a preferred login method or email for social or email logins.
    * @throws If the connection process fails. {@link ConnectionError}
@@ -345,7 +344,7 @@ export class DappClient {
    * });
    */
   async connect(
-    chainId: ChainId,
+    chainId: bigint,
     permissions?: Signers.Session.ExplicitParams,
     options: {
       preferredLoginMethod?: 'google' | 'apple' | 'email' | 'passkey' | 'mnemonic'
@@ -375,7 +374,7 @@ export class DappClient {
    * Adds a new explicit session for a given chain to an existing wallet.
    * @remarks
    * An `explicit session` is a session that can interact with any contract, subject to user-approved permissions.
-   * @param chainId The chain ID on which to add the explicit session. {@link ChainId}
+   * @param chainId The chain ID on which to add the explicit session.
    * @param permissions The permissions to request for the new session. {@link Signers.Session.ExplicitParams}
    *
    * @throws If the session cannot be added. {@link AddExplicitSessionError}
@@ -408,7 +407,7 @@ export class DappClient {
    *   await dappClient.addExplicitSession(1, permissions);
    * }
    */
-  async addExplicitSession(chainId: ChainId, permissions: Signers.Session.ExplicitParams): Promise<void> {
+  async addExplicitSession(chainId: bigint, permissions: Signers.Session.ExplicitParams): Promise<void> {
     if (!this.isInitialized || !this.walletAddress)
       throw new InitializationError('Cannot add an explicit session without an existing wallet.')
 
@@ -425,7 +424,7 @@ export class DappClient {
 
   /**
    * Modifies the permissions of an existing explicit session for a given chain and session address.
-   * @param chainId The chain ID on which the explicit session exists. {@link ChainId}
+   * @param chainId The chain ID on which the explicit session exists.
    * @param sessionAddress The address of the explicit session to modify. {@link Address.Address}
    * @param permissions The new permissions to set for the session. {@link Signers.Session.ExplicitParams}
    *
@@ -454,7 +453,7 @@ export class DappClient {
    * }
    */
   async modifyExplicitSession(
-    chainId: ChainId,
+    chainId: bigint,
     sessionAddress: Address.Address,
     permissions: Signers.Session.ExplicitParams,
   ): Promise<void> {
@@ -474,7 +473,7 @@ export class DappClient {
 
   /**
    * Gets the gas fee options for an array of transactions.
-   * @param chainId The chain ID on which to get the fee options. {@link ChainId}
+   * @param chainId The chain ID on which to get the fee options.
    * @param transactions An array of transactions to get fee options for. These transactions will not be sent.
    * @throws If the fee options cannot be fetched. {@link FeeOptionError}
    * @throws If the client or relevant chain is not initialized. {@link InitializationError}
@@ -501,7 +500,7 @@ export class DappClient {
    *   const txHash = await dappClient.sendTransaction(1, transactions, feeOption);
    * }
    */
-  async getFeeOptions(chainId: ChainId, transactions: Transaction[]): Promise<Relayer.FeeOption[]> {
+  async getFeeOptions(chainId: bigint, transactions: Transaction[]): Promise<Relayer.FeeOption[]> {
     if (!this.isInitialized) throw new InitializationError('Not initialized')
     const chainSessionManager = this.getChainSessionManager(chainId)
     if (!chainSessionManager.isInitialized)
@@ -511,7 +510,7 @@ export class DappClient {
 
   /**
    * Signs and sends a transaction using an available session signer.
-   * @param chainId The chain ID on which to send the transaction. {@link ChainId}
+   * @param chainId The chain ID on which to send the transaction.
    * @param transactions An array of transactions to be executed atomically in a single batch. {@link Transaction}
    * @param feeOption (Optional) The selected fee option to sponsor the transaction. {@link Relayer.FeeOption}
    * @throws {TransactionError} If the transaction fails to send or confirm.
@@ -534,11 +533,7 @@ export class DappClient {
    *
    *   const txHash = await dappClient.sendTransaction(1, [transaction]);
    */
-  async sendTransaction(
-    chainId: ChainId,
-    transactions: Transaction[],
-    feeOption?: Relayer.FeeOption,
-  ): Promise<Hex.Hex> {
+  async sendTransaction(chainId: bigint, transactions: Transaction[], feeOption?: Relayer.FeeOption): Promise<Hex.Hex> {
     if (!this.isInitialized) throw new InitializationError('Not initialized')
     const chainSessionManager = this.getChainSessionManager(chainId)
     if (!chainSessionManager.isInitialized)
@@ -548,7 +543,7 @@ export class DappClient {
 
   /**
    * Signs a standard message (EIP-191) using an available session signer.
-   * @param chainId The chain ID on which to sign the message. {@link ChainId}
+   * @param chainId The chain ID on which to sign the message.
    * @param message The message to sign.
    * @throws If the message cannot be signed. {@link SigningError}
    * @throws If the client or relevant chain is not initialized. {@link InitializationError}
@@ -566,7 +561,7 @@ export class DappClient {
    *   await dappClient.signMessage(1, message);
    * }
    */
-  async signMessage(chainId: ChainId, message: string): Promise<void> {
+  async signMessage(chainId: bigint, message: string): Promise<void> {
     if (!this.isInitialized) throw new InitializationError('Not initialized')
     const chainSessionManager = this.getChainSessionManager(chainId)
     if (!chainSessionManager.isInitialized)
@@ -576,7 +571,7 @@ export class DappClient {
 
   /**
    * Signs a typed data object (EIP-712) using an available session signer.
-   * @param chainId The chain ID on which to sign the typed data. {@link ChainId}
+   * @param chainId The chain ID on which to sign the typed data.
    * @param typedData The typed data object to sign.
    * @throws If the typed data cannot be signed. {@link SigningError}
    * @throws If the client or relevant chain is not initialized. {@link InitializationError}
@@ -594,7 +589,7 @@ export class DappClient {
    *   await dappClient.signTypedData(1, typedData);
    * }
    */
-  async signTypedData(chainId: ChainId, typedData: TypedData): Promise<void> {
+  async signTypedData(chainId: bigint, typedData: TypedData): Promise<void> {
     if (!this.isInitialized) throw new InitializationError('Not initialized')
     const chainSessionManager = this.getChainSessionManager(chainId)
     if (!chainSessionManager.isInitialized)
@@ -652,10 +647,10 @@ export class DappClient {
 
   /**
    * @private Retrieves or creates a ChainSessionManager for a given chain ID.
-   * @param chainId The chain ID to get the ChainSessionManager for. {@link ChainId}
+   * @param chainId The chain ID to get the ChainSessionManager for.
    * @returns The ChainSessionManager for the given chain ID. {@link ChainSessionManager}
    */
-  private getChainSessionManager(chainId: ChainId): ChainSessionManager {
+  private getChainSessionManager(chainId: bigint): ChainSessionManager {
     let chainSessionManager = this.chainSessionManagers.get(chainId)
     if (!chainSessionManager) {
       chainSessionManager = new ChainSessionManager(

--- a/packages/wallet/dapp-client/src/types/index.ts
+++ b/packages/wallet/dapp-client/src/types/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Attestation, Payload } from '@0xsequence/wallet-primitives'
 import { Signers } from '@0xsequence/wallet-core'
-import { ChainId } from '@0xsequence/network'
 import { Address, Hex } from 'ox'
 import type { TypedData } from 'ox/TypedData'
 
@@ -43,13 +42,13 @@ export interface AddImplicitSessionPayload {
 export interface SignMessagePayload {
   address: Address.Address
   message: string
-  chainId: ChainId
+  chainId: bigint
 }
 
 export interface SignTypedDataPayload {
   address: Address.Address
   typedData: TypedData
-  chainId: ChainId
+  chainId: bigint
 }
 
 export interface ConnectSuccessResponsePayload {
@@ -91,7 +90,7 @@ export type Session = {
   address: Address.Address
   isImplicit: boolean
   permissions?: Signers.Session.ExplicitParams
-  chainId?: ChainId
+  chainId?: bigint
 }
 
 // --- Event Types ---
@@ -117,14 +116,14 @@ export type DappClientSignatureEventListener = (data: {
   action: (typeof RequestActionType)['SIGN_MESSAGE' | 'SIGN_TYPED_DATA']
   response?: SignatureResponse
   error?: any
-  chainId: number
+  chainId: bigint
 }) => void
 
 export type DappClientExplicitSessionEventListener = (data: {
   action: (typeof RequestActionType)['ADD_EXPLICIT_SESSION' | 'MODIFY_EXPLICIT_SESSION']
   response?: ExplicitSessionResponsePayload
   error?: any
-  chainId: number
+  chainId: bigint
 }) => void
 
 // --- DappTransport Types ---
@@ -169,14 +168,14 @@ export interface MessageSignatureRequest extends BaseRequest {
   type: 'message_signature'
   message: string
   address: Address.Address
-  chainId: number
+  chainId: bigint
 }
 
 export interface TypedDataSignatureRequest extends BaseRequest {
   type: 'typed_data_signature'
   typedData: unknown
   address: Address.Address
-  chainId: number
+  chainId: bigint
 }
 
 export const WalletSize = {

--- a/packages/wallet/dapp-client/src/utils/index.ts
+++ b/packages/wallet/dapp-client/src/utils/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { allNetworks } from '@0xsequence/network'
+import { Network } from '@0xsequence/wallet-primitives'
 import { Bytes, Hex } from 'ox'
 import { NODES_URL, RELAYER_URL } from './constants.js'
 
@@ -117,8 +117,8 @@ function applyTemplate(template: string, values: Record<string, string>) {
   })
 }
 
-export const getNetwork = (chainId: number) => {
-  const network = allNetworks.find((network) => network.chainId === chainId)
+export const getNetwork = (chainId: Network.ChainId | bigint | number) => {
+  const network = Network.getNetworkFromChainId(chainId)
 
   if (!network) {
     throw new Error(`Network with chainId ${chainId} not found`)
@@ -127,7 +127,7 @@ export const getNetwork = (chainId: number) => {
   return network
 }
 
-export const getRpcUrl = (chainId: number) => {
+export const getRpcUrl = (chainId: Network.ChainId | bigint | number) => {
   const network = getNetwork(chainId)
 
   const url = applyTemplate(NODES_URL, { network: network.name })
@@ -135,7 +135,7 @@ export const getRpcUrl = (chainId: number) => {
   return url
 }
 
-export const getRelayerUrl = (chainId: number) => {
+export const getRelayerUrl = (chainId: Network.ChainId | bigint | number) => {
   const network = getNetwork(chainId)
 
   const url = applyTemplate(RELAYER_URL, { network: network.name })
@@ -143,7 +143,7 @@ export const getRelayerUrl = (chainId: number) => {
   return url
 }
 
-export const getExplorerUrl = (chainId: number, txHash: string) => {
+export const getExplorerUrl = (chainId: Network.ChainId | bigint | number, txHash: string) => {
   const network = getNetwork(chainId)
   const explorerUrl = network.blockExplorer?.rootUrl
   if (!explorerUrl) {

--- a/packages/wallet/dapp-client/src/utils/index.ts
+++ b/packages/wallet/dapp-client/src/utils/index.ts
@@ -145,7 +145,7 @@ export const getRelayerUrl = (chainId: Network.ChainId | bigint | number) => {
 
 export const getExplorerUrl = (chainId: Network.ChainId | bigint | number, txHash: string) => {
   const network = getNetwork(chainId)
-  const explorerUrl = network.blockExplorer?.rootUrl
+  const explorerUrl = network.blockExplorer?.url
   if (!explorerUrl) {
     throw new Error(`Explorer URL not found for chainId ${chainId}`)
   }

--- a/packages/wallet/dapp-client/src/utils/storage.ts
+++ b/packages/wallet/dapp-client/src/utils/storage.ts
@@ -1,6 +1,5 @@
 import { Attestation } from '@0xsequence/wallet-primitives'
 import { Address, Hex } from 'ox'
-import { ChainId } from '@0xsequence/network'
 import { jsonReplacers, jsonRevivers } from './index.js'
 import {
   AddExplicitSessionPayload,
@@ -14,7 +13,7 @@ import {
 export interface ExplicitSessionData {
   pk: Hex.Hex
   walletAddress: Address.Address
-  chainId: ChainId
+  chainId: bigint
   loginMethod?: PreferredLoginMethod
   userEmail?: string
 }
@@ -24,7 +23,7 @@ export interface ImplicitSessionData {
   walletAddress: Address.Address
   attestation: Attestation.Attestation
   identitySignature: Hex.Hex
-  chainId: ChainId
+  chainId: bigint
   loginMethod?: PreferredLoginMethod
   userEmail?: string
 }
@@ -37,7 +36,7 @@ export type PendingPayload =
   | SignTypedDataPayload
 
 export interface PendingRequestContext {
-  chainId: ChainId
+  chainId: bigint
   action: string
   payload: PendingPayload
 }

--- a/packages/wallet/primitives-cli/package.json
+++ b/packages/wallet/primitives-cli/package.json
@@ -8,6 +8,7 @@
     "dev:esbuild": "esbuild src/index.ts --bundle --platform=node --target=node16 --outfile=dist/index.js --watch --sourcemap",
     "start": "tsc && node dist/index.js",
     "lint": "eslint . --max-warnings 0",
+    "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "exports": {

--- a/packages/wallet/primitives/package.json
+++ b/packages/wallet/primitives/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "exports": {

--- a/packages/wallet/primitives/src/extensions/recovery.ts
+++ b/packages/wallet/primitives/src/extensions/recovery.ts
@@ -1,7 +1,8 @@
 import { Abi, AbiFunction, Address, Bytes, Hex, Provider } from 'ox'
-import * as Payload from '../payload.js'
 import * as GenericTree from '../generic-tree.js'
 import { Signature } from '../index.js'
+import * as Network from '../network.js'
+import * as Payload from '../payload.js'
 import { packRSY } from '../utils.js'
 
 export const FLAG_RECOVERY_LEAF = 1

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -16,7 +16,7 @@ export interface Network {
   rpcUrl: string
   logoUrl?: string
   blockExplorer?: BlockExplorerConfig
-  nativeToken: {
+  nativeCurrency: {
     symbol: string
     name: string
     decimals: number
@@ -157,7 +157,7 @@ export const ALL: Network[] = [
       name: 'Etherscan',
       url: 'https://etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -175,7 +175,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Ropsten)',
       url: 'https://ropsten.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'roETH',
       name: 'Ropsten Ether',
       decimals: 18,
@@ -194,7 +194,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Rinkeby)',
       url: 'https://rinkeby.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'rETH',
       name: 'Rinkeby Ether',
       decimals: 18,
@@ -213,7 +213,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Goerli)',
       url: 'https://goerli.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'gETH',
       name: 'Goerli Ether',
       decimals: 18,
@@ -232,7 +232,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Kovan)',
       url: 'https://kovan.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'kETH',
       name: 'Kovan Ether',
       decimals: 18,
@@ -250,7 +250,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Sepolia)',
       url: 'https://sepolia.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sETH',
       name: 'Sepolia Ether',
       decimals: 18,
@@ -267,7 +267,7 @@ export const ALL: Network[] = [
       name: 'Polygonscan',
       url: 'https://polygonscan.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'POL',
       name: 'POL',
       decimals: 18,
@@ -284,7 +284,7 @@ export const ALL: Network[] = [
       name: 'Polygonscan (Mumbai)',
       url: 'https://mumbai.polygonscan.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'mMATIC',
       name: 'Mumbai Polygon',
       decimals: 18,
@@ -302,7 +302,7 @@ export const ALL: Network[] = [
       name: 'OKLink (Amoy)',
       url: 'https://www.oklink.com/amoy/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'aPOL',
       name: 'Amoy POL',
       decimals: 18,
@@ -319,7 +319,7 @@ export const ALL: Network[] = [
       name: 'Polygonscan (zkEVM)',
       url: 'https://zkevm.polygonscan.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -336,7 +336,7 @@ export const ALL: Network[] = [
       name: 'BSCScan',
       url: 'https://bscscan.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'BNB',
       name: 'BNB',
       decimals: 18,
@@ -353,7 +353,7 @@ export const ALL: Network[] = [
       name: 'BSCScan (Testnet)',
       url: 'https://testnet.bscscan.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'tBNB',
       name: 'Testnet BNB',
       decimals: 18,
@@ -370,7 +370,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Optimism)',
       url: 'https://optimistic.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -387,7 +387,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Optimism Kovan)',
       url: 'https://kovan-optimistic.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'kETH',
       name: 'Kovan Ether',
       decimals: 18,
@@ -405,7 +405,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Optimism Goerli)',
       url: 'https://goerli-optimistic.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'gETH',
       name: 'Goerli Ether',
       decimals: 18,
@@ -423,7 +423,7 @@ export const ALL: Network[] = [
       name: 'Etherscan (Optimism Sepolia)',
       url: 'https://sepolia-optimistic.etherscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sETH',
       name: 'Sepolia Ether',
       decimals: 18,
@@ -440,7 +440,7 @@ export const ALL: Network[] = [
       name: 'Arbiscan',
       url: 'https://arbiscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -457,7 +457,7 @@ export const ALL: Network[] = [
       name: 'Arbiscan (Goerli Testnet)',
       url: 'https://testnet.arbiscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'gETH',
       name: 'Goerli Ether',
       decimals: 18,
@@ -475,7 +475,7 @@ export const ALL: Network[] = [
       name: 'Arbiscan (Sepolia Testnet)',
       url: 'https://sepolia.arbiscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sETH',
       name: 'Sepolia Ether',
       decimals: 18,
@@ -492,7 +492,7 @@ export const ALL: Network[] = [
       name: 'Arbiscan Nova',
       url: 'https://nova.arbiscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -509,7 +509,7 @@ export const ALL: Network[] = [
       name: 'Snowtrace',
       url: 'https://subnets.avax.network/c-chain/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'AVAX',
       name: 'AVAX',
       decimals: 18,
@@ -526,7 +526,7 @@ export const ALL: Network[] = [
       name: 'Snowtrace (Testnet)',
       url: 'https://subnets-test.avax.network/c-chain/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'tAVAX',
       name: 'Testnet AVAX',
       decimals: 18,
@@ -543,7 +543,7 @@ export const ALL: Network[] = [
       name: 'Gnosis Chain Explorer',
       url: 'https://blockscout.com/xdai/mainnet/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'XDAI',
       name: 'XDAI',
       decimals: 18,
@@ -560,7 +560,7 @@ export const ALL: Network[] = [
       name: 'Base Explorer',
       url: 'https://basescan.org/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -577,7 +577,7 @@ export const ALL: Network[] = [
       name: 'Base Goerli Explorer',
       url: 'https://goerli.basescan.org/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'gETH',
       name: 'Goerli Ether',
       decimals: 18,
@@ -595,7 +595,7 @@ export const ALL: Network[] = [
       name: 'Base Sepolia Explorer',
       url: 'https://base-sepolia.blockscout.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sETH',
       name: 'Sepolia Ether',
       decimals: 18,
@@ -612,7 +612,7 @@ export const ALL: Network[] = [
       name: 'Oasys Homeverse Explorer',
       url: 'https://explorer.oasys.homeverse.games/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'OAS',
       name: 'OAS',
       decimals: 18,
@@ -629,7 +629,7 @@ export const ALL: Network[] = [
       name: 'Oasys Homeverse Explorer (Testnet)',
       url: 'https://explorer.testnet.oasys.homeverse.games/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'tOAS',
       name: 'Testnet OAS',
       decimals: 18,
@@ -646,7 +646,7 @@ export const ALL: Network[] = [
       name: 'Xai Explorer',
       url: 'https://explorer.xai-chain.net/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'XAI',
       name: 'XAI',
       decimals: 18,
@@ -663,7 +663,7 @@ export const ALL: Network[] = [
       name: 'Xai Sepolia Explorer',
       url: 'https://testnet-explorer-v2.xai-chain.net/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sXAI',
       name: 'Sepolia XAI',
       decimals: 18,
@@ -680,7 +680,7 @@ export const ALL: Network[] = [
       name: 'B3 Explorer',
       url: 'https://explorer.b3.fun/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -697,7 +697,7 @@ export const ALL: Network[] = [
       name: 'B3 Sepolia Explorer',
       url: 'https://sepolia.explorer.b3.fun/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -714,7 +714,7 @@ export const ALL: Network[] = [
       name: 'APE Chain Explorer',
       url: 'https://apechain.calderaexplorer.xyz/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'APE',
       name: 'ApeCoin',
       decimals: 18,
@@ -731,7 +731,7 @@ export const ALL: Network[] = [
       name: 'APE Chain Explorer',
       url: 'https://curtis.explorer.caldera.xyz/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'APE',
       name: 'ApeCoin',
       decimals: 18,
@@ -748,7 +748,7 @@ export const ALL: Network[] = [
       name: 'Blast Explorer',
       url: 'https://blastscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -765,7 +765,7 @@ export const ALL: Network[] = [
       name: 'Blast Sepolia Explorer',
       url: 'https://sepolia.blastexplorer.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -782,7 +782,7 @@ export const ALL: Network[] = [
       name: 'Telos Explorer',
       url: 'https://explorer.telos.net/network/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'TLOS',
       name: 'TLOS',
       decimals: 18,
@@ -799,7 +799,7 @@ export const ALL: Network[] = [
       name: 'Telos Testnet Explorer',
       url: 'https://explorer-test.telos.net/network',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'TLOS',
       name: 'TLOS',
       decimals: 18,
@@ -816,7 +816,7 @@ export const ALL: Network[] = [
       name: 'Borne Testnet Explorer',
       url: 'https://subnets-test.avax.network/bornegfdn',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'BORNE',
       name: 'BORNE',
       decimals: 18,
@@ -834,7 +834,7 @@ export const ALL: Network[] = [
       name: 'SKALE Nebula Gaming Hub Explorer',
       url: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sFUEL',
       name: 'SKALE Fuel',
       decimals: 18,
@@ -851,7 +851,7 @@ export const ALL: Network[] = [
       name: 'SKALE Nebula Gaming Hub Testnet Explorer',
       url: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'sFUEL',
       name: 'SKALE Fuel',
       decimals: 18,
@@ -868,7 +868,7 @@ export const ALL: Network[] = [
       name: 'Soneium Explorer',
       url: 'https://soneium.blockscout.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -885,7 +885,7 @@ export const ALL: Network[] = [
       name: 'Soneium Minato Explorer',
       url: 'https://explorer-testnet.soneium.org/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'ETH',
       name: 'Ether',
       decimals: 18,
@@ -902,7 +902,7 @@ export const ALL: Network[] = [
       name: 'TOY Testnet Explorer',
       url: 'https://toy-chain-testnet.explorer.caldera.xyz/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'TOY',
       name: 'TOY',
       decimals: 18,
@@ -919,7 +919,7 @@ export const ALL: Network[] = [
       name: 'Immutable zkEVM Explorer',
       url: 'https://explorer.immutable.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'IMX',
       name: 'IMX',
       decimals: 18,
@@ -936,7 +936,7 @@ export const ALL: Network[] = [
       name: 'Immutable zkEVM Testnet Explorer',
       url: 'https://explorer.testnet.immutable.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'IMX',
       name: 'IMX',
       decimals: 18,
@@ -953,7 +953,7 @@ export const ALL: Network[] = [
       name: 'The Root Network Explorer',
       url: 'https://rootscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'XRP',
       name: 'XRP',
       decimals: 18,
@@ -970,7 +970,7 @@ export const ALL: Network[] = [
       name: 'The Root Network Porcini Testnet Explorer',
       url: 'https://porcini.rootscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'XRP',
       name: 'XRP',
       decimals: 18,
@@ -987,7 +987,7 @@ export const ALL: Network[] = [
       name: 'LAOS Explorer',
       url: 'https://blockscout.laos.laosfoundation.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'LAOS',
       name: 'LAOS',
       decimals: 18,
@@ -1004,7 +1004,7 @@ export const ALL: Network[] = [
       name: 'LAOS Sigma Testnet Explorer',
       url: 'https://sigma.explorer.laosnetwork.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'SIGMA',
       name: 'SIGMA',
       decimals: 18,
@@ -1021,7 +1021,7 @@ export const ALL: Network[] = [
       name: 'Moonscan',
       url: 'https://moonscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'GLMR',
       name: 'GLMR',
       decimals: 18,
@@ -1038,7 +1038,7 @@ export const ALL: Network[] = [
       name: 'Moonscan (Moonbase Alpha)',
       url: 'https://moonbase.moonscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'GLMR',
       name: 'GLMR',
       decimals: 18,
@@ -1055,7 +1055,7 @@ export const ALL: Network[] = [
       name: 'Etherlink Explorer',
       url: 'https://explorer.etherlink.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'XTZ',
       name: 'Tez',
       decimals: 18,
@@ -1072,7 +1072,7 @@ export const ALL: Network[] = [
       name: 'Etherlink Testnet Explorer',
       url: 'https://testnet.explorer.etherlink.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'XTZ',
       name: 'Tez',
       decimals: 18,
@@ -1089,7 +1089,7 @@ export const ALL: Network[] = [
       name: 'Monad Testnet Explorer',
       url: 'https://testnet.monadexplorer.com/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'MON',
       name: 'MON',
       decimals: 18,
@@ -1107,7 +1107,7 @@ export const ALL: Network[] = [
       name: 'Somnia Testnet Explorer',
       url: 'https://somnia-testnet.socialscan.io/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'STT',
       name: 'STT',
       decimals: 18,
@@ -1125,7 +1125,7 @@ export const ALL: Network[] = [
       name: 'Incentiv Testnet Explorer',
       url: 'https://explorer.testnet.incentiv.net/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'CENT',
       name: 'CENT',
       decimals: 18,
@@ -1143,7 +1143,7 @@ export const ALL: Network[] = [
       name: 'SEI Explorer',
       url: 'https://seitrace.com/?chain=pacific-1',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'SEI',
       name: 'SEI',
       decimals: 18,
@@ -1161,7 +1161,7 @@ export const ALL: Network[] = [
       name: 'Sei Testnet Explorer',
       url: 'https://seitrace.com/?chain=atlantic-2',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'SEI',
       name: 'SEI',
       decimals: 18,
@@ -1179,7 +1179,7 @@ export const ALL: Network[] = [
       name: 'Somnia Explorer',
       url: 'https://mainnet.somnia.w3us.site/',
     },
-    nativeToken: {
+    nativeCurrency: {
       symbol: 'SOMI',
       name: 'SOMI',
       decimals: 18,
@@ -1199,6 +1199,6 @@ export function getNetworkFromName(networkName: string): Network | undefined {
   return ALL.find((network) => network.name === networkName)
 }
 
-export function getNetworkFromChainId(chainId: ChainId | bigint | number): Network | undefined {
+export function getNetworkFromChainId(chainId: ChainId | bigint | number | string): Network | undefined {
   return ALL.find((network) => network.chainId === BigInt(chainId))
 }

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -28,15 +28,10 @@ export interface Network {
 export const ChainId = {
   // Ethereum
   MAINNET: 1n,
-  ROPSTEN: 3n, // network is deprecated
-  RINKEBY: 4n, // network is deprecated
-  GOERLI: 5n, // network is deprecated
-  KOVAN: 42n, // network is deprecated
   SEPOLIA: 11155111n,
 
   // Polygon
   POLYGON: 137n,
-  POLYGON_MUMBAI: 80001n, // network is deprecated
   POLYGON_ZKEVM: 1101n,
   POLYGON_AMOY: 80002n,
 
@@ -46,13 +41,10 @@ export const ChainId = {
 
   // Optimism
   OPTIMISM: 10n,
-  OPTIMISM_KOVAN: 69n, // network is deprecated
-  OPTIMISM_GOERLI: 420n, // network is deprecated
   OPTIMISM_SEPOLIA: 11155420n,
 
   // Arbitrum One
   ARBITRUM: 42161n,
-  ARBITRUM_GOERLI: 421613n, // network is deprecated
   ARBITRUM_SEPOLIA: 421614n,
 
   // Arbitrum Nova
@@ -67,7 +59,6 @@ export const ChainId = {
 
   // BASE
   BASE: 8453n,
-  BASE_GOERLI: 84531n, // network is deprecated
   BASE_SEPOLIA: 84532n,
 
   // HOMEVERSE
@@ -93,9 +84,6 @@ export const ChainId = {
   // Blast
   BLAST: 81457n,
   BLAST_SEPOLIA: 168587773n,
-
-  // Borne
-  BORNE_TESTNET: 94984n,
 
   // SKALE Nebula
   SKALE_NEBULA: 1482601649n,
@@ -165,81 +153,6 @@ export const ALL: Network[] = [
     ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   },
   {
-    chainId: ChainId.ROPSTEN,
-    type: NetworkType.TESTNET,
-    name: 'ropsten',
-    title: 'Ropsten',
-    rpcUrl: getRpcUrl('ropsten'),
-    logoUrl: getLogoUrl(ChainId.ROPSTEN),
-    blockExplorer: {
-      name: 'Etherscan (Ropsten)',
-      url: 'https://ropsten.etherscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'roETH',
-      name: 'Ropsten Ether',
-      decimals: 18,
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    deprecated: true,
-  },
-  {
-    chainId: ChainId.RINKEBY,
-    type: NetworkType.TESTNET,
-    name: 'rinkeby',
-    title: 'Rinkeby',
-    rpcUrl: getRpcUrl('rinkeby'),
-    logoUrl: getLogoUrl(ChainId.RINKEBY),
-    blockExplorer: {
-      name: 'Etherscan (Rinkeby)',
-      url: 'https://rinkeby.etherscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'rETH',
-      name: 'Rinkeby Ether',
-      decimals: 18,
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    deprecated: true,
-  },
-  {
-    chainId: ChainId.GOERLI,
-    type: NetworkType.TESTNET,
-    name: 'goerli',
-    title: 'Goerli',
-    rpcUrl: getRpcUrl('goerli'),
-    logoUrl: getLogoUrl(ChainId.GOERLI),
-    blockExplorer: {
-      name: 'Etherscan (Goerli)',
-      url: 'https://goerli.etherscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'gETH',
-      name: 'Goerli Ether',
-      decimals: 18,
-    },
-    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    deprecated: true,
-  },
-  {
-    chainId: ChainId.KOVAN,
-    type: NetworkType.TESTNET,
-    name: 'kovan',
-    title: 'Kovan',
-    rpcUrl: getRpcUrl('kovan'),
-    logoUrl: getLogoUrl(ChainId.KOVAN),
-    blockExplorer: {
-      name: 'Etherscan (Kovan)',
-      url: 'https://kovan.etherscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'kETH',
-      name: 'Kovan Ether',
-      decimals: 18,
-    },
-    deprecated: true,
-  },
-  {
     chainId: ChainId.SEPOLIA,
     type: NetworkType.TESTNET,
     name: 'sepolia',
@@ -272,24 +185,6 @@ export const ALL: Network[] = [
       name: 'POL',
       decimals: 18,
     },
-  },
-  {
-    chainId: ChainId.POLYGON_MUMBAI,
-    type: NetworkType.TESTNET,
-    name: 'mumbai',
-    title: 'Polygon Mumbai',
-    rpcUrl: getRpcUrl('mumbai'),
-    logoUrl: getLogoUrl(ChainId.POLYGON_MUMBAI),
-    blockExplorer: {
-      name: 'Polygonscan (Mumbai)',
-      url: 'https://mumbai.polygonscan.com/',
-    },
-    nativeCurrency: {
-      symbol: 'mMATIC',
-      name: 'Mumbai Polygon',
-      decimals: 18,
-    },
-    deprecated: true,
   },
   {
     chainId: ChainId.POLYGON_AMOY,
@@ -377,42 +272,6 @@ export const ALL: Network[] = [
     },
   },
   {
-    chainId: ChainId.OPTIMISM_KOVAN,
-    type: NetworkType.TESTNET,
-    name: 'optimism-kovan',
-    title: 'Optimism Kovan',
-    rpcUrl: getRpcUrl('optimism-kovan'),
-    logoUrl: getLogoUrl(ChainId.OPTIMISM_KOVAN),
-    blockExplorer: {
-      name: 'Etherscan (Optimism Kovan)',
-      url: 'https://kovan-optimistic.etherscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'kETH',
-      name: 'Kovan Ether',
-      decimals: 18,
-    },
-    deprecated: true,
-  },
-  {
-    chainId: ChainId.OPTIMISM_GOERLI,
-    type: NetworkType.TESTNET,
-    name: 'optimism-goerli',
-    title: 'Optimism Goerli',
-    rpcUrl: getRpcUrl('optimism-goerli'),
-    logoUrl: getLogoUrl(ChainId.OPTIMISM_GOERLI),
-    blockExplorer: {
-      name: 'Etherscan (Optimism Goerli)',
-      url: 'https://goerli-optimistic.etherscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'gETH',
-      name: 'Goerli Ether',
-      decimals: 18,
-    },
-    deprecated: true,
-  },
-  {
     chainId: ChainId.OPTIMISM_SEPOLIA,
     type: NetworkType.TESTNET,
     name: 'optimism-sepolia',
@@ -445,24 +304,6 @@ export const ALL: Network[] = [
       name: 'Ether',
       decimals: 18,
     },
-  },
-  {
-    chainId: ChainId.ARBITRUM_GOERLI,
-    type: NetworkType.TESTNET,
-    name: 'arbitrum-goerli',
-    title: 'Arbitrum Goerli',
-    rpcUrl: getRpcUrl('arbitrum-goerli'),
-    logoUrl: getLogoUrl(ChainId.ARBITRUM_GOERLI),
-    blockExplorer: {
-      name: 'Arbiscan (Goerli Testnet)',
-      url: 'https://testnet.arbiscan.io/',
-    },
-    nativeCurrency: {
-      symbol: 'gETH',
-      name: 'Goerli Ether',
-      decimals: 18,
-    },
-    deprecated: true,
   },
   {
     chainId: ChainId.ARBITRUM_SEPOLIA,
@@ -565,24 +406,6 @@ export const ALL: Network[] = [
       name: 'Ether',
       decimals: 18,
     },
-  },
-  {
-    chainId: ChainId.BASE_GOERLI,
-    type: NetworkType.TESTNET,
-    name: 'base-goerli',
-    title: 'Base Goerli',
-    rpcUrl: getRpcUrl('base-goerli'),
-    logoUrl: getLogoUrl(ChainId.BASE_GOERLI),
-    blockExplorer: {
-      name: 'Base Goerli Explorer',
-      url: 'https://goerli.basescan.org/',
-    },
-    nativeCurrency: {
-      symbol: 'gETH',
-      name: 'Goerli Ether',
-      decimals: 18,
-    },
-    deprecated: true,
   },
   {
     chainId: ChainId.BASE_SEPOLIA,
@@ -804,24 +627,6 @@ export const ALL: Network[] = [
       name: 'TLOS',
       decimals: 18,
     },
-  },
-  {
-    chainId: ChainId.BORNE_TESTNET,
-    type: NetworkType.TESTNET,
-    name: 'borne-testnet',
-    title: 'Borne Testnet',
-    rpcUrl: getRpcUrl('borne-testnet'),
-    logoUrl: getLogoUrl(ChainId.BORNE_TESTNET),
-    blockExplorer: {
-      name: 'Borne Testnet Explorer',
-      url: 'https://subnets-test.avax.network/bornegfdn',
-    },
-    nativeCurrency: {
-      symbol: 'BORNE',
-      name: 'BORNE',
-      decimals: 18,
-    },
-    deprecated: true,
   },
   {
     chainId: ChainId.SKALE_NEBULA,

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -1,630 +1,1166 @@
-export type Network = {
+export enum NetworkType {
+  MAINNET = 'mainnet',
+  TESTNET = 'testnet',
+  LOCAL = 'local',
+}
+
+export type BlockExplorerConfig = {
+  name?: string
+  rootUrl: string
+}
+
+export interface Network {
+  chainId: ChainId
+  type: NetworkType
   name: string
-  rpc: string
-  chainId: bigint
-  explorer: string
-  nativeCurrency: {
-    name: string
+  title?: string
+  logoURI?: string
+  blockExplorer?: BlockExplorerConfig
+  nativeToken: {
     symbol: string
+    name: string
     decimals: number
   }
+  ensAddress?: string
+  deprecated?: true
 }
 
-// Helper function to create RPC URL for a network
-function getRpcUrl(networkName: string): string {
-  return `https://nodes.sequence.app/${networkName}`
-}
+export const ChainId = {
+  // Ethereum
+  MAINNET: 1n,
+  ROPSTEN: 3n, // network is deprecated
+  RINKEBY: 4n, // network is deprecated
+  GOERLI: 5n, // network is deprecated
+  KOVAN: 42n, // network is deprecated
+  SEPOLIA: 11155111n,
 
-export const Mainnet: Network = {
-  name: 'mainnet',
-  rpc: getRpcUrl('mainnet'),
-  chainId: 1n,
-  explorer: 'https://etherscan.io/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  // Polygon
+  POLYGON: 137n,
+  POLYGON_MUMBAI: 80001n, // network is deprecated
+  POLYGON_ZKEVM: 1101n,
+  POLYGON_AMOY: 80002n,
+
+  // BSC
+  BSC: 56n,
+  BSC_TESTNET: 97n,
+
+  // Optimism
+  OPTIMISM: 10n,
+  OPTIMISM_KOVAN: 69n, // network is deprecated
+  OPTIMISM_GOERLI: 420n, // network is deprecated
+  OPTIMISM_SEPOLIA: 11155420n,
+
+  // Arbitrum One
+  ARBITRUM: 42161n,
+  ARBITRUM_GOERLI: 421613n, // network is deprecated
+  ARBITRUM_SEPOLIA: 421614n,
+
+  // Arbitrum Nova
+  ARBITRUM_NOVA: 42170n,
+
+  // Avalanche
+  AVALANCHE: 43114n,
+  AVALANCHE_TESTNET: 43113n,
+
+  // Gnosis Chain (XDAI)
+  GNOSIS: 100n,
+
+  // BASE
+  BASE: 8453n,
+  BASE_GOERLI: 84531n, // network is deprecated
+  BASE_SEPOLIA: 84532n,
+
+  // HOMEVERSE
+  HOMEVERSE_TESTNET: 40875n,
+  HOMEVERSE: 19011n,
+
+  // Xai
+  XAI: 660279n,
+  XAI_SEPOLIA: 37714555429n,
+
+  // TELOS
+  TELOS: 40n,
+  TELOS_TESTNET: 41n,
+
+  // B3 Sepolia
+  B3: 8333n,
+  B3_SEPOLIA: 1993n,
+
+  // APE Chain
+  APECHAIN: 33139n,
+  APECHAIN_TESTNET: 33111n,
+
+  // Blast
+  BLAST: 81457n,
+  BLAST_SEPOLIA: 168587773n,
+
+  // Borne
+  BORNE_TESTNET: 94984n,
+
+  // SKALE Nebula
+  SKALE_NEBULA: 1482601649n,
+  SKALE_NEBULA_TESTNET: 37084624n,
+
+  // Soneium Minato
+  SONEIUM_MINATO: 1946n,
+  SONEIUM: 1868n,
+
+  // TOY Testnet
+  TOY_TESTNET: 21000000n,
+
+  // Immutable zkEVM
+  IMMUTABLE_ZKEVM: 13371n,
+  IMMUTABLE_ZKEVM_TESTNET: 13473n,
+
+  // The Root Network
+  ROOT_NETWORK: 7668n,
+  ROOT_NETWORK_PORCINI: 7672n,
+
+  // HARDHAT TESTNETS
+  HARDHAT: 31337n,
+  HARDHAT_2: 31338n,
+
+  // LAOS
+  LAOS: 6283n,
+  LAOS_SIGMA_TESTNET: 62850n,
+
+  // ETHERLINK
+  ETHERLINK: 42793n,
+  ETHERLINK_TESTNET: 128123n,
+
+  // MOONBEAM
+  MOONBEAM: 1284n,
+  MOONBASE_ALPHA: 1287n,
+
+  // MONAD
+  MONAD_TESTNET: 10143n,
+
+  // SOMNIA
+  SOMNIA_TESTNET: 50312n,
+  SOMNIA: 5031n,
+
+  // INCENTIV
+  INCENTIV_TESTNET: 11690n,
+
+  // SEI
+  SEI: 1329n,
+  SEI_TESTNET: 1328n,
+} as const
+
+export type ChainId = (typeof ChainId)[keyof typeof ChainId]
+
+export const ALL: Network[] = [
+  {
+    chainId: ChainId.MAINNET,
+    type: NetworkType.MAINNET,
+    name: 'mainnet',
+    title: 'Ethereum',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MAINNET}.webp`,
+    blockExplorer: {
+      name: 'Etherscan',
+      rootUrl: 'https://etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   },
-}
-
-export const Sepolia: Network = {
-  name: 'sepolia',
-  rpc: getRpcUrl('sepolia'),
-  chainId: 11155111n,
-  explorer: 'https://sepolia.etherscan.io/',
-  nativeCurrency: {
-    name: 'Sepolia Ether',
-    symbol: 'sETH',
-    decimals: 18,
+  {
+    chainId: ChainId.ROPSTEN,
+    type: NetworkType.TESTNET,
+    name: 'ropsten',
+    title: 'Ropsten',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROPSTEN}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Ropsten)',
+      rootUrl: 'https://ropsten.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'roETH',
+      name: 'Ropsten Ether',
+      decimals: 18,
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    deprecated: true,
   },
-}
-
-export const Polygon: Network = {
-  name: 'polygon',
-  rpc: getRpcUrl('polygon'),
-  chainId: 137n,
-  explorer: 'https://polygonscan.com/',
-  nativeCurrency: {
-    name: 'POL',
-    symbol: 'POL',
-    decimals: 18,
+  {
+    chainId: ChainId.RINKEBY,
+    type: NetworkType.TESTNET,
+    name: 'rinkeby',
+    title: 'Rinkeby',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.RINKEBY}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Rinkeby)',
+      rootUrl: 'https://rinkeby.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'rETH',
+      name: 'Rinkeby Ether',
+      decimals: 18,
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    deprecated: true,
   },
-}
-
-export const PolygonAmoy: Network = {
-  name: 'amoy',
-  rpc: getRpcUrl('amoy'),
-  chainId: 80002n,
-  explorer: 'https://www.oklink.com/amoy/',
-  nativeCurrency: {
-    name: 'Amoy POL',
-    symbol: 'aPOL',
-    decimals: 18,
+  {
+    chainId: ChainId.GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'goerli',
+    title: 'Goerli',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GOERLI}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Goerli)',
+      rootUrl: 'https://goerli.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'gETH',
+      name: 'Goerli Ether',
+      decimals: 18,
+    },
+    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    deprecated: true,
   },
-}
-
-export const PolygonZkEVM: Network = {
-  name: 'polygon-zkevm',
-  rpc: getRpcUrl('polygon-zkevm'),
-  chainId: 1101n,
-  explorer: 'https://zkevm.polygonscan.com/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.KOVAN,
+    type: NetworkType.TESTNET,
+    name: 'kovan',
+    title: 'Kovan',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.KOVAN}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Kovan)',
+      rootUrl: 'https://kovan.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'kETH',
+      name: 'Kovan Ether',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const BSC: Network = {
-  name: 'bsc',
-  rpc: getRpcUrl('bsc'),
-  chainId: 56n,
-  explorer: 'https://bscscan.com/',
-  nativeCurrency: {
-    name: 'BNB',
-    symbol: 'BNB',
-    decimals: 18,
+  {
+    chainId: ChainId.SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'sepolia',
+    title: 'Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Sepolia)',
+      rootUrl: 'https://sepolia.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'sETH',
+      name: 'Sepolia Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const BSCTestnet: Network = {
-  name: 'bsc-testnet',
-  rpc: getRpcUrl('bsc-testnet'),
-  chainId: 97n,
-  explorer: 'https://testnet.bscscan.com/',
-  nativeCurrency: {
-    name: 'Testnet BNB',
-    symbol: 'tBNB',
-    decimals: 18,
+  {
+    chainId: ChainId.POLYGON,
+    type: NetworkType.MAINNET,
+    name: 'polygon',
+    title: 'Polygon',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON}.webp`,
+    blockExplorer: {
+      name: 'Polygonscan',
+      rootUrl: 'https://polygonscan.com/',
+    },
+    nativeToken: {
+      symbol: 'POL',
+      name: 'POL',
+      decimals: 18,
+    },
   },
-}
-
-export const Optimism: Network = {
-  name: 'optimism',
-  rpc: getRpcUrl('optimism'),
-  chainId: 10n,
-  explorer: 'https://optimistic.etherscan.io/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.POLYGON_MUMBAI,
+    type: NetworkType.TESTNET,
+    name: 'mumbai',
+    title: 'Polygon Mumbai',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_MUMBAI}.webp`,
+    blockExplorer: {
+      name: 'Polygonscan (Mumbai)',
+      rootUrl: 'https://mumbai.polygonscan.com/',
+    },
+    nativeToken: {
+      symbol: 'mMATIC',
+      name: 'Mumbai Polygon',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const OptimismSepolia: Network = {
-  name: 'optimism-sepolia',
-  rpc: getRpcUrl('optimism-sepolia'),
-  chainId: 11155420n,
-  explorer: 'https://sepolia-optimistic.etherscan.io/',
-  nativeCurrency: {
-    name: 'Sepolia Ether',
-    symbol: 'sETH',
-    decimals: 18,
+  {
+    chainId: ChainId.POLYGON_AMOY,
+    type: NetworkType.TESTNET,
+    name: 'amoy',
+    title: 'Polygon Amoy',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_AMOY}.webp`,
+    blockExplorer: {
+      name: 'OKLink (Amoy)',
+      rootUrl: 'https://www.oklink.com/amoy/',
+    },
+    nativeToken: {
+      symbol: 'aPOL',
+      name: 'Amoy POL',
+      decimals: 18,
+    },
   },
-}
-
-export const Arbitrum: Network = {
-  name: 'arbitrum',
-  rpc: getRpcUrl('arbitrum'),
-  chainId: 42161n,
-  explorer: 'https://arbiscan.io/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: NetworkType.MAINNET,
+    name: 'polygon-zkevm',
+    title: 'Polygon zkEVM',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_ZKEVM}.webp`,
+    blockExplorer: {
+      name: 'Polygonscan (zkEVM)',
+      rootUrl: 'https://zkevm.polygonscan.com/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const ArbitrumSepolia: Network = {
-  name: 'arbitrum-sepolia',
-  rpc: getRpcUrl('arbitrum-sepolia'),
-  chainId: 421614n,
-  explorer: 'https://sepolia.arbiscan.io/',
-  nativeCurrency: {
-    name: 'Sepolia Ether',
-    symbol: 'sETH',
-    decimals: 18,
+  {
+    chainId: ChainId.BSC,
+    type: NetworkType.MAINNET,
+    name: 'bsc',
+    title: 'BNB Smart Chain',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC}.webp`,
+    blockExplorer: {
+      name: 'BSCScan',
+      rootUrl: 'https://bscscan.com/',
+    },
+    nativeToken: {
+      symbol: 'BNB',
+      name: 'BNB',
+      decimals: 18,
+    },
   },
-}
-
-export const ArbitrumNova: Network = {
-  name: 'arbitrum-nova',
-  rpc: getRpcUrl('arbitrum-nova'),
-  chainId: 42170n,
-  explorer: 'https://nova.arbiscan.io/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.BSC_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'bsc-testnet',
+    title: 'BNB Smart Chain Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'BSCScan (Testnet)',
+      rootUrl: 'https://testnet.bscscan.com/',
+    },
+    nativeToken: {
+      symbol: 'tBNB',
+      name: 'Testnet BNB',
+      decimals: 18,
+    },
   },
-}
-
-export const Avalanche: Network = {
-  name: 'avalanche',
-  rpc: getRpcUrl('avalanche'),
-  chainId: 43114n,
-  explorer: 'https://subnets.avax.network/c-chain/',
-  nativeCurrency: {
-    name: 'AVAX',
-    symbol: 'AVAX',
-    decimals: 18,
+  {
+    chainId: ChainId.OPTIMISM,
+    type: NetworkType.MAINNET,
+    name: 'optimism',
+    title: 'Optimism',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Optimism)',
+      rootUrl: 'https://optimistic.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const AvalancheTestnet: Network = {
-  name: 'avalanche-testnet',
-  rpc: getRpcUrl('avalanche-testnet'),
-  chainId: 43113n,
-  explorer: 'https://subnets-test.avax.network/c-chain/',
-  nativeCurrency: {
-    name: 'Testnet AVAX',
-    symbol: 'tAVAX',
-    decimals: 18,
+  {
+    chainId: ChainId.OPTIMISM_KOVAN,
+    type: NetworkType.TESTNET,
+    name: 'optimism-kovan',
+    title: 'Optimism Kovan',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_KOVAN}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Optimism Kovan)',
+      rootUrl: 'https://kovan-optimistic.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'kETH',
+      name: 'Kovan Ether',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const Gnosis: Network = {
-  name: 'gnosis',
-  rpc: getRpcUrl('gnosis'),
-  chainId: 100n,
-  explorer: 'https://blockscout.com/xdai/mainnet/',
-  nativeCurrency: {
-    name: 'XDAI',
-    symbol: 'XDAI',
-    decimals: 18,
+  {
+    chainId: ChainId.OPTIMISM_GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'optimism-goerli',
+    title: 'Optimism Goerli',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_GOERLI}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Optimism Goerli)',
+      rootUrl: 'https://goerli-optimistic.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'gETH',
+      name: 'Goerli Ether',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const Base: Network = {
-  name: 'base',
-  rpc: getRpcUrl('base'),
-  chainId: 8453n,
-  explorer: 'https://basescan.org/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.OPTIMISM_SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'optimism-sepolia',
+    title: 'Optimism Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'Etherscan (Optimism Sepolia)',
+      rootUrl: 'https://sepolia-optimistic.etherscan.io/',
+    },
+    nativeToken: {
+      symbol: 'sETH',
+      name: 'Sepolia Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const BaseSepolia: Network = {
-  name: 'base-sepolia',
-  rpc: getRpcUrl('base-sepolia'),
-  chainId: 84532n,
-  explorer: 'https://base-sepolia.blockscout.com/',
-  nativeCurrency: {
-    name: 'Sepolia Ether',
-    symbol: 'sETH',
-    decimals: 18,
+  {
+    chainId: ChainId.ARBITRUM,
+    type: NetworkType.MAINNET,
+    name: 'arbitrum',
+    title: 'Arbitrum One',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM}.webp`,
+    blockExplorer: {
+      name: 'Arbiscan',
+      rootUrl: 'https://arbiscan.io/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const Homeverse: Network = {
-  name: 'homeverse',
-  rpc: getRpcUrl('homeverse'),
-  chainId: 19011n,
-  explorer: 'https://explorer.oasys.homeverse.games/',
-  nativeCurrency: {
-    name: 'OAS',
-    symbol: 'OAS',
-    decimals: 18,
+  {
+    chainId: ChainId.ARBITRUM_GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'arbitrum-goerli',
+    title: 'Arbitrum Goerli',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_GOERLI}.webp`,
+    blockExplorer: {
+      name: 'Arbiscan (Goerli Testnet)',
+      rootUrl: 'https://testnet.arbiscan.io/',
+    },
+    nativeToken: {
+      symbol: 'gETH',
+      name: 'Goerli Ether',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const HomeverseTestnet: Network = {
-  name: 'homeverse-testnet',
-  rpc: getRpcUrl('homeverse-testnet'),
-  chainId: 40875n,
-  explorer: 'https://explorer.testnet.oasys.homeverse.games/',
-  nativeCurrency: {
-    name: 'Testnet OAS',
-    symbol: 'tOAS',
-    decimals: 18,
+  {
+    chainId: ChainId.ARBITRUM_SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'arbitrum-sepolia',
+    title: 'Arbitrum Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'Arbiscan (Sepolia Testnet)',
+      rootUrl: 'https://sepolia.arbiscan.io/',
+    },
+    nativeToken: {
+      symbol: 'sETH',
+      name: 'Sepolia Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const Xai: Network = {
-  name: 'xai',
-  rpc: getRpcUrl('xai'),
-  chainId: 660279n,
-  explorer: 'https://explorer.xai-chain.net/',
-  nativeCurrency: {
-    name: 'XAI',
-    symbol: 'XAI',
-    decimals: 18,
+  {
+    chainId: ChainId.ARBITRUM_NOVA,
+    type: NetworkType.MAINNET,
+    name: 'arbitrum-nova',
+    title: 'Arbitrum Nova',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_NOVA}.webp`,
+    blockExplorer: {
+      name: 'Arbiscan Nova',
+      rootUrl: 'https://nova.arbiscan.io/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const XaiSepolia: Network = {
-  name: 'xai-sepolia',
-  rpc: getRpcUrl('xai-sepolia'),
-  chainId: 37714555429n,
-  explorer: 'https://testnet-explorer-v2.xai-chain.net/',
-  nativeCurrency: {
-    name: 'Sepolia XAI',
-    symbol: 'sXAI',
-    decimals: 18,
+  {
+    chainId: ChainId.AVALANCHE,
+    type: NetworkType.MAINNET,
+    name: 'avalanche',
+    title: 'Avalanche',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE}.webp`,
+    blockExplorer: {
+      name: 'Snowtrace',
+      rootUrl: 'https://subnets.avax.network/c-chain/',
+    },
+    nativeToken: {
+      symbol: 'AVAX',
+      name: 'AVAX',
+      decimals: 18,
+    },
   },
-}
-
-export const Telos: Network = {
-  name: 'telos',
-  rpc: getRpcUrl('telos'),
-  chainId: 40n,
-  explorer: 'https://explorer.telos.net/network/',
-  nativeCurrency: {
-    name: 'TLOS',
-    symbol: 'TLOS',
-    decimals: 18,
+  {
+    chainId: ChainId.AVALANCHE_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'avalanche-testnet',
+    title: 'Avalanche Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Snowtrace (Testnet)',
+      rootUrl: 'https://subnets-test.avax.network/c-chain/',
+    },
+    nativeToken: {
+      symbol: 'tAVAX',
+      name: 'Testnet AVAX',
+      decimals: 18,
+    },
   },
-}
-
-export const TelosTestnet: Network = {
-  name: 'telos-testnet',
-  rpc: getRpcUrl('telos-testnet'),
-  chainId: 41n,
-  explorer: 'https://explorer-test.telos.net/network',
-  nativeCurrency: {
-    name: 'TLOS',
-    symbol: 'TLOS',
-    decimals: 18,
+  {
+    chainId: ChainId.GNOSIS,
+    type: NetworkType.MAINNET,
+    name: 'gnosis',
+    title: 'Gnosis Chain',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GNOSIS}.webp`,
+    blockExplorer: {
+      name: 'Gnosis Chain Explorer',
+      rootUrl: 'https://blockscout.com/xdai/mainnet/',
+    },
+    nativeToken: {
+      symbol: 'XDAI',
+      name: 'XDAI',
+      decimals: 18,
+    },
   },
-}
-
-export const B3: Network = {
-  name: 'b3',
-  rpc: getRpcUrl('b3'),
-  chainId: 8333n,
-  explorer: 'https://explorer.b3.fun/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.BASE,
+    type: NetworkType.MAINNET,
+    name: 'base',
+    title: 'Base (Coinbase)',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE}.webp`,
+    blockExplorer: {
+      name: 'Base Explorer',
+      rootUrl: 'https://basescan.org/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const B3Sepolia: Network = {
-  name: 'b3-sepolia',
-  rpc: getRpcUrl('b3-sepolia'),
-  chainId: 1993n,
-  explorer: 'https://sepolia.explorer.b3.fun/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.BASE_GOERLI,
+    type: NetworkType.TESTNET,
+    name: 'base-goerli',
+    title: 'Base Goerli',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_GOERLI}.webp`,
+    blockExplorer: {
+      name: 'Base Goerli Explorer',
+      rootUrl: 'https://goerli.basescan.org/',
+    },
+    nativeToken: {
+      symbol: 'gETH',
+      name: 'Goerli Ether',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const ApeChain: Network = {
-  name: 'apechain',
-  rpc: getRpcUrl('apechain'),
-  chainId: 33139n,
-  explorer: 'https://apechain.calderaexplorer.xyz/',
-  nativeCurrency: {
-    name: 'ApeCoin',
-    symbol: 'APE',
-    decimals: 18,
+  {
+    chainId: ChainId.BASE_SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'base-sepolia',
+    title: 'Base Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'Base Sepolia Explorer',
+      rootUrl: 'https://base-sepolia.blockscout.com/',
+    },
+    nativeToken: {
+      symbol: 'sETH',
+      name: 'Sepolia Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const ApeChainTestnet: Network = {
-  name: 'apechain-testnet',
-  rpc: getRpcUrl('apechain-testnet'),
-  chainId: 33111n,
-  explorer: 'https://curtis.explorer.caldera.xyz/',
-  nativeCurrency: {
-    name: 'ApeCoin',
-    symbol: 'APE',
-    decimals: 18,
+  {
+    chainId: ChainId.HOMEVERSE,
+    type: NetworkType.MAINNET,
+    name: 'homeverse',
+    title: 'Oasys Homeverse',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE}.webp`,
+    blockExplorer: {
+      name: 'Oasys Homeverse Explorer',
+      rootUrl: 'https://explorer.oasys.homeverse.games/',
+    },
+    nativeToken: {
+      symbol: 'OAS',
+      name: 'OAS',
+      decimals: 18,
+    },
   },
-}
-
-export const Blast: Network = {
-  name: 'blast',
-  rpc: getRpcUrl('blast'),
-  chainId: 81457n,
-  explorer: 'https://blastscan.io/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.HOMEVERSE_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'homeverse-testnet',
+    title: 'Oasys Homeverse Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Oasys Homeverse Explorer (Testnet)',
+      rootUrl: 'https://explorer.testnet.oasys.homeverse.games/',
+    },
+    nativeToken: {
+      symbol: 'tOAS',
+      name: 'Testnet OAS',
+      decimals: 18,
+    },
   },
-}
-
-export const BlastSepolia: Network = {
-  name: 'blast-sepolia',
-  rpc: getRpcUrl('blast-sepolia'),
-  chainId: 168587773n,
-  explorer: 'https://sepolia.blastexplorer.io/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.XAI,
+    type: NetworkType.MAINNET,
+    name: 'xai',
+    title: 'Xai',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI}.webp`,
+    blockExplorer: {
+      name: 'Xai Explorer',
+      rootUrl: 'https://explorer.xai-chain.net/',
+    },
+    nativeToken: {
+      symbol: 'XAI',
+      name: 'XAI',
+      decimals: 18,
+    },
   },
-}
-
-export const SkaleNebula: Network = {
-  name: 'skale-nebula',
-  rpc: getRpcUrl('skale-nebula'),
-  chainId: 1482601649n,
-  explorer: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
-  nativeCurrency: {
-    name: 'SKALE Fuel',
-    symbol: 'sFUEL',
-    decimals: 18,
+  {
+    chainId: ChainId.XAI_SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'xai-sepolia',
+    title: 'Xai Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI_SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'Xai Sepolia Explorer',
+      rootUrl: 'https://testnet-explorer-v2.xai-chain.net/',
+    },
+    nativeToken: {
+      symbol: 'sXAI',
+      name: 'Sepolia XAI',
+      decimals: 18,
+    },
   },
-}
-
-export const SkaleNebulaTestnet: Network = {
-  name: 'skale-nebula-testnet',
-  rpc: getRpcUrl('skale-nebula-testnet'),
-  chainId: 37084624n,
-  explorer: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
-  nativeCurrency: {
-    name: 'SKALE Fuel',
-    symbol: 'sFUEL',
-    decimals: 18,
+  {
+    chainId: ChainId.B3,
+    type: NetworkType.MAINNET,
+    name: 'b3',
+    title: 'B3',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3}.webp`,
+    blockExplorer: {
+      name: 'B3 Explorer',
+      rootUrl: 'https://explorer.b3.fun/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const Soneium: Network = {
-  name: 'soneium',
-  rpc: getRpcUrl('soneium'),
-  chainId: 1868n,
-  explorer: 'https://soneium.blockscout.com/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.B3_SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'b3-sepolia',
+    title: 'B3 Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3_SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'B3 Sepolia Explorer',
+      rootUrl: 'https://sepolia.explorer.b3.fun/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const SoneiumMinato: Network = {
-  name: 'soneium-minato',
-  rpc: getRpcUrl('soneium-minato'),
-  chainId: 1946n,
-  explorer: 'https://explorer-testnet.soneium.org/',
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
+  {
+    chainId: ChainId.APECHAIN,
+    type: NetworkType.MAINNET,
+    name: 'apechain',
+    title: 'APE Chain',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN}.webp`,
+    blockExplorer: {
+      name: 'APE Chain Explorer',
+      rootUrl: 'https://apechain.calderaexplorer.xyz/',
+    },
+    nativeToken: {
+      symbol: 'APE',
+      name: 'ApeCoin',
+      decimals: 18,
+    },
   },
-}
-
-export const ToyTestnet: Network = {
-  name: 'toy-testnet',
-  rpc: getRpcUrl('toy-testnet'),
-  chainId: 21000000n,
-  explorer: 'https://toy-chain-testnet.explorer.caldera.xyz/',
-  nativeCurrency: {
-    name: 'TOY',
-    symbol: 'TOY',
-    decimals: 18,
+  {
+    chainId: ChainId.APECHAIN_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'apechain-testnet',
+    title: 'APE Chain Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'APE Chain Explorer',
+      rootUrl: 'https://curtis.explorer.caldera.xyz/',
+    },
+    nativeToken: {
+      symbol: 'APE',
+      name: 'ApeCoin',
+      decimals: 18,
+    },
   },
-}
-
-export const ImmutableZkEVM: Network = {
-  name: 'immutable-zkevm',
-  rpc: getRpcUrl('immutable-zkevm'),
-  chainId: 13371n,
-  explorer: 'https://explorer.immutable.com/',
-  nativeCurrency: {
-    name: 'IMX',
-    symbol: 'IMX',
-    decimals: 18,
+  {
+    chainId: ChainId.BLAST,
+    type: NetworkType.MAINNET,
+    name: 'blast',
+    title: 'Blast',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST}.webp`,
+    blockExplorer: {
+      name: 'Blast Explorer',
+      rootUrl: 'https://blastscan.io/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const ImmutableZkEVMTestnet: Network = {
-  name: 'immutable-zkevm-testnet',
-  rpc: getRpcUrl('immutable-zkevm-testnet'),
-  chainId: 13473n,
-  explorer: 'https://explorer.testnet.immutable.com/',
-  nativeCurrency: {
-    name: 'IMX',
-    symbol: 'IMX',
-    decimals: 18,
+  {
+    chainId: ChainId.BLAST_SEPOLIA,
+    type: NetworkType.TESTNET,
+    name: 'blast-sepolia',
+    title: 'Blast Sepolia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST_SEPOLIA}.webp`,
+    blockExplorer: {
+      name: 'Blast Sepolia Explorer',
+      rootUrl: 'https://sepolia.blastexplorer.io/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const RootNetwork: Network = {
-  name: 'rootnet',
-  rpc: getRpcUrl('rootnet'),
-  chainId: 7668n,
-  explorer: 'https://rootscan.io/',
-  nativeCurrency: {
-    name: 'XRP',
-    symbol: 'XRP',
-    decimals: 18,
+  {
+    chainId: ChainId.TELOS,
+    type: NetworkType.MAINNET,
+    name: 'telos',
+    title: 'Telos',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS}.webp`,
+    blockExplorer: {
+      name: 'Telos Explorer',
+      rootUrl: 'https://explorer.telos.net/network/',
+    },
+    nativeToken: {
+      symbol: 'TLOS',
+      name: 'TLOS',
+      decimals: 18,
+    },
   },
-}
-
-export const RootNetworkPorcini: Network = {
-  name: 'rootnet-porcini',
-  rpc: getRpcUrl('rootnet-porcini'),
-  chainId: 7672n,
-  explorer: 'https://porcini.rootscan.io/',
-  nativeCurrency: {
-    name: 'XRP',
-    symbol: 'XRP',
-    decimals: 18,
+  {
+    chainId: ChainId.TELOS_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'telos-testnet',
+    title: 'Telos Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Telos Testnet Explorer',
+      rootUrl: 'https://explorer-test.telos.net/network',
+    },
+    nativeToken: {
+      symbol: 'TLOS',
+      name: 'TLOS',
+      decimals: 18,
+    },
   },
-}
-
-export const Laos: Network = {
-  name: 'laos',
-  rpc: getRpcUrl('laos'),
-  chainId: 6283n,
-  explorer: 'https://blockscout.laos.laosfoundation.io/',
-  nativeCurrency: {
-    name: 'LAOS',
-    symbol: 'LAOS',
-    decimals: 18,
+  {
+    chainId: ChainId.BORNE_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'borne-testnet',
+    title: 'Borne Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BORNE_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Borne Testnet Explorer',
+      rootUrl: 'https://subnets-test.avax.network/bornegfdn',
+    },
+    nativeToken: {
+      symbol: 'BORNE',
+      name: 'BORNE',
+      decimals: 18,
+    },
+    deprecated: true,
   },
-}
-
-export const LaosSigmaTestnet: Network = {
-  name: 'laos-sigma-testnet',
-  rpc: getRpcUrl('laos-sigma-testnet'),
-  chainId: 62850n,
-  explorer: 'https://sigma.explorer.laosnetwork.io/',
-  nativeCurrency: {
-    name: 'SIGMA',
-    symbol: 'SIGMA',
-    decimals: 18,
+  {
+    chainId: ChainId.SKALE_NEBULA,
+    type: NetworkType.MAINNET,
+    name: 'skale-nebula',
+    title: 'SKALE Nebula Gaming Hub',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA}.webp`,
+    blockExplorer: {
+      name: 'SKALE Nebula Gaming Hub Explorer',
+      rootUrl: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
+    },
+    nativeToken: {
+      symbol: 'sFUEL',
+      name: 'SKALE Fuel',
+      decimals: 18,
+    },
   },
-}
-
-export const Moonbeam: Network = {
-  name: 'moonbeam',
-  rpc: getRpcUrl('moonbeam'),
-  chainId: 1284n,
-  explorer: 'https://moonscan.io/',
-  nativeCurrency: {
-    name: 'GLMR',
-    symbol: 'GLMR',
-    decimals: 18,
+  {
+    chainId: ChainId.SKALE_NEBULA_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'skale-nebula-testnet',
+    title: 'SKALE Nebula Gaming Hub Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'SKALE Nebula Gaming Hub Testnet Explorer',
+      rootUrl: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
+    },
+    nativeToken: {
+      symbol: 'sFUEL',
+      name: 'SKALE Fuel',
+      decimals: 18,
+    },
   },
-}
-
-export const MoonbaseAlpha: Network = {
-  name: 'moonbase-alpha',
-  rpc: getRpcUrl('moonbase-alpha'),
-  chainId: 1287n,
-  explorer: 'https://moonbase.moonscan.io/',
-  nativeCurrency: {
-    name: 'GLMR',
-    symbol: 'GLMR',
-    decimals: 18,
+  {
+    chainId: ChainId.SONEIUM,
+    type: NetworkType.MAINNET,
+    name: 'soneium',
+    title: 'Soneium',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM}.webp`,
+    blockExplorer: {
+      name: 'Soneium Explorer',
+      rootUrl: 'https://soneium.blockscout.com/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const Etherlink: Network = {
-  name: 'etherlink',
-  rpc: getRpcUrl('etherlink'),
-  chainId: 42793n,
-  explorer: 'https://explorer.etherlink.com/',
-  nativeCurrency: {
-    name: 'Tez',
-    symbol: 'XTZ',
-    decimals: 18,
+  {
+    chainId: ChainId.SONEIUM_MINATO,
+    type: NetworkType.TESTNET,
+    name: 'soneium-minato',
+    title: 'Soneium Minato (Testnet)',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM_MINATO}.webp`,
+    blockExplorer: {
+      name: 'Soneium Minato Explorer',
+      rootUrl: 'https://explorer-testnet.soneium.org/',
+    },
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
   },
-}
-
-export const EtherlinkTestnet: Network = {
-  name: 'etherlink-testnet',
-  rpc: getRpcUrl('etherlink-testnet'),
-  chainId: 128123n,
-  explorer: 'https://testnet.explorer.etherlink.com/',
-  nativeCurrency: {
-    name: 'Tez',
-    symbol: 'XTZ',
-    decimals: 18,
+  {
+    chainId: ChainId.TOY_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'toy-testnet',
+    title: 'TOY (Testnet)',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TOY_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'TOY Testnet Explorer',
+      rootUrl: 'https://toy-chain-testnet.explorer.caldera.xyz/',
+    },
+    nativeToken: {
+      symbol: 'TOY',
+      name: 'TOY',
+      decimals: 18,
+    },
   },
-}
-
-export const MonadTestnet: Network = {
-  name: 'monad-testnet',
-  rpc: getRpcUrl('monad-testnet'),
-  chainId: 10143n,
-  explorer: 'https://testnet.monadexplorer.com/',
-  nativeCurrency: {
-    name: 'MON',
-    symbol: 'MON',
-    decimals: 18,
+  {
+    chainId: ChainId.IMMUTABLE_ZKEVM,
+    type: NetworkType.MAINNET,
+    name: 'immutable-zkevm',
+    title: 'Immutable zkEVM',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM}.webp`,
+    blockExplorer: {
+      name: 'Immutable zkEVM Explorer',
+      rootUrl: 'https://explorer.immutable.com/',
+    },
+    nativeToken: {
+      symbol: 'IMX',
+      name: 'IMX',
+      decimals: 18,
+    },
   },
-}
-
-export const Somnia: Network = {
-  name: 'somnia',
-  rpc: getRpcUrl('somnia'),
-  chainId: 5031n,
-  explorer: 'https://mainnet.somnia.w3us.site/',
-  nativeCurrency: {
-    name: 'SOMI',
-    symbol: 'SOMI',
-    decimals: 18,
+  {
+    chainId: ChainId.IMMUTABLE_ZKEVM_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'immutable-zkevm-testnet',
+    title: 'Immutable zkEVM Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Immutable zkEVM Testnet Explorer',
+      rootUrl: 'https://explorer.testnet.immutable.com/',
+    },
+    nativeToken: {
+      symbol: 'IMX',
+      name: 'IMX',
+      decimals: 18,
+    },
   },
-}
-
-export const SomniaTestnet: Network = {
-  name: 'somnia-testnet',
-  rpc: getRpcUrl('somnia-testnet'),
-  chainId: 50312n,
-  explorer: 'https://somnia-testnet.socialscan.io/',
-  nativeCurrency: {
-    name: 'STT',
-    symbol: 'STT',
-    decimals: 18,
+  {
+    chainId: ChainId.ROOT_NETWORK,
+    type: NetworkType.MAINNET,
+    name: 'rootnet',
+    title: 'The Root Network',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK}.webp`,
+    blockExplorer: {
+      name: 'The Root Network Explorer',
+      rootUrl: 'https://rootscan.io/',
+    },
+    nativeToken: {
+      symbol: 'XRP',
+      name: 'XRP',
+      decimals: 18,
+    },
   },
-}
+  {
+    chainId: ChainId.ROOT_NETWORK_PORCINI,
+    type: NetworkType.TESTNET,
+    name: 'rootnet-porcini',
+    title: 'The Root Network Porcini Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK_PORCINI}.webp`,
+    blockExplorer: {
+      name: 'The Root Network Porcini Testnet Explorer',
+      rootUrl: 'https://porcini.rootscan.io/',
+    },
+    nativeToken: {
+      symbol: 'XRP',
+      name: 'XRP',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.HARDHAT,
+    type: NetworkType.LOCAL,
+    name: 'hardhat',
+    title: 'Hardhat (local testnet)',
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.HARDHAT_2,
+    type: NetworkType.LOCAL,
+    name: 'hardhat2',
+    title: 'Hardhat (local testnet)',
+    nativeToken: {
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.LAOS,
+    type: NetworkType.MAINNET,
+    name: 'laos',
+    title: 'LAOS',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS}.webp`,
+    blockExplorer: {
+      name: 'LAOS Explorer',
+      rootUrl: 'https://blockscout.laos.laosfoundation.io/',
+    },
+    nativeToken: {
+      symbol: 'LAOS',
+      name: 'LAOS',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.LAOS_SIGMA_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'laos-sigma-testnet',
+    title: 'LAOS Sigma Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS_SIGMA_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'LAOS Sigma Testnet Explorer',
+      rootUrl: 'https://sigma.explorer.laosnetwork.io/',
+    },
+    nativeToken: {
+      symbol: 'SIGMA',
+      name: 'SIGMA',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.MOONBEAM,
+    type: NetworkType.MAINNET,
+    name: 'moonbeam',
+    title: 'Moonbeam',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBEAM}.webp`,
+    blockExplorer: {
+      name: 'Moonscan',
+      rootUrl: 'https://moonscan.io/',
+    },
+    nativeToken: {
+      symbol: 'GLMR',
+      name: 'GLMR',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.MOONBASE_ALPHA,
+    type: NetworkType.TESTNET,
+    name: 'moonbase-alpha',
+    title: 'Moonbase Alpha',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBASE_ALPHA}.webp`,
+    blockExplorer: {
+      name: 'Moonscan (Moonbase Alpha)',
+      rootUrl: 'https://moonbase.moonscan.io/',
+    },
+    nativeToken: {
+      symbol: 'GLMR',
+      name: 'GLMR',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.ETHERLINK,
+    type: NetworkType.MAINNET,
+    name: 'etherlink',
+    title: 'Etherlink',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK}.webp`,
+    blockExplorer: {
+      name: 'Etherlink Explorer',
+      rootUrl: 'https://explorer.etherlink.com/',
+    },
+    nativeToken: {
+      symbol: 'XTZ',
+      name: 'Tez',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.ETHERLINK_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'etherlink-testnet',
+    title: 'Etherlink Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Etherlink Testnet Explorer',
+      rootUrl: 'https://testnet.explorer.etherlink.com/',
+    },
+    nativeToken: {
+      symbol: 'XTZ',
+      name: 'Tez',
+      decimals: 18,
+    },
+  },
+  {
+    chainId: ChainId.MONAD_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'monad-testnet',
+    title: 'Monad Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MONAD_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Monad Testnet Explorer',
+      rootUrl: 'https://testnet.monadexplorer.com/',
+    },
+    nativeToken: {
+      symbol: 'MON',
+      name: 'MON',
+      decimals: 18,
+    },
+  },
 
-export const All = [
-  Mainnet,
-  Sepolia,
-  Polygon,
-  PolygonAmoy,
-  PolygonZkEVM,
-  BSC,
-  BSCTestnet,
-  Optimism,
-  OptimismSepolia,
-  Arbitrum,
-  ArbitrumSepolia,
-  ArbitrumNova,
-  Avalanche,
-  AvalancheTestnet,
-  Gnosis,
-  Base,
-  BaseSepolia,
-  Homeverse,
-  HomeverseTestnet,
-  Xai,
-  XaiSepolia,
-  Telos,
-  TelosTestnet,
-  B3,
-  B3Sepolia,
-  ApeChain,
-  ApeChainTestnet,
-  Blast,
-  BlastSepolia,
-  SkaleNebula,
-  SkaleNebulaTestnet,
-  Soneium,
-  SoneiumMinato,
-  ToyTestnet,
-  ImmutableZkEVM,
-  ImmutableZkEVMTestnet,
-  RootNetwork,
-  RootNetworkPorcini,
-  Laos,
-  LaosSigmaTestnet,
-  Moonbeam,
-  MoonbaseAlpha,
-  Etherlink,
-  EtherlinkTestnet,
-  MonadTestnet,
-  Somnia,
-  SomniaTestnet,
+  {
+    chainId: ChainId.SOMNIA_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'somnia-testnet',
+    title: 'Somnia Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Somnia Testnet Explorer',
+      rootUrl: 'https://somnia-testnet.socialscan.io/',
+    },
+    nativeToken: {
+      symbol: 'STT',
+      name: 'STT',
+      decimals: 18,
+    },
+  },
+
+  {
+    chainId: ChainId.INCENTIV_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'incentiv-testnet',
+    title: 'Incentiv Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.INCENTIV_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Incentiv Testnet Explorer',
+      rootUrl: 'https://explorer.testnet.incentiv.net/',
+    },
+    nativeToken: {
+      symbol: 'CENT',
+      name: 'CENT',
+      decimals: 18,
+    },
+  },
+
+  {
+    chainId: ChainId.SEI,
+    type: NetworkType.MAINNET,
+    name: 'sei',
+    title: 'Sei',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI}.webp`,
+    blockExplorer: {
+      name: 'SEI Explorer',
+      rootUrl: 'https://seitrace.com/?chain=pacific-1',
+    },
+    nativeToken: {
+      symbol: 'SEI',
+      name: 'SEI',
+      decimals: 18,
+    },
+  },
+
+  {
+    chainId: ChainId.SEI_TESTNET,
+    type: NetworkType.TESTNET,
+    name: 'sei-testnet',
+    title: 'Sei Testnet',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI_TESTNET}.webp`,
+    blockExplorer: {
+      name: 'Sei Testnet Explorer',
+      rootUrl: 'https://seitrace.com/?chain=atlantic-2',
+    },
+    nativeToken: {
+      symbol: 'SEI',
+      name: 'SEI',
+      decimals: 18,
+    },
+  },
+
+  {
+    chainId: ChainId.SOMNIA,
+    type: NetworkType.MAINNET,
+    name: 'somnia',
+    title: 'Somnia',
+    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA}.webp`,
+    blockExplorer: {
+      name: 'Somnia Explorer',
+      rootUrl: 'https://mainnet.somnia.w3us.site/',
+    },
+    nativeToken: {
+      symbol: 'SOMI',
+      name: 'SOMI',
+      decimals: 18,
+    },
+  },
 ]
+
+export function getNetworkFromName(networkName: string): Network | undefined {
+  return ALL.find((network) => network.name === networkName)
+}
+
+export function getNetworkFromChainId(chainId: ChainId | bigint | number): Network | undefined {
+  return ALL.find((network) => network.chainId === BigInt(chainId))
+}
+
+export function getRpcUrl(network: Network): string {
+  return `https://nodes.sequence.app/${network.name}`
+}

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -1,7 +1,6 @@
 export enum NetworkType {
   MAINNET = 'mainnet',
   TESTNET = 'testnet',
-  LOCAL = 'local',
 }
 
 export type BlockExplorerConfig = {
@@ -116,10 +115,6 @@ export const ChainId = {
   // The Root Network
   ROOT_NETWORK: 7668n,
   ROOT_NETWORK_PORCINI: 7672n,
-
-  // HARDHAT TESTNETS
-  HARDHAT: 31337n,
-  HARDHAT_2: 31338n,
 
   // LAOS
   LAOS: 6283n,
@@ -978,30 +973,6 @@ export const ALL: Network[] = [
     nativeToken: {
       symbol: 'XRP',
       name: 'XRP',
-      decimals: 18,
-    },
-  },
-  {
-    chainId: ChainId.HARDHAT,
-    type: NetworkType.LOCAL,
-    name: 'hardhat',
-    title: 'Hardhat (local testnet)',
-    rpcUrl: 'http://localhost:8545',
-    nativeToken: {
-      symbol: 'ETH',
-      name: 'Ether',
-      decimals: 18,
-    },
-  },
-  {
-    chainId: ChainId.HARDHAT_2,
-    type: NetworkType.LOCAL,
-    name: 'hardhat2',
-    title: 'Hardhat (local testnet)',
-    rpcUrl: 'http://localhost:8545',
-    nativeToken: {
-      symbol: 'ETH',
-      name: 'Ether',
       decimals: 18,
     },
   },

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -14,6 +14,7 @@ export interface Network {
   type: NetworkType
   name: string
   title?: string
+  rpc: string
   logoURI?: string
   blockExplorer?: BlockExplorerConfig
   nativeToken: {
@@ -155,6 +156,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'mainnet',
     title: 'Ethereum',
+    rpc: getRpcUrl('mainnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MAINNET}.webp`,
     blockExplorer: {
       name: 'Etherscan',
@@ -172,6 +174,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'ropsten',
     title: 'Ropsten',
+    rpc: getRpcUrl('ropsten'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROPSTEN}.webp`,
     blockExplorer: {
       name: 'Etherscan (Ropsten)',
@@ -190,6 +193,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'rinkeby',
     title: 'Rinkeby',
+    rpc: getRpcUrl('rinkeby'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.RINKEBY}.webp`,
     blockExplorer: {
       name: 'Etherscan (Rinkeby)',
@@ -208,6 +212,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'goerli',
     title: 'Goerli',
+    rpc: getRpcUrl('goerli'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GOERLI}.webp`,
     blockExplorer: {
       name: 'Etherscan (Goerli)',
@@ -226,6 +231,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'kovan',
     title: 'Kovan',
+    rpc: getRpcUrl('kovan'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.KOVAN}.webp`,
     blockExplorer: {
       name: 'Etherscan (Kovan)',
@@ -243,6 +249,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'sepolia',
     title: 'Sepolia',
+    rpc: getRpcUrl('sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Etherscan (Sepolia)',
@@ -259,6 +266,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'polygon',
     title: 'Polygon',
+    rpc: getRpcUrl('polygon'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON}.webp`,
     blockExplorer: {
       name: 'Polygonscan',
@@ -275,6 +283,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'mumbai',
     title: 'Polygon Mumbai',
+    rpc: getRpcUrl('mumbai'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_MUMBAI}.webp`,
     blockExplorer: {
       name: 'Polygonscan (Mumbai)',
@@ -292,6 +301,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'amoy',
     title: 'Polygon Amoy',
+    rpc: getRpcUrl('amoy'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_AMOY}.webp`,
     blockExplorer: {
       name: 'OKLink (Amoy)',
@@ -308,6 +318,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'polygon-zkevm',
     title: 'Polygon zkEVM',
+    rpc: getRpcUrl('polygon-zkevm'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_ZKEVM}.webp`,
     blockExplorer: {
       name: 'Polygonscan (zkEVM)',
@@ -324,6 +335,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'bsc',
     title: 'BNB Smart Chain',
+    rpc: getRpcUrl('bsc'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC}.webp`,
     blockExplorer: {
       name: 'BSCScan',
@@ -340,6 +352,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'bsc-testnet',
     title: 'BNB Smart Chain Testnet',
+    rpc: getRpcUrl('bsc-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC_TESTNET}.webp`,
     blockExplorer: {
       name: 'BSCScan (Testnet)',
@@ -356,6 +369,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'optimism',
     title: 'Optimism',
+    rpc: getRpcUrl('optimism'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism)',
@@ -372,6 +386,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'optimism-kovan',
     title: 'Optimism Kovan',
+    rpc: getRpcUrl('optimism-kovan'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_KOVAN}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism Kovan)',
@@ -389,6 +404,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'optimism-goerli',
     title: 'Optimism Goerli',
+    rpc: getRpcUrl('optimism-goerli'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_GOERLI}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism Goerli)',
@@ -406,6 +422,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'optimism-sepolia',
     title: 'Optimism Sepolia',
+    rpc: getRpcUrl('optimism-sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism Sepolia)',
@@ -422,6 +439,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'arbitrum',
     title: 'Arbitrum One',
+    rpc: getRpcUrl('arbitrum'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM}.webp`,
     blockExplorer: {
       name: 'Arbiscan',
@@ -438,6 +456,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'arbitrum-goerli',
     title: 'Arbitrum Goerli',
+    rpc: getRpcUrl('arbitrum-goerli'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_GOERLI}.webp`,
     blockExplorer: {
       name: 'Arbiscan (Goerli Testnet)',
@@ -455,6 +474,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'arbitrum-sepolia',
     title: 'Arbitrum Sepolia',
+    rpc: getRpcUrl('arbitrum-sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Arbiscan (Sepolia Testnet)',
@@ -471,6 +491,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'arbitrum-nova',
     title: 'Arbitrum Nova',
+    rpc: getRpcUrl('arbitrum-nova'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_NOVA}.webp`,
     blockExplorer: {
       name: 'Arbiscan Nova',
@@ -487,6 +508,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'avalanche',
     title: 'Avalanche',
+    rpc: getRpcUrl('avalanche'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE}.webp`,
     blockExplorer: {
       name: 'Snowtrace',
@@ -503,6 +525,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'avalanche-testnet',
     title: 'Avalanche Testnet',
+    rpc: getRpcUrl('avalanche-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE_TESTNET}.webp`,
     blockExplorer: {
       name: 'Snowtrace (Testnet)',
@@ -519,6 +542,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'gnosis',
     title: 'Gnosis Chain',
+    rpc: getRpcUrl('gnosis'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GNOSIS}.webp`,
     blockExplorer: {
       name: 'Gnosis Chain Explorer',
@@ -535,6 +559,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'base',
     title: 'Base (Coinbase)',
+    rpc: getRpcUrl('base'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE}.webp`,
     blockExplorer: {
       name: 'Base Explorer',
@@ -551,6 +576,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'base-goerli',
     title: 'Base Goerli',
+    rpc: getRpcUrl('base-goerli'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_GOERLI}.webp`,
     blockExplorer: {
       name: 'Base Goerli Explorer',
@@ -568,6 +594,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'base-sepolia',
     title: 'Base Sepolia',
+    rpc: getRpcUrl('base-sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Base Sepolia Explorer',
@@ -584,6 +611,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'homeverse',
     title: 'Oasys Homeverse',
+    rpc: getRpcUrl('homeverse'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE}.webp`,
     blockExplorer: {
       name: 'Oasys Homeverse Explorer',
@@ -600,6 +628,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'homeverse-testnet',
     title: 'Oasys Homeverse Testnet',
+    rpc: getRpcUrl('homeverse-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE_TESTNET}.webp`,
     blockExplorer: {
       name: 'Oasys Homeverse Explorer (Testnet)',
@@ -616,6 +645,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'xai',
     title: 'Xai',
+    rpc: getRpcUrl('xai'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI}.webp`,
     blockExplorer: {
       name: 'Xai Explorer',
@@ -632,6 +662,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'xai-sepolia',
     title: 'Xai Sepolia',
+    rpc: getRpcUrl('xai-sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Xai Sepolia Explorer',
@@ -648,6 +679,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'b3',
     title: 'B3',
+    rpc: getRpcUrl('b3'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3}.webp`,
     blockExplorer: {
       name: 'B3 Explorer',
@@ -664,6 +696,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'b3-sepolia',
     title: 'B3 Sepolia',
+    rpc: getRpcUrl('b3-sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'B3 Sepolia Explorer',
@@ -680,6 +713,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'apechain',
     title: 'APE Chain',
+    rpc: getRpcUrl('apechain'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN}.webp`,
     blockExplorer: {
       name: 'APE Chain Explorer',
@@ -696,6 +730,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'apechain-testnet',
     title: 'APE Chain Testnet',
+    rpc: getRpcUrl('apechain-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN_TESTNET}.webp`,
     blockExplorer: {
       name: 'APE Chain Explorer',
@@ -712,6 +747,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'blast',
     title: 'Blast',
+    rpc: getRpcUrl('blast'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST}.webp`,
     blockExplorer: {
       name: 'Blast Explorer',
@@ -728,6 +764,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'blast-sepolia',
     title: 'Blast Sepolia',
+    rpc: getRpcUrl('blast-sepolia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Blast Sepolia Explorer',
@@ -744,6 +781,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'telos',
     title: 'Telos',
+    rpc: getRpcUrl('telos'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS}.webp`,
     blockExplorer: {
       name: 'Telos Explorer',
@@ -760,6 +798,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'telos-testnet',
     title: 'Telos Testnet',
+    rpc: getRpcUrl('telos-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS_TESTNET}.webp`,
     blockExplorer: {
       name: 'Telos Testnet Explorer',
@@ -776,6 +815,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'borne-testnet',
     title: 'Borne Testnet',
+    rpc: getRpcUrl('borne-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BORNE_TESTNET}.webp`,
     blockExplorer: {
       name: 'Borne Testnet Explorer',
@@ -793,6 +833,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'skale-nebula',
     title: 'SKALE Nebula Gaming Hub',
+    rpc: getRpcUrl('skale-nebula'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA}.webp`,
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Explorer',
@@ -809,6 +850,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'skale-nebula-testnet',
     title: 'SKALE Nebula Gaming Hub Testnet',
+    rpc: getRpcUrl('skale-nebula-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA_TESTNET}.webp`,
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Testnet Explorer',
@@ -825,6 +867,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'soneium',
     title: 'Soneium',
+    rpc: getRpcUrl('soneium'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM}.webp`,
     blockExplorer: {
       name: 'Soneium Explorer',
@@ -841,6 +884,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'soneium-minato',
     title: 'Soneium Minato (Testnet)',
+    rpc: getRpcUrl('soneium-minato'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM_MINATO}.webp`,
     blockExplorer: {
       name: 'Soneium Minato Explorer',
@@ -857,6 +901,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'toy-testnet',
     title: 'TOY (Testnet)',
+    rpc: getRpcUrl('toy-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TOY_TESTNET}.webp`,
     blockExplorer: {
       name: 'TOY Testnet Explorer',
@@ -873,6 +918,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'immutable-zkevm',
     title: 'Immutable zkEVM',
+    rpc: getRpcUrl('immutable-zkevm'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM}.webp`,
     blockExplorer: {
       name: 'Immutable zkEVM Explorer',
@@ -889,6 +935,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'immutable-zkevm-testnet',
     title: 'Immutable zkEVM Testnet',
+    rpc: getRpcUrl('immutable-zkevm-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM_TESTNET}.webp`,
     blockExplorer: {
       name: 'Immutable zkEVM Testnet Explorer',
@@ -905,6 +952,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'rootnet',
     title: 'The Root Network',
+    rpc: getRpcUrl('rootnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK}.webp`,
     blockExplorer: {
       name: 'The Root Network Explorer',
@@ -921,6 +969,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'rootnet-porcini',
     title: 'The Root Network Porcini Testnet',
+    rpc: getRpcUrl('rootnet-porcini'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK_PORCINI}.webp`,
     blockExplorer: {
       name: 'The Root Network Porcini Testnet Explorer',
@@ -937,6 +986,7 @@ export const ALL: Network[] = [
     type: NetworkType.LOCAL,
     name: 'hardhat',
     title: 'Hardhat (local testnet)',
+    rpc: 'http://localhost:8545',
     nativeToken: {
       symbol: 'ETH',
       name: 'Ether',
@@ -948,6 +998,7 @@ export const ALL: Network[] = [
     type: NetworkType.LOCAL,
     name: 'hardhat2',
     title: 'Hardhat (local testnet)',
+    rpc: 'http://localhost:8545',
     nativeToken: {
       symbol: 'ETH',
       name: 'Ether',
@@ -959,6 +1010,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'laos',
     title: 'LAOS',
+    rpc: getRpcUrl('laos'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS}.webp`,
     blockExplorer: {
       name: 'LAOS Explorer',
@@ -975,6 +1027,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'laos-sigma-testnet',
     title: 'LAOS Sigma Testnet',
+    rpc: getRpcUrl('laos-sigma-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS_SIGMA_TESTNET}.webp`,
     blockExplorer: {
       name: 'LAOS Sigma Testnet Explorer',
@@ -991,6 +1044,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'moonbeam',
     title: 'Moonbeam',
+    rpc: getRpcUrl('moonbeam'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBEAM}.webp`,
     blockExplorer: {
       name: 'Moonscan',
@@ -1007,6 +1061,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'moonbase-alpha',
     title: 'Moonbase Alpha',
+    rpc: getRpcUrl('moonbase-alpha'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBASE_ALPHA}.webp`,
     blockExplorer: {
       name: 'Moonscan (Moonbase Alpha)',
@@ -1023,6 +1078,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'etherlink',
     title: 'Etherlink',
+    rpc: getRpcUrl('etherlink'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK}.webp`,
     blockExplorer: {
       name: 'Etherlink Explorer',
@@ -1039,6 +1095,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'etherlink-testnet',
     title: 'Etherlink Testnet',
+    rpc: getRpcUrl('etherlink-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK_TESTNET}.webp`,
     blockExplorer: {
       name: 'Etherlink Testnet Explorer',
@@ -1055,6 +1112,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'monad-testnet',
     title: 'Monad Testnet',
+    rpc: getRpcUrl('monad-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MONAD_TESTNET}.webp`,
     blockExplorer: {
       name: 'Monad Testnet Explorer',
@@ -1072,6 +1130,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'somnia-testnet',
     title: 'Somnia Testnet',
+    rpc: getRpcUrl('somnia-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA_TESTNET}.webp`,
     blockExplorer: {
       name: 'Somnia Testnet Explorer',
@@ -1089,6 +1148,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'incentiv-testnet',
     title: 'Incentiv Testnet',
+    rpc: getRpcUrl('incentiv-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.INCENTIV_TESTNET}.webp`,
     blockExplorer: {
       name: 'Incentiv Testnet Explorer',
@@ -1106,6 +1166,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'sei',
     title: 'Sei',
+    rpc: getRpcUrl('sei'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI}.webp`,
     blockExplorer: {
       name: 'SEI Explorer',
@@ -1123,6 +1184,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'sei-testnet',
     title: 'Sei Testnet',
+    rpc: getRpcUrl('sei-testnet'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI_TESTNET}.webp`,
     blockExplorer: {
       name: 'Sei Testnet Explorer',
@@ -1140,6 +1202,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'somnia',
     title: 'Somnia',
+    rpc: getRpcUrl('somnia'),
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA}.webp`,
     blockExplorer: {
       name: 'Somnia Explorer',
@@ -1153,14 +1216,14 @@ export const ALL: Network[] = [
   },
 ]
 
+function getRpcUrl(networkName: string): string {
+  return `https://nodes.sequence.app/${networkName}`
+}
+
 export function getNetworkFromName(networkName: string): Network | undefined {
   return ALL.find((network) => network.name === networkName)
 }
 
 export function getNetworkFromChainId(chainId: ChainId | bigint | number): Network | undefined {
   return ALL.find((network) => network.chainId === BigInt(chainId))
-}
-
-export function getRpcUrl(network: Network): string {
-  return `https://nodes.sequence.app/${network.name}`
 }

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -157,7 +157,7 @@ export const ALL: Network[] = [
     name: 'mainnet',
     title: 'Ethereum',
     rpc: getRpcUrl('mainnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MAINNET}.webp`,
+    logoURI: getLogoUrl(ChainId.MAINNET),
     blockExplorer: {
       name: 'Etherscan',
       url: 'https://etherscan.io/',
@@ -175,7 +175,7 @@ export const ALL: Network[] = [
     name: 'ropsten',
     title: 'Ropsten',
     rpc: getRpcUrl('ropsten'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROPSTEN}.webp`,
+    logoURI: getLogoUrl(ChainId.ROPSTEN),
     blockExplorer: {
       name: 'Etherscan (Ropsten)',
       url: 'https://ropsten.etherscan.io/',
@@ -194,7 +194,7 @@ export const ALL: Network[] = [
     name: 'rinkeby',
     title: 'Rinkeby',
     rpc: getRpcUrl('rinkeby'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.RINKEBY}.webp`,
+    logoURI: getLogoUrl(ChainId.RINKEBY),
     blockExplorer: {
       name: 'Etherscan (Rinkeby)',
       url: 'https://rinkeby.etherscan.io/',
@@ -213,7 +213,7 @@ export const ALL: Network[] = [
     name: 'goerli',
     title: 'Goerli',
     rpc: getRpcUrl('goerli'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GOERLI}.webp`,
+    logoURI: getLogoUrl(ChainId.GOERLI),
     blockExplorer: {
       name: 'Etherscan (Goerli)',
       url: 'https://goerli.etherscan.io/',
@@ -232,7 +232,7 @@ export const ALL: Network[] = [
     name: 'kovan',
     title: 'Kovan',
     rpc: getRpcUrl('kovan'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.KOVAN}.webp`,
+    logoURI: getLogoUrl(ChainId.KOVAN),
     blockExplorer: {
       name: 'Etherscan (Kovan)',
       url: 'https://kovan.etherscan.io/',
@@ -250,7 +250,7 @@ export const ALL: Network[] = [
     name: 'sepolia',
     title: 'Sepolia',
     rpc: getRpcUrl('sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.SEPOLIA),
     blockExplorer: {
       name: 'Etherscan (Sepolia)',
       url: 'https://sepolia.etherscan.io/',
@@ -267,7 +267,7 @@ export const ALL: Network[] = [
     name: 'polygon',
     title: 'Polygon',
     rpc: getRpcUrl('polygon'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON}.webp`,
+    logoURI: getLogoUrl(ChainId.POLYGON),
     blockExplorer: {
       name: 'Polygonscan',
       url: 'https://polygonscan.com/',
@@ -284,7 +284,7 @@ export const ALL: Network[] = [
     name: 'mumbai',
     title: 'Polygon Mumbai',
     rpc: getRpcUrl('mumbai'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_MUMBAI}.webp`,
+    logoURI: getLogoUrl(ChainId.POLYGON_MUMBAI),
     blockExplorer: {
       name: 'Polygonscan (Mumbai)',
       url: 'https://mumbai.polygonscan.com/',
@@ -302,7 +302,7 @@ export const ALL: Network[] = [
     name: 'amoy',
     title: 'Polygon Amoy',
     rpc: getRpcUrl('amoy'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_AMOY}.webp`,
+    logoURI: getLogoUrl(ChainId.POLYGON_AMOY),
     blockExplorer: {
       name: 'OKLink (Amoy)',
       url: 'https://www.oklink.com/amoy/',
@@ -319,7 +319,7 @@ export const ALL: Network[] = [
     name: 'polygon-zkevm',
     title: 'Polygon zkEVM',
     rpc: getRpcUrl('polygon-zkevm'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_ZKEVM}.webp`,
+    logoURI: getLogoUrl(ChainId.POLYGON_ZKEVM),
     blockExplorer: {
       name: 'Polygonscan (zkEVM)',
       url: 'https://zkevm.polygonscan.com/',
@@ -336,7 +336,7 @@ export const ALL: Network[] = [
     name: 'bsc',
     title: 'BNB Smart Chain',
     rpc: getRpcUrl('bsc'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC}.webp`,
+    logoURI: getLogoUrl(ChainId.BSC),
     blockExplorer: {
       name: 'BSCScan',
       url: 'https://bscscan.com/',
@@ -353,7 +353,7 @@ export const ALL: Network[] = [
     name: 'bsc-testnet',
     title: 'BNB Smart Chain Testnet',
     rpc: getRpcUrl('bsc-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.BSC_TESTNET),
     blockExplorer: {
       name: 'BSCScan (Testnet)',
       url: 'https://testnet.bscscan.com/',
@@ -370,7 +370,7 @@ export const ALL: Network[] = [
     name: 'optimism',
     title: 'Optimism',
     rpc: getRpcUrl('optimism'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM}.webp`,
+    logoURI: getLogoUrl(ChainId.OPTIMISM),
     blockExplorer: {
       name: 'Etherscan (Optimism)',
       url: 'https://optimistic.etherscan.io/',
@@ -387,7 +387,7 @@ export const ALL: Network[] = [
     name: 'optimism-kovan',
     title: 'Optimism Kovan',
     rpc: getRpcUrl('optimism-kovan'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_KOVAN}.webp`,
+    logoURI: getLogoUrl(ChainId.OPTIMISM_KOVAN),
     blockExplorer: {
       name: 'Etherscan (Optimism Kovan)',
       url: 'https://kovan-optimistic.etherscan.io/',
@@ -405,7 +405,7 @@ export const ALL: Network[] = [
     name: 'optimism-goerli',
     title: 'Optimism Goerli',
     rpc: getRpcUrl('optimism-goerli'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_GOERLI}.webp`,
+    logoURI: getLogoUrl(ChainId.OPTIMISM_GOERLI),
     blockExplorer: {
       name: 'Etherscan (Optimism Goerli)',
       url: 'https://goerli-optimistic.etherscan.io/',
@@ -423,7 +423,7 @@ export const ALL: Network[] = [
     name: 'optimism-sepolia',
     title: 'Optimism Sepolia',
     rpc: getRpcUrl('optimism-sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.OPTIMISM_SEPOLIA),
     blockExplorer: {
       name: 'Etherscan (Optimism Sepolia)',
       url: 'https://sepolia-optimistic.etherscan.io/',
@@ -440,7 +440,7 @@ export const ALL: Network[] = [
     name: 'arbitrum',
     title: 'Arbitrum One',
     rpc: getRpcUrl('arbitrum'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM}.webp`,
+    logoURI: getLogoUrl(ChainId.ARBITRUM),
     blockExplorer: {
       name: 'Arbiscan',
       url: 'https://arbiscan.io/',
@@ -457,7 +457,7 @@ export const ALL: Network[] = [
     name: 'arbitrum-goerli',
     title: 'Arbitrum Goerli',
     rpc: getRpcUrl('arbitrum-goerli'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_GOERLI}.webp`,
+    logoURI: getLogoUrl(ChainId.ARBITRUM_GOERLI),
     blockExplorer: {
       name: 'Arbiscan (Goerli Testnet)',
       url: 'https://testnet.arbiscan.io/',
@@ -475,7 +475,7 @@ export const ALL: Network[] = [
     name: 'arbitrum-sepolia',
     title: 'Arbitrum Sepolia',
     rpc: getRpcUrl('arbitrum-sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.ARBITRUM_SEPOLIA),
     blockExplorer: {
       name: 'Arbiscan (Sepolia Testnet)',
       url: 'https://sepolia.arbiscan.io/',
@@ -492,7 +492,7 @@ export const ALL: Network[] = [
     name: 'arbitrum-nova',
     title: 'Arbitrum Nova',
     rpc: getRpcUrl('arbitrum-nova'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_NOVA}.webp`,
+    logoURI: getLogoUrl(ChainId.ARBITRUM_NOVA),
     blockExplorer: {
       name: 'Arbiscan Nova',
       url: 'https://nova.arbiscan.io/',
@@ -509,7 +509,7 @@ export const ALL: Network[] = [
     name: 'avalanche',
     title: 'Avalanche',
     rpc: getRpcUrl('avalanche'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE}.webp`,
+    logoURI: getLogoUrl(ChainId.AVALANCHE),
     blockExplorer: {
       name: 'Snowtrace',
       url: 'https://subnets.avax.network/c-chain/',
@@ -526,7 +526,7 @@ export const ALL: Network[] = [
     name: 'avalanche-testnet',
     title: 'Avalanche Testnet',
     rpc: getRpcUrl('avalanche-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.AVALANCHE_TESTNET),
     blockExplorer: {
       name: 'Snowtrace (Testnet)',
       url: 'https://subnets-test.avax.network/c-chain/',
@@ -543,7 +543,7 @@ export const ALL: Network[] = [
     name: 'gnosis',
     title: 'Gnosis Chain',
     rpc: getRpcUrl('gnosis'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GNOSIS}.webp`,
+    logoURI: getLogoUrl(ChainId.GNOSIS),
     blockExplorer: {
       name: 'Gnosis Chain Explorer',
       url: 'https://blockscout.com/xdai/mainnet/',
@@ -560,7 +560,7 @@ export const ALL: Network[] = [
     name: 'base',
     title: 'Base (Coinbase)',
     rpc: getRpcUrl('base'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE}.webp`,
+    logoURI: getLogoUrl(ChainId.BASE),
     blockExplorer: {
       name: 'Base Explorer',
       url: 'https://basescan.org/',
@@ -577,7 +577,7 @@ export const ALL: Network[] = [
     name: 'base-goerli',
     title: 'Base Goerli',
     rpc: getRpcUrl('base-goerli'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_GOERLI}.webp`,
+    logoURI: getLogoUrl(ChainId.BASE_GOERLI),
     blockExplorer: {
       name: 'Base Goerli Explorer',
       url: 'https://goerli.basescan.org/',
@@ -595,7 +595,7 @@ export const ALL: Network[] = [
     name: 'base-sepolia',
     title: 'Base Sepolia',
     rpc: getRpcUrl('base-sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.BASE_SEPOLIA),
     blockExplorer: {
       name: 'Base Sepolia Explorer',
       url: 'https://base-sepolia.blockscout.com/',
@@ -612,7 +612,7 @@ export const ALL: Network[] = [
     name: 'homeverse',
     title: 'Oasys Homeverse',
     rpc: getRpcUrl('homeverse'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE}.webp`,
+    logoURI: getLogoUrl(ChainId.HOMEVERSE),
     blockExplorer: {
       name: 'Oasys Homeverse Explorer',
       url: 'https://explorer.oasys.homeverse.games/',
@@ -629,7 +629,7 @@ export const ALL: Network[] = [
     name: 'homeverse-testnet',
     title: 'Oasys Homeverse Testnet',
     rpc: getRpcUrl('homeverse-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.HOMEVERSE_TESTNET),
     blockExplorer: {
       name: 'Oasys Homeverse Explorer (Testnet)',
       url: 'https://explorer.testnet.oasys.homeverse.games/',
@@ -646,7 +646,7 @@ export const ALL: Network[] = [
     name: 'xai',
     title: 'Xai',
     rpc: getRpcUrl('xai'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI}.webp`,
+    logoURI: getLogoUrl(ChainId.XAI),
     blockExplorer: {
       name: 'Xai Explorer',
       url: 'https://explorer.xai-chain.net/',
@@ -663,7 +663,7 @@ export const ALL: Network[] = [
     name: 'xai-sepolia',
     title: 'Xai Sepolia',
     rpc: getRpcUrl('xai-sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI_SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.XAI_SEPOLIA),
     blockExplorer: {
       name: 'Xai Sepolia Explorer',
       url: 'https://testnet-explorer-v2.xai-chain.net/',
@@ -680,7 +680,7 @@ export const ALL: Network[] = [
     name: 'b3',
     title: 'B3',
     rpc: getRpcUrl('b3'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3}.webp`,
+    logoURI: getLogoUrl(ChainId.B3),
     blockExplorer: {
       name: 'B3 Explorer',
       url: 'https://explorer.b3.fun/',
@@ -697,7 +697,7 @@ export const ALL: Network[] = [
     name: 'b3-sepolia',
     title: 'B3 Sepolia',
     rpc: getRpcUrl('b3-sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3_SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.B3_SEPOLIA),
     blockExplorer: {
       name: 'B3 Sepolia Explorer',
       url: 'https://sepolia.explorer.b3.fun/',
@@ -714,7 +714,7 @@ export const ALL: Network[] = [
     name: 'apechain',
     title: 'APE Chain',
     rpc: getRpcUrl('apechain'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN}.webp`,
+    logoURI: getLogoUrl(ChainId.APECHAIN),
     blockExplorer: {
       name: 'APE Chain Explorer',
       url: 'https://apechain.calderaexplorer.xyz/',
@@ -731,7 +731,7 @@ export const ALL: Network[] = [
     name: 'apechain-testnet',
     title: 'APE Chain Testnet',
     rpc: getRpcUrl('apechain-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.APECHAIN_TESTNET),
     blockExplorer: {
       name: 'APE Chain Explorer',
       url: 'https://curtis.explorer.caldera.xyz/',
@@ -748,7 +748,7 @@ export const ALL: Network[] = [
     name: 'blast',
     title: 'Blast',
     rpc: getRpcUrl('blast'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST}.webp`,
+    logoURI: getLogoUrl(ChainId.BLAST),
     blockExplorer: {
       name: 'Blast Explorer',
       url: 'https://blastscan.io/',
@@ -765,7 +765,7 @@ export const ALL: Network[] = [
     name: 'blast-sepolia',
     title: 'Blast Sepolia',
     rpc: getRpcUrl('blast-sepolia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST_SEPOLIA}.webp`,
+    logoURI: getLogoUrl(ChainId.BLAST_SEPOLIA),
     blockExplorer: {
       name: 'Blast Sepolia Explorer',
       url: 'https://sepolia.blastexplorer.io/',
@@ -782,7 +782,7 @@ export const ALL: Network[] = [
     name: 'telos',
     title: 'Telos',
     rpc: getRpcUrl('telos'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS}.webp`,
+    logoURI: getLogoUrl(ChainId.TELOS),
     blockExplorer: {
       name: 'Telos Explorer',
       url: 'https://explorer.telos.net/network/',
@@ -799,7 +799,7 @@ export const ALL: Network[] = [
     name: 'telos-testnet',
     title: 'Telos Testnet',
     rpc: getRpcUrl('telos-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.TELOS_TESTNET),
     blockExplorer: {
       name: 'Telos Testnet Explorer',
       url: 'https://explorer-test.telos.net/network',
@@ -816,7 +816,7 @@ export const ALL: Network[] = [
     name: 'borne-testnet',
     title: 'Borne Testnet',
     rpc: getRpcUrl('borne-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BORNE_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.BORNE_TESTNET),
     blockExplorer: {
       name: 'Borne Testnet Explorer',
       url: 'https://subnets-test.avax.network/bornegfdn',
@@ -834,7 +834,7 @@ export const ALL: Network[] = [
     name: 'skale-nebula',
     title: 'SKALE Nebula Gaming Hub',
     rpc: getRpcUrl('skale-nebula'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA}.webp`,
+    logoURI: getLogoUrl(ChainId.SKALE_NEBULA),
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Explorer',
       url: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
@@ -851,7 +851,7 @@ export const ALL: Network[] = [
     name: 'skale-nebula-testnet',
     title: 'SKALE Nebula Gaming Hub Testnet',
     rpc: getRpcUrl('skale-nebula-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.SKALE_NEBULA_TESTNET),
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Testnet Explorer',
       url: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
@@ -868,7 +868,7 @@ export const ALL: Network[] = [
     name: 'soneium',
     title: 'Soneium',
     rpc: getRpcUrl('soneium'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM}.webp`,
+    logoURI: getLogoUrl(ChainId.SONEIUM),
     blockExplorer: {
       name: 'Soneium Explorer',
       url: 'https://soneium.blockscout.com/',
@@ -885,7 +885,7 @@ export const ALL: Network[] = [
     name: 'soneium-minato',
     title: 'Soneium Minato (Testnet)',
     rpc: getRpcUrl('soneium-minato'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM_MINATO}.webp`,
+    logoURI: getLogoUrl(ChainId.SONEIUM_MINATO),
     blockExplorer: {
       name: 'Soneium Minato Explorer',
       url: 'https://explorer-testnet.soneium.org/',
@@ -902,7 +902,7 @@ export const ALL: Network[] = [
     name: 'toy-testnet',
     title: 'TOY (Testnet)',
     rpc: getRpcUrl('toy-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TOY_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.TOY_TESTNET),
     blockExplorer: {
       name: 'TOY Testnet Explorer',
       url: 'https://toy-chain-testnet.explorer.caldera.xyz/',
@@ -919,7 +919,7 @@ export const ALL: Network[] = [
     name: 'immutable-zkevm',
     title: 'Immutable zkEVM',
     rpc: getRpcUrl('immutable-zkevm'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM}.webp`,
+    logoURI: getLogoUrl(ChainId.IMMUTABLE_ZKEVM),
     blockExplorer: {
       name: 'Immutable zkEVM Explorer',
       url: 'https://explorer.immutable.com/',
@@ -936,7 +936,7 @@ export const ALL: Network[] = [
     name: 'immutable-zkevm-testnet',
     title: 'Immutable zkEVM Testnet',
     rpc: getRpcUrl('immutable-zkevm-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.IMMUTABLE_ZKEVM_TESTNET),
     blockExplorer: {
       name: 'Immutable zkEVM Testnet Explorer',
       url: 'https://explorer.testnet.immutable.com/',
@@ -953,7 +953,7 @@ export const ALL: Network[] = [
     name: 'rootnet',
     title: 'The Root Network',
     rpc: getRpcUrl('rootnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK}.webp`,
+    logoURI: getLogoUrl(ChainId.ROOT_NETWORK),
     blockExplorer: {
       name: 'The Root Network Explorer',
       url: 'https://rootscan.io/',
@@ -970,7 +970,7 @@ export const ALL: Network[] = [
     name: 'rootnet-porcini',
     title: 'The Root Network Porcini Testnet',
     rpc: getRpcUrl('rootnet-porcini'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK_PORCINI}.webp`,
+    logoURI: getLogoUrl(ChainId.ROOT_NETWORK_PORCINI),
     blockExplorer: {
       name: 'The Root Network Porcini Testnet Explorer',
       url: 'https://porcini.rootscan.io/',
@@ -1011,7 +1011,7 @@ export const ALL: Network[] = [
     name: 'laos',
     title: 'LAOS',
     rpc: getRpcUrl('laos'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS}.webp`,
+    logoURI: getLogoUrl(ChainId.LAOS),
     blockExplorer: {
       name: 'LAOS Explorer',
       url: 'https://blockscout.laos.laosfoundation.io/',
@@ -1028,7 +1028,7 @@ export const ALL: Network[] = [
     name: 'laos-sigma-testnet',
     title: 'LAOS Sigma Testnet',
     rpc: getRpcUrl('laos-sigma-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS_SIGMA_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.LAOS_SIGMA_TESTNET),
     blockExplorer: {
       name: 'LAOS Sigma Testnet Explorer',
       url: 'https://sigma.explorer.laosnetwork.io/',
@@ -1045,7 +1045,7 @@ export const ALL: Network[] = [
     name: 'moonbeam',
     title: 'Moonbeam',
     rpc: getRpcUrl('moonbeam'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBEAM}.webp`,
+    logoURI: getLogoUrl(ChainId.MOONBEAM),
     blockExplorer: {
       name: 'Moonscan',
       url: 'https://moonscan.io/',
@@ -1062,7 +1062,7 @@ export const ALL: Network[] = [
     name: 'moonbase-alpha',
     title: 'Moonbase Alpha',
     rpc: getRpcUrl('moonbase-alpha'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBASE_ALPHA}.webp`,
+    logoURI: getLogoUrl(ChainId.MOONBASE_ALPHA),
     blockExplorer: {
       name: 'Moonscan (Moonbase Alpha)',
       url: 'https://moonbase.moonscan.io/',
@@ -1079,7 +1079,7 @@ export const ALL: Network[] = [
     name: 'etherlink',
     title: 'Etherlink',
     rpc: getRpcUrl('etherlink'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK}.webp`,
+    logoURI: getLogoUrl(ChainId.ETHERLINK),
     blockExplorer: {
       name: 'Etherlink Explorer',
       url: 'https://explorer.etherlink.com/',
@@ -1096,7 +1096,7 @@ export const ALL: Network[] = [
     name: 'etherlink-testnet',
     title: 'Etherlink Testnet',
     rpc: getRpcUrl('etherlink-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.ETHERLINK_TESTNET),
     blockExplorer: {
       name: 'Etherlink Testnet Explorer',
       url: 'https://testnet.explorer.etherlink.com/',
@@ -1113,7 +1113,7 @@ export const ALL: Network[] = [
     name: 'monad-testnet',
     title: 'Monad Testnet',
     rpc: getRpcUrl('monad-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MONAD_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.MONAD_TESTNET),
     blockExplorer: {
       name: 'Monad Testnet Explorer',
       url: 'https://testnet.monadexplorer.com/',
@@ -1131,7 +1131,7 @@ export const ALL: Network[] = [
     name: 'somnia-testnet',
     title: 'Somnia Testnet',
     rpc: getRpcUrl('somnia-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.SOMNIA_TESTNET),
     blockExplorer: {
       name: 'Somnia Testnet Explorer',
       url: 'https://somnia-testnet.socialscan.io/',
@@ -1149,7 +1149,7 @@ export const ALL: Network[] = [
     name: 'incentiv-testnet',
     title: 'Incentiv Testnet',
     rpc: getRpcUrl('incentiv-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.INCENTIV_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.INCENTIV_TESTNET),
     blockExplorer: {
       name: 'Incentiv Testnet Explorer',
       url: 'https://explorer.testnet.incentiv.net/',
@@ -1167,7 +1167,7 @@ export const ALL: Network[] = [
     name: 'sei',
     title: 'Sei',
     rpc: getRpcUrl('sei'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI}.webp`,
+    logoURI: getLogoUrl(ChainId.SEI),
     blockExplorer: {
       name: 'SEI Explorer',
       url: 'https://seitrace.com/?chain=pacific-1',
@@ -1185,7 +1185,7 @@ export const ALL: Network[] = [
     name: 'sei-testnet',
     title: 'Sei Testnet',
     rpc: getRpcUrl('sei-testnet'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI_TESTNET}.webp`,
+    logoURI: getLogoUrl(ChainId.SEI_TESTNET),
     blockExplorer: {
       name: 'Sei Testnet Explorer',
       url: 'https://seitrace.com/?chain=atlantic-2',
@@ -1203,7 +1203,7 @@ export const ALL: Network[] = [
     name: 'somnia',
     title: 'Somnia',
     rpc: getRpcUrl('somnia'),
-    logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA}.webp`,
+    logoURI: getLogoUrl(ChainId.SOMNIA),
     blockExplorer: {
       name: 'Somnia Explorer',
       url: 'https://mainnet.somnia.w3us.site/',
@@ -1218,6 +1218,10 @@ export const ALL: Network[] = [
 
 function getRpcUrl(networkName: string): string {
   return `https://nodes.sequence.app/${networkName}`
+}
+
+function getLogoUrl(chainId: ChainId): string {
+  return `https://assets.sequence.info/images/networks/medium/${chainId}.webp`
 }
 
 export function getNetworkFromName(networkName: string): Network | undefined {

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -15,7 +15,7 @@ export interface Network {
   name: string
   title?: string
   rpc: string
-  logoURI?: string
+  logoUrl?: string
   blockExplorer?: BlockExplorerConfig
   nativeToken: {
     symbol: string
@@ -157,7 +157,7 @@ export const ALL: Network[] = [
     name: 'mainnet',
     title: 'Ethereum',
     rpc: getRpcUrl('mainnet'),
-    logoURI: getLogoUrl(ChainId.MAINNET),
+    logoUrl: getLogoUrl(ChainId.MAINNET),
     blockExplorer: {
       name: 'Etherscan',
       url: 'https://etherscan.io/',
@@ -175,7 +175,7 @@ export const ALL: Network[] = [
     name: 'ropsten',
     title: 'Ropsten',
     rpc: getRpcUrl('ropsten'),
-    logoURI: getLogoUrl(ChainId.ROPSTEN),
+    logoUrl: getLogoUrl(ChainId.ROPSTEN),
     blockExplorer: {
       name: 'Etherscan (Ropsten)',
       url: 'https://ropsten.etherscan.io/',
@@ -194,7 +194,7 @@ export const ALL: Network[] = [
     name: 'rinkeby',
     title: 'Rinkeby',
     rpc: getRpcUrl('rinkeby'),
-    logoURI: getLogoUrl(ChainId.RINKEBY),
+    logoUrl: getLogoUrl(ChainId.RINKEBY),
     blockExplorer: {
       name: 'Etherscan (Rinkeby)',
       url: 'https://rinkeby.etherscan.io/',
@@ -213,7 +213,7 @@ export const ALL: Network[] = [
     name: 'goerli',
     title: 'Goerli',
     rpc: getRpcUrl('goerli'),
-    logoURI: getLogoUrl(ChainId.GOERLI),
+    logoUrl: getLogoUrl(ChainId.GOERLI),
     blockExplorer: {
       name: 'Etherscan (Goerli)',
       url: 'https://goerli.etherscan.io/',
@@ -232,7 +232,7 @@ export const ALL: Network[] = [
     name: 'kovan',
     title: 'Kovan',
     rpc: getRpcUrl('kovan'),
-    logoURI: getLogoUrl(ChainId.KOVAN),
+    logoUrl: getLogoUrl(ChainId.KOVAN),
     blockExplorer: {
       name: 'Etherscan (Kovan)',
       url: 'https://kovan.etherscan.io/',
@@ -250,7 +250,7 @@ export const ALL: Network[] = [
     name: 'sepolia',
     title: 'Sepolia',
     rpc: getRpcUrl('sepolia'),
-    logoURI: getLogoUrl(ChainId.SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.SEPOLIA),
     blockExplorer: {
       name: 'Etherscan (Sepolia)',
       url: 'https://sepolia.etherscan.io/',
@@ -267,7 +267,7 @@ export const ALL: Network[] = [
     name: 'polygon',
     title: 'Polygon',
     rpc: getRpcUrl('polygon'),
-    logoURI: getLogoUrl(ChainId.POLYGON),
+    logoUrl: getLogoUrl(ChainId.POLYGON),
     blockExplorer: {
       name: 'Polygonscan',
       url: 'https://polygonscan.com/',
@@ -284,7 +284,7 @@ export const ALL: Network[] = [
     name: 'mumbai',
     title: 'Polygon Mumbai',
     rpc: getRpcUrl('mumbai'),
-    logoURI: getLogoUrl(ChainId.POLYGON_MUMBAI),
+    logoUrl: getLogoUrl(ChainId.POLYGON_MUMBAI),
     blockExplorer: {
       name: 'Polygonscan (Mumbai)',
       url: 'https://mumbai.polygonscan.com/',
@@ -302,7 +302,7 @@ export const ALL: Network[] = [
     name: 'amoy',
     title: 'Polygon Amoy',
     rpc: getRpcUrl('amoy'),
-    logoURI: getLogoUrl(ChainId.POLYGON_AMOY),
+    logoUrl: getLogoUrl(ChainId.POLYGON_AMOY),
     blockExplorer: {
       name: 'OKLink (Amoy)',
       url: 'https://www.oklink.com/amoy/',
@@ -319,7 +319,7 @@ export const ALL: Network[] = [
     name: 'polygon-zkevm',
     title: 'Polygon zkEVM',
     rpc: getRpcUrl('polygon-zkevm'),
-    logoURI: getLogoUrl(ChainId.POLYGON_ZKEVM),
+    logoUrl: getLogoUrl(ChainId.POLYGON_ZKEVM),
     blockExplorer: {
       name: 'Polygonscan (zkEVM)',
       url: 'https://zkevm.polygonscan.com/',
@@ -336,7 +336,7 @@ export const ALL: Network[] = [
     name: 'bsc',
     title: 'BNB Smart Chain',
     rpc: getRpcUrl('bsc'),
-    logoURI: getLogoUrl(ChainId.BSC),
+    logoUrl: getLogoUrl(ChainId.BSC),
     blockExplorer: {
       name: 'BSCScan',
       url: 'https://bscscan.com/',
@@ -353,7 +353,7 @@ export const ALL: Network[] = [
     name: 'bsc-testnet',
     title: 'BNB Smart Chain Testnet',
     rpc: getRpcUrl('bsc-testnet'),
-    logoURI: getLogoUrl(ChainId.BSC_TESTNET),
+    logoUrl: getLogoUrl(ChainId.BSC_TESTNET),
     blockExplorer: {
       name: 'BSCScan (Testnet)',
       url: 'https://testnet.bscscan.com/',
@@ -370,7 +370,7 @@ export const ALL: Network[] = [
     name: 'optimism',
     title: 'Optimism',
     rpc: getRpcUrl('optimism'),
-    logoURI: getLogoUrl(ChainId.OPTIMISM),
+    logoUrl: getLogoUrl(ChainId.OPTIMISM),
     blockExplorer: {
       name: 'Etherscan (Optimism)',
       url: 'https://optimistic.etherscan.io/',
@@ -387,7 +387,7 @@ export const ALL: Network[] = [
     name: 'optimism-kovan',
     title: 'Optimism Kovan',
     rpc: getRpcUrl('optimism-kovan'),
-    logoURI: getLogoUrl(ChainId.OPTIMISM_KOVAN),
+    logoUrl: getLogoUrl(ChainId.OPTIMISM_KOVAN),
     blockExplorer: {
       name: 'Etherscan (Optimism Kovan)',
       url: 'https://kovan-optimistic.etherscan.io/',
@@ -405,7 +405,7 @@ export const ALL: Network[] = [
     name: 'optimism-goerli',
     title: 'Optimism Goerli',
     rpc: getRpcUrl('optimism-goerli'),
-    logoURI: getLogoUrl(ChainId.OPTIMISM_GOERLI),
+    logoUrl: getLogoUrl(ChainId.OPTIMISM_GOERLI),
     blockExplorer: {
       name: 'Etherscan (Optimism Goerli)',
       url: 'https://goerli-optimistic.etherscan.io/',
@@ -423,7 +423,7 @@ export const ALL: Network[] = [
     name: 'optimism-sepolia',
     title: 'Optimism Sepolia',
     rpc: getRpcUrl('optimism-sepolia'),
-    logoURI: getLogoUrl(ChainId.OPTIMISM_SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.OPTIMISM_SEPOLIA),
     blockExplorer: {
       name: 'Etherscan (Optimism Sepolia)',
       url: 'https://sepolia-optimistic.etherscan.io/',
@@ -440,7 +440,7 @@ export const ALL: Network[] = [
     name: 'arbitrum',
     title: 'Arbitrum One',
     rpc: getRpcUrl('arbitrum'),
-    logoURI: getLogoUrl(ChainId.ARBITRUM),
+    logoUrl: getLogoUrl(ChainId.ARBITRUM),
     blockExplorer: {
       name: 'Arbiscan',
       url: 'https://arbiscan.io/',
@@ -457,7 +457,7 @@ export const ALL: Network[] = [
     name: 'arbitrum-goerli',
     title: 'Arbitrum Goerli',
     rpc: getRpcUrl('arbitrum-goerli'),
-    logoURI: getLogoUrl(ChainId.ARBITRUM_GOERLI),
+    logoUrl: getLogoUrl(ChainId.ARBITRUM_GOERLI),
     blockExplorer: {
       name: 'Arbiscan (Goerli Testnet)',
       url: 'https://testnet.arbiscan.io/',
@@ -475,7 +475,7 @@ export const ALL: Network[] = [
     name: 'arbitrum-sepolia',
     title: 'Arbitrum Sepolia',
     rpc: getRpcUrl('arbitrum-sepolia'),
-    logoURI: getLogoUrl(ChainId.ARBITRUM_SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.ARBITRUM_SEPOLIA),
     blockExplorer: {
       name: 'Arbiscan (Sepolia Testnet)',
       url: 'https://sepolia.arbiscan.io/',
@@ -492,7 +492,7 @@ export const ALL: Network[] = [
     name: 'arbitrum-nova',
     title: 'Arbitrum Nova',
     rpc: getRpcUrl('arbitrum-nova'),
-    logoURI: getLogoUrl(ChainId.ARBITRUM_NOVA),
+    logoUrl: getLogoUrl(ChainId.ARBITRUM_NOVA),
     blockExplorer: {
       name: 'Arbiscan Nova',
       url: 'https://nova.arbiscan.io/',
@@ -509,7 +509,7 @@ export const ALL: Network[] = [
     name: 'avalanche',
     title: 'Avalanche',
     rpc: getRpcUrl('avalanche'),
-    logoURI: getLogoUrl(ChainId.AVALANCHE),
+    logoUrl: getLogoUrl(ChainId.AVALANCHE),
     blockExplorer: {
       name: 'Snowtrace',
       url: 'https://subnets.avax.network/c-chain/',
@@ -526,7 +526,7 @@ export const ALL: Network[] = [
     name: 'avalanche-testnet',
     title: 'Avalanche Testnet',
     rpc: getRpcUrl('avalanche-testnet'),
-    logoURI: getLogoUrl(ChainId.AVALANCHE_TESTNET),
+    logoUrl: getLogoUrl(ChainId.AVALANCHE_TESTNET),
     blockExplorer: {
       name: 'Snowtrace (Testnet)',
       url: 'https://subnets-test.avax.network/c-chain/',
@@ -543,7 +543,7 @@ export const ALL: Network[] = [
     name: 'gnosis',
     title: 'Gnosis Chain',
     rpc: getRpcUrl('gnosis'),
-    logoURI: getLogoUrl(ChainId.GNOSIS),
+    logoUrl: getLogoUrl(ChainId.GNOSIS),
     blockExplorer: {
       name: 'Gnosis Chain Explorer',
       url: 'https://blockscout.com/xdai/mainnet/',
@@ -560,7 +560,7 @@ export const ALL: Network[] = [
     name: 'base',
     title: 'Base (Coinbase)',
     rpc: getRpcUrl('base'),
-    logoURI: getLogoUrl(ChainId.BASE),
+    logoUrl: getLogoUrl(ChainId.BASE),
     blockExplorer: {
       name: 'Base Explorer',
       url: 'https://basescan.org/',
@@ -577,7 +577,7 @@ export const ALL: Network[] = [
     name: 'base-goerli',
     title: 'Base Goerli',
     rpc: getRpcUrl('base-goerli'),
-    logoURI: getLogoUrl(ChainId.BASE_GOERLI),
+    logoUrl: getLogoUrl(ChainId.BASE_GOERLI),
     blockExplorer: {
       name: 'Base Goerli Explorer',
       url: 'https://goerli.basescan.org/',
@@ -595,7 +595,7 @@ export const ALL: Network[] = [
     name: 'base-sepolia',
     title: 'Base Sepolia',
     rpc: getRpcUrl('base-sepolia'),
-    logoURI: getLogoUrl(ChainId.BASE_SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.BASE_SEPOLIA),
     blockExplorer: {
       name: 'Base Sepolia Explorer',
       url: 'https://base-sepolia.blockscout.com/',
@@ -612,7 +612,7 @@ export const ALL: Network[] = [
     name: 'homeverse',
     title: 'Oasys Homeverse',
     rpc: getRpcUrl('homeverse'),
-    logoURI: getLogoUrl(ChainId.HOMEVERSE),
+    logoUrl: getLogoUrl(ChainId.HOMEVERSE),
     blockExplorer: {
       name: 'Oasys Homeverse Explorer',
       url: 'https://explorer.oasys.homeverse.games/',
@@ -629,7 +629,7 @@ export const ALL: Network[] = [
     name: 'homeverse-testnet',
     title: 'Oasys Homeverse Testnet',
     rpc: getRpcUrl('homeverse-testnet'),
-    logoURI: getLogoUrl(ChainId.HOMEVERSE_TESTNET),
+    logoUrl: getLogoUrl(ChainId.HOMEVERSE_TESTNET),
     blockExplorer: {
       name: 'Oasys Homeverse Explorer (Testnet)',
       url: 'https://explorer.testnet.oasys.homeverse.games/',
@@ -646,7 +646,7 @@ export const ALL: Network[] = [
     name: 'xai',
     title: 'Xai',
     rpc: getRpcUrl('xai'),
-    logoURI: getLogoUrl(ChainId.XAI),
+    logoUrl: getLogoUrl(ChainId.XAI),
     blockExplorer: {
       name: 'Xai Explorer',
       url: 'https://explorer.xai-chain.net/',
@@ -663,7 +663,7 @@ export const ALL: Network[] = [
     name: 'xai-sepolia',
     title: 'Xai Sepolia',
     rpc: getRpcUrl('xai-sepolia'),
-    logoURI: getLogoUrl(ChainId.XAI_SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.XAI_SEPOLIA),
     blockExplorer: {
       name: 'Xai Sepolia Explorer',
       url: 'https://testnet-explorer-v2.xai-chain.net/',
@@ -680,7 +680,7 @@ export const ALL: Network[] = [
     name: 'b3',
     title: 'B3',
     rpc: getRpcUrl('b3'),
-    logoURI: getLogoUrl(ChainId.B3),
+    logoUrl: getLogoUrl(ChainId.B3),
     blockExplorer: {
       name: 'B3 Explorer',
       url: 'https://explorer.b3.fun/',
@@ -697,7 +697,7 @@ export const ALL: Network[] = [
     name: 'b3-sepolia',
     title: 'B3 Sepolia',
     rpc: getRpcUrl('b3-sepolia'),
-    logoURI: getLogoUrl(ChainId.B3_SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.B3_SEPOLIA),
     blockExplorer: {
       name: 'B3 Sepolia Explorer',
       url: 'https://sepolia.explorer.b3.fun/',
@@ -714,7 +714,7 @@ export const ALL: Network[] = [
     name: 'apechain',
     title: 'APE Chain',
     rpc: getRpcUrl('apechain'),
-    logoURI: getLogoUrl(ChainId.APECHAIN),
+    logoUrl: getLogoUrl(ChainId.APECHAIN),
     blockExplorer: {
       name: 'APE Chain Explorer',
       url: 'https://apechain.calderaexplorer.xyz/',
@@ -731,7 +731,7 @@ export const ALL: Network[] = [
     name: 'apechain-testnet',
     title: 'APE Chain Testnet',
     rpc: getRpcUrl('apechain-testnet'),
-    logoURI: getLogoUrl(ChainId.APECHAIN_TESTNET),
+    logoUrl: getLogoUrl(ChainId.APECHAIN_TESTNET),
     blockExplorer: {
       name: 'APE Chain Explorer',
       url: 'https://curtis.explorer.caldera.xyz/',
@@ -748,7 +748,7 @@ export const ALL: Network[] = [
     name: 'blast',
     title: 'Blast',
     rpc: getRpcUrl('blast'),
-    logoURI: getLogoUrl(ChainId.BLAST),
+    logoUrl: getLogoUrl(ChainId.BLAST),
     blockExplorer: {
       name: 'Blast Explorer',
       url: 'https://blastscan.io/',
@@ -765,7 +765,7 @@ export const ALL: Network[] = [
     name: 'blast-sepolia',
     title: 'Blast Sepolia',
     rpc: getRpcUrl('blast-sepolia'),
-    logoURI: getLogoUrl(ChainId.BLAST_SEPOLIA),
+    logoUrl: getLogoUrl(ChainId.BLAST_SEPOLIA),
     blockExplorer: {
       name: 'Blast Sepolia Explorer',
       url: 'https://sepolia.blastexplorer.io/',
@@ -782,7 +782,7 @@ export const ALL: Network[] = [
     name: 'telos',
     title: 'Telos',
     rpc: getRpcUrl('telos'),
-    logoURI: getLogoUrl(ChainId.TELOS),
+    logoUrl: getLogoUrl(ChainId.TELOS),
     blockExplorer: {
       name: 'Telos Explorer',
       url: 'https://explorer.telos.net/network/',
@@ -799,7 +799,7 @@ export const ALL: Network[] = [
     name: 'telos-testnet',
     title: 'Telos Testnet',
     rpc: getRpcUrl('telos-testnet'),
-    logoURI: getLogoUrl(ChainId.TELOS_TESTNET),
+    logoUrl: getLogoUrl(ChainId.TELOS_TESTNET),
     blockExplorer: {
       name: 'Telos Testnet Explorer',
       url: 'https://explorer-test.telos.net/network',
@@ -816,7 +816,7 @@ export const ALL: Network[] = [
     name: 'borne-testnet',
     title: 'Borne Testnet',
     rpc: getRpcUrl('borne-testnet'),
-    logoURI: getLogoUrl(ChainId.BORNE_TESTNET),
+    logoUrl: getLogoUrl(ChainId.BORNE_TESTNET),
     blockExplorer: {
       name: 'Borne Testnet Explorer',
       url: 'https://subnets-test.avax.network/bornegfdn',
@@ -834,7 +834,7 @@ export const ALL: Network[] = [
     name: 'skale-nebula',
     title: 'SKALE Nebula Gaming Hub',
     rpc: getRpcUrl('skale-nebula'),
-    logoURI: getLogoUrl(ChainId.SKALE_NEBULA),
+    logoUrl: getLogoUrl(ChainId.SKALE_NEBULA),
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Explorer',
       url: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
@@ -851,7 +851,7 @@ export const ALL: Network[] = [
     name: 'skale-nebula-testnet',
     title: 'SKALE Nebula Gaming Hub Testnet',
     rpc: getRpcUrl('skale-nebula-testnet'),
-    logoURI: getLogoUrl(ChainId.SKALE_NEBULA_TESTNET),
+    logoUrl: getLogoUrl(ChainId.SKALE_NEBULA_TESTNET),
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Testnet Explorer',
       url: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
@@ -868,7 +868,7 @@ export const ALL: Network[] = [
     name: 'soneium',
     title: 'Soneium',
     rpc: getRpcUrl('soneium'),
-    logoURI: getLogoUrl(ChainId.SONEIUM),
+    logoUrl: getLogoUrl(ChainId.SONEIUM),
     blockExplorer: {
       name: 'Soneium Explorer',
       url: 'https://soneium.blockscout.com/',
@@ -885,7 +885,7 @@ export const ALL: Network[] = [
     name: 'soneium-minato',
     title: 'Soneium Minato (Testnet)',
     rpc: getRpcUrl('soneium-minato'),
-    logoURI: getLogoUrl(ChainId.SONEIUM_MINATO),
+    logoUrl: getLogoUrl(ChainId.SONEIUM_MINATO),
     blockExplorer: {
       name: 'Soneium Minato Explorer',
       url: 'https://explorer-testnet.soneium.org/',
@@ -902,7 +902,7 @@ export const ALL: Network[] = [
     name: 'toy-testnet',
     title: 'TOY (Testnet)',
     rpc: getRpcUrl('toy-testnet'),
-    logoURI: getLogoUrl(ChainId.TOY_TESTNET),
+    logoUrl: getLogoUrl(ChainId.TOY_TESTNET),
     blockExplorer: {
       name: 'TOY Testnet Explorer',
       url: 'https://toy-chain-testnet.explorer.caldera.xyz/',
@@ -919,7 +919,7 @@ export const ALL: Network[] = [
     name: 'immutable-zkevm',
     title: 'Immutable zkEVM',
     rpc: getRpcUrl('immutable-zkevm'),
-    logoURI: getLogoUrl(ChainId.IMMUTABLE_ZKEVM),
+    logoUrl: getLogoUrl(ChainId.IMMUTABLE_ZKEVM),
     blockExplorer: {
       name: 'Immutable zkEVM Explorer',
       url: 'https://explorer.immutable.com/',
@@ -936,7 +936,7 @@ export const ALL: Network[] = [
     name: 'immutable-zkevm-testnet',
     title: 'Immutable zkEVM Testnet',
     rpc: getRpcUrl('immutable-zkevm-testnet'),
-    logoURI: getLogoUrl(ChainId.IMMUTABLE_ZKEVM_TESTNET),
+    logoUrl: getLogoUrl(ChainId.IMMUTABLE_ZKEVM_TESTNET),
     blockExplorer: {
       name: 'Immutable zkEVM Testnet Explorer',
       url: 'https://explorer.testnet.immutable.com/',
@@ -953,7 +953,7 @@ export const ALL: Network[] = [
     name: 'rootnet',
     title: 'The Root Network',
     rpc: getRpcUrl('rootnet'),
-    logoURI: getLogoUrl(ChainId.ROOT_NETWORK),
+    logoUrl: getLogoUrl(ChainId.ROOT_NETWORK),
     blockExplorer: {
       name: 'The Root Network Explorer',
       url: 'https://rootscan.io/',
@@ -970,7 +970,7 @@ export const ALL: Network[] = [
     name: 'rootnet-porcini',
     title: 'The Root Network Porcini Testnet',
     rpc: getRpcUrl('rootnet-porcini'),
-    logoURI: getLogoUrl(ChainId.ROOT_NETWORK_PORCINI),
+    logoUrl: getLogoUrl(ChainId.ROOT_NETWORK_PORCINI),
     blockExplorer: {
       name: 'The Root Network Porcini Testnet Explorer',
       url: 'https://porcini.rootscan.io/',
@@ -1011,7 +1011,7 @@ export const ALL: Network[] = [
     name: 'laos',
     title: 'LAOS',
     rpc: getRpcUrl('laos'),
-    logoURI: getLogoUrl(ChainId.LAOS),
+    logoUrl: getLogoUrl(ChainId.LAOS),
     blockExplorer: {
       name: 'LAOS Explorer',
       url: 'https://blockscout.laos.laosfoundation.io/',
@@ -1028,7 +1028,7 @@ export const ALL: Network[] = [
     name: 'laos-sigma-testnet',
     title: 'LAOS Sigma Testnet',
     rpc: getRpcUrl('laos-sigma-testnet'),
-    logoURI: getLogoUrl(ChainId.LAOS_SIGMA_TESTNET),
+    logoUrl: getLogoUrl(ChainId.LAOS_SIGMA_TESTNET),
     blockExplorer: {
       name: 'LAOS Sigma Testnet Explorer',
       url: 'https://sigma.explorer.laosnetwork.io/',
@@ -1045,7 +1045,7 @@ export const ALL: Network[] = [
     name: 'moonbeam',
     title: 'Moonbeam',
     rpc: getRpcUrl('moonbeam'),
-    logoURI: getLogoUrl(ChainId.MOONBEAM),
+    logoUrl: getLogoUrl(ChainId.MOONBEAM),
     blockExplorer: {
       name: 'Moonscan',
       url: 'https://moonscan.io/',
@@ -1062,7 +1062,7 @@ export const ALL: Network[] = [
     name: 'moonbase-alpha',
     title: 'Moonbase Alpha',
     rpc: getRpcUrl('moonbase-alpha'),
-    logoURI: getLogoUrl(ChainId.MOONBASE_ALPHA),
+    logoUrl: getLogoUrl(ChainId.MOONBASE_ALPHA),
     blockExplorer: {
       name: 'Moonscan (Moonbase Alpha)',
       url: 'https://moonbase.moonscan.io/',
@@ -1079,7 +1079,7 @@ export const ALL: Network[] = [
     name: 'etherlink',
     title: 'Etherlink',
     rpc: getRpcUrl('etherlink'),
-    logoURI: getLogoUrl(ChainId.ETHERLINK),
+    logoUrl: getLogoUrl(ChainId.ETHERLINK),
     blockExplorer: {
       name: 'Etherlink Explorer',
       url: 'https://explorer.etherlink.com/',
@@ -1096,7 +1096,7 @@ export const ALL: Network[] = [
     name: 'etherlink-testnet',
     title: 'Etherlink Testnet',
     rpc: getRpcUrl('etherlink-testnet'),
-    logoURI: getLogoUrl(ChainId.ETHERLINK_TESTNET),
+    logoUrl: getLogoUrl(ChainId.ETHERLINK_TESTNET),
     blockExplorer: {
       name: 'Etherlink Testnet Explorer',
       url: 'https://testnet.explorer.etherlink.com/',
@@ -1113,7 +1113,7 @@ export const ALL: Network[] = [
     name: 'monad-testnet',
     title: 'Monad Testnet',
     rpc: getRpcUrl('monad-testnet'),
-    logoURI: getLogoUrl(ChainId.MONAD_TESTNET),
+    logoUrl: getLogoUrl(ChainId.MONAD_TESTNET),
     blockExplorer: {
       name: 'Monad Testnet Explorer',
       url: 'https://testnet.monadexplorer.com/',
@@ -1131,7 +1131,7 @@ export const ALL: Network[] = [
     name: 'somnia-testnet',
     title: 'Somnia Testnet',
     rpc: getRpcUrl('somnia-testnet'),
-    logoURI: getLogoUrl(ChainId.SOMNIA_TESTNET),
+    logoUrl: getLogoUrl(ChainId.SOMNIA_TESTNET),
     blockExplorer: {
       name: 'Somnia Testnet Explorer',
       url: 'https://somnia-testnet.socialscan.io/',
@@ -1149,7 +1149,7 @@ export const ALL: Network[] = [
     name: 'incentiv-testnet',
     title: 'Incentiv Testnet',
     rpc: getRpcUrl('incentiv-testnet'),
-    logoURI: getLogoUrl(ChainId.INCENTIV_TESTNET),
+    logoUrl: getLogoUrl(ChainId.INCENTIV_TESTNET),
     blockExplorer: {
       name: 'Incentiv Testnet Explorer',
       url: 'https://explorer.testnet.incentiv.net/',
@@ -1167,7 +1167,7 @@ export const ALL: Network[] = [
     name: 'sei',
     title: 'Sei',
     rpc: getRpcUrl('sei'),
-    logoURI: getLogoUrl(ChainId.SEI),
+    logoUrl: getLogoUrl(ChainId.SEI),
     blockExplorer: {
       name: 'SEI Explorer',
       url: 'https://seitrace.com/?chain=pacific-1',
@@ -1185,7 +1185,7 @@ export const ALL: Network[] = [
     name: 'sei-testnet',
     title: 'Sei Testnet',
     rpc: getRpcUrl('sei-testnet'),
-    logoURI: getLogoUrl(ChainId.SEI_TESTNET),
+    logoUrl: getLogoUrl(ChainId.SEI_TESTNET),
     blockExplorer: {
       name: 'Sei Testnet Explorer',
       url: 'https://seitrace.com/?chain=atlantic-2',
@@ -1203,7 +1203,7 @@ export const ALL: Network[] = [
     name: 'somnia',
     title: 'Somnia',
     rpc: getRpcUrl('somnia'),
-    logoURI: getLogoUrl(ChainId.SOMNIA),
+    logoUrl: getLogoUrl(ChainId.SOMNIA),
     blockExplorer: {
       name: 'Somnia Explorer',
       url: 'https://mainnet.somnia.w3us.site/',

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -10,11 +10,11 @@ export type BlockExplorerConfig = {
 }
 
 export interface Network {
-  chainId: ChainId
+  chainId: bigint
   type: NetworkType
   name: string
   title?: string
-  rpc: string
+  rpcUrl: string
   logoUrl?: string
   blockExplorer?: BlockExplorerConfig
   nativeToken: {
@@ -156,7 +156,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'mainnet',
     title: 'Ethereum',
-    rpc: getRpcUrl('mainnet'),
+    rpcUrl: getRpcUrl('mainnet'),
     logoUrl: getLogoUrl(ChainId.MAINNET),
     blockExplorer: {
       name: 'Etherscan',
@@ -174,7 +174,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'ropsten',
     title: 'Ropsten',
-    rpc: getRpcUrl('ropsten'),
+    rpcUrl: getRpcUrl('ropsten'),
     logoUrl: getLogoUrl(ChainId.ROPSTEN),
     blockExplorer: {
       name: 'Etherscan (Ropsten)',
@@ -193,7 +193,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'rinkeby',
     title: 'Rinkeby',
-    rpc: getRpcUrl('rinkeby'),
+    rpcUrl: getRpcUrl('rinkeby'),
     logoUrl: getLogoUrl(ChainId.RINKEBY),
     blockExplorer: {
       name: 'Etherscan (Rinkeby)',
@@ -212,7 +212,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'goerli',
     title: 'Goerli',
-    rpc: getRpcUrl('goerli'),
+    rpcUrl: getRpcUrl('goerli'),
     logoUrl: getLogoUrl(ChainId.GOERLI),
     blockExplorer: {
       name: 'Etherscan (Goerli)',
@@ -231,7 +231,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'kovan',
     title: 'Kovan',
-    rpc: getRpcUrl('kovan'),
+    rpcUrl: getRpcUrl('kovan'),
     logoUrl: getLogoUrl(ChainId.KOVAN),
     blockExplorer: {
       name: 'Etherscan (Kovan)',
@@ -249,7 +249,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'sepolia',
     title: 'Sepolia',
-    rpc: getRpcUrl('sepolia'),
+    rpcUrl: getRpcUrl('sepolia'),
     logoUrl: getLogoUrl(ChainId.SEPOLIA),
     blockExplorer: {
       name: 'Etherscan (Sepolia)',
@@ -266,7 +266,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'polygon',
     title: 'Polygon',
-    rpc: getRpcUrl('polygon'),
+    rpcUrl: getRpcUrl('polygon'),
     logoUrl: getLogoUrl(ChainId.POLYGON),
     blockExplorer: {
       name: 'Polygonscan',
@@ -283,7 +283,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'mumbai',
     title: 'Polygon Mumbai',
-    rpc: getRpcUrl('mumbai'),
+    rpcUrl: getRpcUrl('mumbai'),
     logoUrl: getLogoUrl(ChainId.POLYGON_MUMBAI),
     blockExplorer: {
       name: 'Polygonscan (Mumbai)',
@@ -301,7 +301,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'amoy',
     title: 'Polygon Amoy',
-    rpc: getRpcUrl('amoy'),
+    rpcUrl: getRpcUrl('amoy'),
     logoUrl: getLogoUrl(ChainId.POLYGON_AMOY),
     blockExplorer: {
       name: 'OKLink (Amoy)',
@@ -318,7 +318,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'polygon-zkevm',
     title: 'Polygon zkEVM',
-    rpc: getRpcUrl('polygon-zkevm'),
+    rpcUrl: getRpcUrl('polygon-zkevm'),
     logoUrl: getLogoUrl(ChainId.POLYGON_ZKEVM),
     blockExplorer: {
       name: 'Polygonscan (zkEVM)',
@@ -335,7 +335,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'bsc',
     title: 'BNB Smart Chain',
-    rpc: getRpcUrl('bsc'),
+    rpcUrl: getRpcUrl('bsc'),
     logoUrl: getLogoUrl(ChainId.BSC),
     blockExplorer: {
       name: 'BSCScan',
@@ -352,7 +352,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'bsc-testnet',
     title: 'BNB Smart Chain Testnet',
-    rpc: getRpcUrl('bsc-testnet'),
+    rpcUrl: getRpcUrl('bsc-testnet'),
     logoUrl: getLogoUrl(ChainId.BSC_TESTNET),
     blockExplorer: {
       name: 'BSCScan (Testnet)',
@@ -369,7 +369,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'optimism',
     title: 'Optimism',
-    rpc: getRpcUrl('optimism'),
+    rpcUrl: getRpcUrl('optimism'),
     logoUrl: getLogoUrl(ChainId.OPTIMISM),
     blockExplorer: {
       name: 'Etherscan (Optimism)',
@@ -386,7 +386,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'optimism-kovan',
     title: 'Optimism Kovan',
-    rpc: getRpcUrl('optimism-kovan'),
+    rpcUrl: getRpcUrl('optimism-kovan'),
     logoUrl: getLogoUrl(ChainId.OPTIMISM_KOVAN),
     blockExplorer: {
       name: 'Etherscan (Optimism Kovan)',
@@ -404,7 +404,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'optimism-goerli',
     title: 'Optimism Goerli',
-    rpc: getRpcUrl('optimism-goerli'),
+    rpcUrl: getRpcUrl('optimism-goerli'),
     logoUrl: getLogoUrl(ChainId.OPTIMISM_GOERLI),
     blockExplorer: {
       name: 'Etherscan (Optimism Goerli)',
@@ -422,7 +422,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'optimism-sepolia',
     title: 'Optimism Sepolia',
-    rpc: getRpcUrl('optimism-sepolia'),
+    rpcUrl: getRpcUrl('optimism-sepolia'),
     logoUrl: getLogoUrl(ChainId.OPTIMISM_SEPOLIA),
     blockExplorer: {
       name: 'Etherscan (Optimism Sepolia)',
@@ -439,7 +439,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'arbitrum',
     title: 'Arbitrum One',
-    rpc: getRpcUrl('arbitrum'),
+    rpcUrl: getRpcUrl('arbitrum'),
     logoUrl: getLogoUrl(ChainId.ARBITRUM),
     blockExplorer: {
       name: 'Arbiscan',
@@ -456,7 +456,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'arbitrum-goerli',
     title: 'Arbitrum Goerli',
-    rpc: getRpcUrl('arbitrum-goerli'),
+    rpcUrl: getRpcUrl('arbitrum-goerli'),
     logoUrl: getLogoUrl(ChainId.ARBITRUM_GOERLI),
     blockExplorer: {
       name: 'Arbiscan (Goerli Testnet)',
@@ -474,7 +474,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'arbitrum-sepolia',
     title: 'Arbitrum Sepolia',
-    rpc: getRpcUrl('arbitrum-sepolia'),
+    rpcUrl: getRpcUrl('arbitrum-sepolia'),
     logoUrl: getLogoUrl(ChainId.ARBITRUM_SEPOLIA),
     blockExplorer: {
       name: 'Arbiscan (Sepolia Testnet)',
@@ -491,7 +491,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'arbitrum-nova',
     title: 'Arbitrum Nova',
-    rpc: getRpcUrl('arbitrum-nova'),
+    rpcUrl: getRpcUrl('arbitrum-nova'),
     logoUrl: getLogoUrl(ChainId.ARBITRUM_NOVA),
     blockExplorer: {
       name: 'Arbiscan Nova',
@@ -508,7 +508,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'avalanche',
     title: 'Avalanche',
-    rpc: getRpcUrl('avalanche'),
+    rpcUrl: getRpcUrl('avalanche'),
     logoUrl: getLogoUrl(ChainId.AVALANCHE),
     blockExplorer: {
       name: 'Snowtrace',
@@ -525,7 +525,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'avalanche-testnet',
     title: 'Avalanche Testnet',
-    rpc: getRpcUrl('avalanche-testnet'),
+    rpcUrl: getRpcUrl('avalanche-testnet'),
     logoUrl: getLogoUrl(ChainId.AVALANCHE_TESTNET),
     blockExplorer: {
       name: 'Snowtrace (Testnet)',
@@ -542,7 +542,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'gnosis',
     title: 'Gnosis Chain',
-    rpc: getRpcUrl('gnosis'),
+    rpcUrl: getRpcUrl('gnosis'),
     logoUrl: getLogoUrl(ChainId.GNOSIS),
     blockExplorer: {
       name: 'Gnosis Chain Explorer',
@@ -559,7 +559,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'base',
     title: 'Base (Coinbase)',
-    rpc: getRpcUrl('base'),
+    rpcUrl: getRpcUrl('base'),
     logoUrl: getLogoUrl(ChainId.BASE),
     blockExplorer: {
       name: 'Base Explorer',
@@ -576,7 +576,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'base-goerli',
     title: 'Base Goerli',
-    rpc: getRpcUrl('base-goerli'),
+    rpcUrl: getRpcUrl('base-goerli'),
     logoUrl: getLogoUrl(ChainId.BASE_GOERLI),
     blockExplorer: {
       name: 'Base Goerli Explorer',
@@ -594,7 +594,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'base-sepolia',
     title: 'Base Sepolia',
-    rpc: getRpcUrl('base-sepolia'),
+    rpcUrl: getRpcUrl('base-sepolia'),
     logoUrl: getLogoUrl(ChainId.BASE_SEPOLIA),
     blockExplorer: {
       name: 'Base Sepolia Explorer',
@@ -611,7 +611,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'homeverse',
     title: 'Oasys Homeverse',
-    rpc: getRpcUrl('homeverse'),
+    rpcUrl: getRpcUrl('homeverse'),
     logoUrl: getLogoUrl(ChainId.HOMEVERSE),
     blockExplorer: {
       name: 'Oasys Homeverse Explorer',
@@ -628,7 +628,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'homeverse-testnet',
     title: 'Oasys Homeverse Testnet',
-    rpc: getRpcUrl('homeverse-testnet'),
+    rpcUrl: getRpcUrl('homeverse-testnet'),
     logoUrl: getLogoUrl(ChainId.HOMEVERSE_TESTNET),
     blockExplorer: {
       name: 'Oasys Homeverse Explorer (Testnet)',
@@ -645,7 +645,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'xai',
     title: 'Xai',
-    rpc: getRpcUrl('xai'),
+    rpcUrl: getRpcUrl('xai'),
     logoUrl: getLogoUrl(ChainId.XAI),
     blockExplorer: {
       name: 'Xai Explorer',
@@ -662,7 +662,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'xai-sepolia',
     title: 'Xai Sepolia',
-    rpc: getRpcUrl('xai-sepolia'),
+    rpcUrl: getRpcUrl('xai-sepolia'),
     logoUrl: getLogoUrl(ChainId.XAI_SEPOLIA),
     blockExplorer: {
       name: 'Xai Sepolia Explorer',
@@ -679,7 +679,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'b3',
     title: 'B3',
-    rpc: getRpcUrl('b3'),
+    rpcUrl: getRpcUrl('b3'),
     logoUrl: getLogoUrl(ChainId.B3),
     blockExplorer: {
       name: 'B3 Explorer',
@@ -696,7 +696,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'b3-sepolia',
     title: 'B3 Sepolia',
-    rpc: getRpcUrl('b3-sepolia'),
+    rpcUrl: getRpcUrl('b3-sepolia'),
     logoUrl: getLogoUrl(ChainId.B3_SEPOLIA),
     blockExplorer: {
       name: 'B3 Sepolia Explorer',
@@ -713,7 +713,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'apechain',
     title: 'APE Chain',
-    rpc: getRpcUrl('apechain'),
+    rpcUrl: getRpcUrl('apechain'),
     logoUrl: getLogoUrl(ChainId.APECHAIN),
     blockExplorer: {
       name: 'APE Chain Explorer',
@@ -730,7 +730,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'apechain-testnet',
     title: 'APE Chain Testnet',
-    rpc: getRpcUrl('apechain-testnet'),
+    rpcUrl: getRpcUrl('apechain-testnet'),
     logoUrl: getLogoUrl(ChainId.APECHAIN_TESTNET),
     blockExplorer: {
       name: 'APE Chain Explorer',
@@ -747,7 +747,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'blast',
     title: 'Blast',
-    rpc: getRpcUrl('blast'),
+    rpcUrl: getRpcUrl('blast'),
     logoUrl: getLogoUrl(ChainId.BLAST),
     blockExplorer: {
       name: 'Blast Explorer',
@@ -764,7 +764,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'blast-sepolia',
     title: 'Blast Sepolia',
-    rpc: getRpcUrl('blast-sepolia'),
+    rpcUrl: getRpcUrl('blast-sepolia'),
     logoUrl: getLogoUrl(ChainId.BLAST_SEPOLIA),
     blockExplorer: {
       name: 'Blast Sepolia Explorer',
@@ -781,7 +781,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'telos',
     title: 'Telos',
-    rpc: getRpcUrl('telos'),
+    rpcUrl: getRpcUrl('telos'),
     logoUrl: getLogoUrl(ChainId.TELOS),
     blockExplorer: {
       name: 'Telos Explorer',
@@ -798,7 +798,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'telos-testnet',
     title: 'Telos Testnet',
-    rpc: getRpcUrl('telos-testnet'),
+    rpcUrl: getRpcUrl('telos-testnet'),
     logoUrl: getLogoUrl(ChainId.TELOS_TESTNET),
     blockExplorer: {
       name: 'Telos Testnet Explorer',
@@ -815,7 +815,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'borne-testnet',
     title: 'Borne Testnet',
-    rpc: getRpcUrl('borne-testnet'),
+    rpcUrl: getRpcUrl('borne-testnet'),
     logoUrl: getLogoUrl(ChainId.BORNE_TESTNET),
     blockExplorer: {
       name: 'Borne Testnet Explorer',
@@ -833,7 +833,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'skale-nebula',
     title: 'SKALE Nebula Gaming Hub',
-    rpc: getRpcUrl('skale-nebula'),
+    rpcUrl: getRpcUrl('skale-nebula'),
     logoUrl: getLogoUrl(ChainId.SKALE_NEBULA),
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Explorer',
@@ -850,7 +850,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'skale-nebula-testnet',
     title: 'SKALE Nebula Gaming Hub Testnet',
-    rpc: getRpcUrl('skale-nebula-testnet'),
+    rpcUrl: getRpcUrl('skale-nebula-testnet'),
     logoUrl: getLogoUrl(ChainId.SKALE_NEBULA_TESTNET),
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Testnet Explorer',
@@ -867,7 +867,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'soneium',
     title: 'Soneium',
-    rpc: getRpcUrl('soneium'),
+    rpcUrl: getRpcUrl('soneium'),
     logoUrl: getLogoUrl(ChainId.SONEIUM),
     blockExplorer: {
       name: 'Soneium Explorer',
@@ -884,7 +884,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'soneium-minato',
     title: 'Soneium Minato (Testnet)',
-    rpc: getRpcUrl('soneium-minato'),
+    rpcUrl: getRpcUrl('soneium-minato'),
     logoUrl: getLogoUrl(ChainId.SONEIUM_MINATO),
     blockExplorer: {
       name: 'Soneium Minato Explorer',
@@ -901,7 +901,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'toy-testnet',
     title: 'TOY (Testnet)',
-    rpc: getRpcUrl('toy-testnet'),
+    rpcUrl: getRpcUrl('toy-testnet'),
     logoUrl: getLogoUrl(ChainId.TOY_TESTNET),
     blockExplorer: {
       name: 'TOY Testnet Explorer',
@@ -918,7 +918,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'immutable-zkevm',
     title: 'Immutable zkEVM',
-    rpc: getRpcUrl('immutable-zkevm'),
+    rpcUrl: getRpcUrl('immutable-zkevm'),
     logoUrl: getLogoUrl(ChainId.IMMUTABLE_ZKEVM),
     blockExplorer: {
       name: 'Immutable zkEVM Explorer',
@@ -935,7 +935,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'immutable-zkevm-testnet',
     title: 'Immutable zkEVM Testnet',
-    rpc: getRpcUrl('immutable-zkevm-testnet'),
+    rpcUrl: getRpcUrl('immutable-zkevm-testnet'),
     logoUrl: getLogoUrl(ChainId.IMMUTABLE_ZKEVM_TESTNET),
     blockExplorer: {
       name: 'Immutable zkEVM Testnet Explorer',
@@ -952,7 +952,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'rootnet',
     title: 'The Root Network',
-    rpc: getRpcUrl('rootnet'),
+    rpcUrl: getRpcUrl('rootnet'),
     logoUrl: getLogoUrl(ChainId.ROOT_NETWORK),
     blockExplorer: {
       name: 'The Root Network Explorer',
@@ -969,7 +969,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'rootnet-porcini',
     title: 'The Root Network Porcini Testnet',
-    rpc: getRpcUrl('rootnet-porcini'),
+    rpcUrl: getRpcUrl('rootnet-porcini'),
     logoUrl: getLogoUrl(ChainId.ROOT_NETWORK_PORCINI),
     blockExplorer: {
       name: 'The Root Network Porcini Testnet Explorer',
@@ -986,7 +986,7 @@ export const ALL: Network[] = [
     type: NetworkType.LOCAL,
     name: 'hardhat',
     title: 'Hardhat (local testnet)',
-    rpc: 'http://localhost:8545',
+    rpcUrl: 'http://localhost:8545',
     nativeToken: {
       symbol: 'ETH',
       name: 'Ether',
@@ -998,7 +998,7 @@ export const ALL: Network[] = [
     type: NetworkType.LOCAL,
     name: 'hardhat2',
     title: 'Hardhat (local testnet)',
-    rpc: 'http://localhost:8545',
+    rpcUrl: 'http://localhost:8545',
     nativeToken: {
       symbol: 'ETH',
       name: 'Ether',
@@ -1010,7 +1010,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'laos',
     title: 'LAOS',
-    rpc: getRpcUrl('laos'),
+    rpcUrl: getRpcUrl('laos'),
     logoUrl: getLogoUrl(ChainId.LAOS),
     blockExplorer: {
       name: 'LAOS Explorer',
@@ -1027,7 +1027,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'laos-sigma-testnet',
     title: 'LAOS Sigma Testnet',
-    rpc: getRpcUrl('laos-sigma-testnet'),
+    rpcUrl: getRpcUrl('laos-sigma-testnet'),
     logoUrl: getLogoUrl(ChainId.LAOS_SIGMA_TESTNET),
     blockExplorer: {
       name: 'LAOS Sigma Testnet Explorer',
@@ -1044,7 +1044,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'moonbeam',
     title: 'Moonbeam',
-    rpc: getRpcUrl('moonbeam'),
+    rpcUrl: getRpcUrl('moonbeam'),
     logoUrl: getLogoUrl(ChainId.MOONBEAM),
     blockExplorer: {
       name: 'Moonscan',
@@ -1061,7 +1061,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'moonbase-alpha',
     title: 'Moonbase Alpha',
-    rpc: getRpcUrl('moonbase-alpha'),
+    rpcUrl: getRpcUrl('moonbase-alpha'),
     logoUrl: getLogoUrl(ChainId.MOONBASE_ALPHA),
     blockExplorer: {
       name: 'Moonscan (Moonbase Alpha)',
@@ -1078,7 +1078,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'etherlink',
     title: 'Etherlink',
-    rpc: getRpcUrl('etherlink'),
+    rpcUrl: getRpcUrl('etherlink'),
     logoUrl: getLogoUrl(ChainId.ETHERLINK),
     blockExplorer: {
       name: 'Etherlink Explorer',
@@ -1095,7 +1095,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'etherlink-testnet',
     title: 'Etherlink Testnet',
-    rpc: getRpcUrl('etherlink-testnet'),
+    rpcUrl: getRpcUrl('etherlink-testnet'),
     logoUrl: getLogoUrl(ChainId.ETHERLINK_TESTNET),
     blockExplorer: {
       name: 'Etherlink Testnet Explorer',
@@ -1112,7 +1112,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'monad-testnet',
     title: 'Monad Testnet',
-    rpc: getRpcUrl('monad-testnet'),
+    rpcUrl: getRpcUrl('monad-testnet'),
     logoUrl: getLogoUrl(ChainId.MONAD_TESTNET),
     blockExplorer: {
       name: 'Monad Testnet Explorer',
@@ -1130,7 +1130,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'somnia-testnet',
     title: 'Somnia Testnet',
-    rpc: getRpcUrl('somnia-testnet'),
+    rpcUrl: getRpcUrl('somnia-testnet'),
     logoUrl: getLogoUrl(ChainId.SOMNIA_TESTNET),
     blockExplorer: {
       name: 'Somnia Testnet Explorer',
@@ -1148,7 +1148,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'incentiv-testnet',
     title: 'Incentiv Testnet',
-    rpc: getRpcUrl('incentiv-testnet'),
+    rpcUrl: getRpcUrl('incentiv-testnet'),
     logoUrl: getLogoUrl(ChainId.INCENTIV_TESTNET),
     blockExplorer: {
       name: 'Incentiv Testnet Explorer',
@@ -1166,7 +1166,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'sei',
     title: 'Sei',
-    rpc: getRpcUrl('sei'),
+    rpcUrl: getRpcUrl('sei'),
     logoUrl: getLogoUrl(ChainId.SEI),
     blockExplorer: {
       name: 'SEI Explorer',
@@ -1184,7 +1184,7 @@ export const ALL: Network[] = [
     type: NetworkType.TESTNET,
     name: 'sei-testnet',
     title: 'Sei Testnet',
-    rpc: getRpcUrl('sei-testnet'),
+    rpcUrl: getRpcUrl('sei-testnet'),
     logoUrl: getLogoUrl(ChainId.SEI_TESTNET),
     blockExplorer: {
       name: 'Sei Testnet Explorer',
@@ -1202,7 +1202,7 @@ export const ALL: Network[] = [
     type: NetworkType.MAINNET,
     name: 'somnia',
     title: 'Somnia',
-    rpc: getRpcUrl('somnia'),
+    rpcUrl: getRpcUrl('somnia'),
     logoUrl: getLogoUrl(ChainId.SOMNIA),
     blockExplorer: {
       name: 'Somnia Explorer',

--- a/packages/wallet/primitives/src/network.ts
+++ b/packages/wallet/primitives/src/network.ts
@@ -6,7 +6,7 @@ export enum NetworkType {
 
 export type BlockExplorerConfig = {
   name?: string
-  rootUrl: string
+  url: string
 }
 
 export interface Network {
@@ -160,7 +160,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MAINNET}.webp`,
     blockExplorer: {
       name: 'Etherscan',
-      rootUrl: 'https://etherscan.io/',
+      url: 'https://etherscan.io/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -178,7 +178,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROPSTEN}.webp`,
     blockExplorer: {
       name: 'Etherscan (Ropsten)',
-      rootUrl: 'https://ropsten.etherscan.io/',
+      url: 'https://ropsten.etherscan.io/',
     },
     nativeToken: {
       symbol: 'roETH',
@@ -197,7 +197,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.RINKEBY}.webp`,
     blockExplorer: {
       name: 'Etherscan (Rinkeby)',
-      rootUrl: 'https://rinkeby.etherscan.io/',
+      url: 'https://rinkeby.etherscan.io/',
     },
     nativeToken: {
       symbol: 'rETH',
@@ -216,7 +216,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GOERLI}.webp`,
     blockExplorer: {
       name: 'Etherscan (Goerli)',
-      rootUrl: 'https://goerli.etherscan.io/',
+      url: 'https://goerli.etherscan.io/',
     },
     nativeToken: {
       symbol: 'gETH',
@@ -235,7 +235,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.KOVAN}.webp`,
     blockExplorer: {
       name: 'Etherscan (Kovan)',
-      rootUrl: 'https://kovan.etherscan.io/',
+      url: 'https://kovan.etherscan.io/',
     },
     nativeToken: {
       symbol: 'kETH',
@@ -253,7 +253,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Etherscan (Sepolia)',
-      rootUrl: 'https://sepolia.etherscan.io/',
+      url: 'https://sepolia.etherscan.io/',
     },
     nativeToken: {
       symbol: 'sETH',
@@ -270,7 +270,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON}.webp`,
     blockExplorer: {
       name: 'Polygonscan',
-      rootUrl: 'https://polygonscan.com/',
+      url: 'https://polygonscan.com/',
     },
     nativeToken: {
       symbol: 'POL',
@@ -287,7 +287,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_MUMBAI}.webp`,
     blockExplorer: {
       name: 'Polygonscan (Mumbai)',
-      rootUrl: 'https://mumbai.polygonscan.com/',
+      url: 'https://mumbai.polygonscan.com/',
     },
     nativeToken: {
       symbol: 'mMATIC',
@@ -305,7 +305,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_AMOY}.webp`,
     blockExplorer: {
       name: 'OKLink (Amoy)',
-      rootUrl: 'https://www.oklink.com/amoy/',
+      url: 'https://www.oklink.com/amoy/',
     },
     nativeToken: {
       symbol: 'aPOL',
@@ -322,7 +322,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.POLYGON_ZKEVM}.webp`,
     blockExplorer: {
       name: 'Polygonscan (zkEVM)',
-      rootUrl: 'https://zkevm.polygonscan.com/',
+      url: 'https://zkevm.polygonscan.com/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -339,7 +339,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC}.webp`,
     blockExplorer: {
       name: 'BSCScan',
-      rootUrl: 'https://bscscan.com/',
+      url: 'https://bscscan.com/',
     },
     nativeToken: {
       symbol: 'BNB',
@@ -356,7 +356,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BSC_TESTNET}.webp`,
     blockExplorer: {
       name: 'BSCScan (Testnet)',
-      rootUrl: 'https://testnet.bscscan.com/',
+      url: 'https://testnet.bscscan.com/',
     },
     nativeToken: {
       symbol: 'tBNB',
@@ -373,7 +373,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism)',
-      rootUrl: 'https://optimistic.etherscan.io/',
+      url: 'https://optimistic.etherscan.io/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -390,7 +390,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_KOVAN}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism Kovan)',
-      rootUrl: 'https://kovan-optimistic.etherscan.io/',
+      url: 'https://kovan-optimistic.etherscan.io/',
     },
     nativeToken: {
       symbol: 'kETH',
@@ -408,7 +408,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_GOERLI}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism Goerli)',
-      rootUrl: 'https://goerli-optimistic.etherscan.io/',
+      url: 'https://goerli-optimistic.etherscan.io/',
     },
     nativeToken: {
       symbol: 'gETH',
@@ -426,7 +426,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.OPTIMISM_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Etherscan (Optimism Sepolia)',
-      rootUrl: 'https://sepolia-optimistic.etherscan.io/',
+      url: 'https://sepolia-optimistic.etherscan.io/',
     },
     nativeToken: {
       symbol: 'sETH',
@@ -443,7 +443,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM}.webp`,
     blockExplorer: {
       name: 'Arbiscan',
-      rootUrl: 'https://arbiscan.io/',
+      url: 'https://arbiscan.io/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -460,7 +460,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_GOERLI}.webp`,
     blockExplorer: {
       name: 'Arbiscan (Goerli Testnet)',
-      rootUrl: 'https://testnet.arbiscan.io/',
+      url: 'https://testnet.arbiscan.io/',
     },
     nativeToken: {
       symbol: 'gETH',
@@ -478,7 +478,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Arbiscan (Sepolia Testnet)',
-      rootUrl: 'https://sepolia.arbiscan.io/',
+      url: 'https://sepolia.arbiscan.io/',
     },
     nativeToken: {
       symbol: 'sETH',
@@ -495,7 +495,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ARBITRUM_NOVA}.webp`,
     blockExplorer: {
       name: 'Arbiscan Nova',
-      rootUrl: 'https://nova.arbiscan.io/',
+      url: 'https://nova.arbiscan.io/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -512,7 +512,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE}.webp`,
     blockExplorer: {
       name: 'Snowtrace',
-      rootUrl: 'https://subnets.avax.network/c-chain/',
+      url: 'https://subnets.avax.network/c-chain/',
     },
     nativeToken: {
       symbol: 'AVAX',
@@ -529,7 +529,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.AVALANCHE_TESTNET}.webp`,
     blockExplorer: {
       name: 'Snowtrace (Testnet)',
-      rootUrl: 'https://subnets-test.avax.network/c-chain/',
+      url: 'https://subnets-test.avax.network/c-chain/',
     },
     nativeToken: {
       symbol: 'tAVAX',
@@ -546,7 +546,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.GNOSIS}.webp`,
     blockExplorer: {
       name: 'Gnosis Chain Explorer',
-      rootUrl: 'https://blockscout.com/xdai/mainnet/',
+      url: 'https://blockscout.com/xdai/mainnet/',
     },
     nativeToken: {
       symbol: 'XDAI',
@@ -563,7 +563,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE}.webp`,
     blockExplorer: {
       name: 'Base Explorer',
-      rootUrl: 'https://basescan.org/',
+      url: 'https://basescan.org/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -580,7 +580,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_GOERLI}.webp`,
     blockExplorer: {
       name: 'Base Goerli Explorer',
-      rootUrl: 'https://goerli.basescan.org/',
+      url: 'https://goerli.basescan.org/',
     },
     nativeToken: {
       symbol: 'gETH',
@@ -598,7 +598,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BASE_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Base Sepolia Explorer',
-      rootUrl: 'https://base-sepolia.blockscout.com/',
+      url: 'https://base-sepolia.blockscout.com/',
     },
     nativeToken: {
       symbol: 'sETH',
@@ -615,7 +615,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE}.webp`,
     blockExplorer: {
       name: 'Oasys Homeverse Explorer',
-      rootUrl: 'https://explorer.oasys.homeverse.games/',
+      url: 'https://explorer.oasys.homeverse.games/',
     },
     nativeToken: {
       symbol: 'OAS',
@@ -632,7 +632,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.HOMEVERSE_TESTNET}.webp`,
     blockExplorer: {
       name: 'Oasys Homeverse Explorer (Testnet)',
-      rootUrl: 'https://explorer.testnet.oasys.homeverse.games/',
+      url: 'https://explorer.testnet.oasys.homeverse.games/',
     },
     nativeToken: {
       symbol: 'tOAS',
@@ -649,7 +649,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI}.webp`,
     blockExplorer: {
       name: 'Xai Explorer',
-      rootUrl: 'https://explorer.xai-chain.net/',
+      url: 'https://explorer.xai-chain.net/',
     },
     nativeToken: {
       symbol: 'XAI',
@@ -666,7 +666,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.XAI_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Xai Sepolia Explorer',
-      rootUrl: 'https://testnet-explorer-v2.xai-chain.net/',
+      url: 'https://testnet-explorer-v2.xai-chain.net/',
     },
     nativeToken: {
       symbol: 'sXAI',
@@ -683,7 +683,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3}.webp`,
     blockExplorer: {
       name: 'B3 Explorer',
-      rootUrl: 'https://explorer.b3.fun/',
+      url: 'https://explorer.b3.fun/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -700,7 +700,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.B3_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'B3 Sepolia Explorer',
-      rootUrl: 'https://sepolia.explorer.b3.fun/',
+      url: 'https://sepolia.explorer.b3.fun/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -717,7 +717,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN}.webp`,
     blockExplorer: {
       name: 'APE Chain Explorer',
-      rootUrl: 'https://apechain.calderaexplorer.xyz/',
+      url: 'https://apechain.calderaexplorer.xyz/',
     },
     nativeToken: {
       symbol: 'APE',
@@ -734,7 +734,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.APECHAIN_TESTNET}.webp`,
     blockExplorer: {
       name: 'APE Chain Explorer',
-      rootUrl: 'https://curtis.explorer.caldera.xyz/',
+      url: 'https://curtis.explorer.caldera.xyz/',
     },
     nativeToken: {
       symbol: 'APE',
@@ -751,7 +751,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST}.webp`,
     blockExplorer: {
       name: 'Blast Explorer',
-      rootUrl: 'https://blastscan.io/',
+      url: 'https://blastscan.io/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -768,7 +768,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BLAST_SEPOLIA}.webp`,
     blockExplorer: {
       name: 'Blast Sepolia Explorer',
-      rootUrl: 'https://sepolia.blastexplorer.io/',
+      url: 'https://sepolia.blastexplorer.io/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -785,7 +785,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS}.webp`,
     blockExplorer: {
       name: 'Telos Explorer',
-      rootUrl: 'https://explorer.telos.net/network/',
+      url: 'https://explorer.telos.net/network/',
     },
     nativeToken: {
       symbol: 'TLOS',
@@ -802,7 +802,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TELOS_TESTNET}.webp`,
     blockExplorer: {
       name: 'Telos Testnet Explorer',
-      rootUrl: 'https://explorer-test.telos.net/network',
+      url: 'https://explorer-test.telos.net/network',
     },
     nativeToken: {
       symbol: 'TLOS',
@@ -819,7 +819,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.BORNE_TESTNET}.webp`,
     blockExplorer: {
       name: 'Borne Testnet Explorer',
-      rootUrl: 'https://subnets-test.avax.network/bornegfdn',
+      url: 'https://subnets-test.avax.network/bornegfdn',
     },
     nativeToken: {
       symbol: 'BORNE',
@@ -837,7 +837,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA}.webp`,
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Explorer',
-      rootUrl: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
+      url: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com/',
     },
     nativeToken: {
       symbol: 'sFUEL',
@@ -854,7 +854,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SKALE_NEBULA_TESTNET}.webp`,
     blockExplorer: {
       name: 'SKALE Nebula Gaming Hub Testnet Explorer',
-      rootUrl: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
+      url: 'https://lanky-ill-funny-testnet.explorer.testnet.skalenodes.com/',
     },
     nativeToken: {
       symbol: 'sFUEL',
@@ -871,7 +871,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM}.webp`,
     blockExplorer: {
       name: 'Soneium Explorer',
-      rootUrl: 'https://soneium.blockscout.com/',
+      url: 'https://soneium.blockscout.com/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -888,7 +888,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SONEIUM_MINATO}.webp`,
     blockExplorer: {
       name: 'Soneium Minato Explorer',
-      rootUrl: 'https://explorer-testnet.soneium.org/',
+      url: 'https://explorer-testnet.soneium.org/',
     },
     nativeToken: {
       symbol: 'ETH',
@@ -905,7 +905,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.TOY_TESTNET}.webp`,
     blockExplorer: {
       name: 'TOY Testnet Explorer',
-      rootUrl: 'https://toy-chain-testnet.explorer.caldera.xyz/',
+      url: 'https://toy-chain-testnet.explorer.caldera.xyz/',
     },
     nativeToken: {
       symbol: 'TOY',
@@ -922,7 +922,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM}.webp`,
     blockExplorer: {
       name: 'Immutable zkEVM Explorer',
-      rootUrl: 'https://explorer.immutable.com/',
+      url: 'https://explorer.immutable.com/',
     },
     nativeToken: {
       symbol: 'IMX',
@@ -939,7 +939,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.IMMUTABLE_ZKEVM_TESTNET}.webp`,
     blockExplorer: {
       name: 'Immutable zkEVM Testnet Explorer',
-      rootUrl: 'https://explorer.testnet.immutable.com/',
+      url: 'https://explorer.testnet.immutable.com/',
     },
     nativeToken: {
       symbol: 'IMX',
@@ -956,7 +956,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK}.webp`,
     blockExplorer: {
       name: 'The Root Network Explorer',
-      rootUrl: 'https://rootscan.io/',
+      url: 'https://rootscan.io/',
     },
     nativeToken: {
       symbol: 'XRP',
@@ -973,7 +973,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ROOT_NETWORK_PORCINI}.webp`,
     blockExplorer: {
       name: 'The Root Network Porcini Testnet Explorer',
-      rootUrl: 'https://porcini.rootscan.io/',
+      url: 'https://porcini.rootscan.io/',
     },
     nativeToken: {
       symbol: 'XRP',
@@ -1014,7 +1014,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS}.webp`,
     blockExplorer: {
       name: 'LAOS Explorer',
-      rootUrl: 'https://blockscout.laos.laosfoundation.io/',
+      url: 'https://blockscout.laos.laosfoundation.io/',
     },
     nativeToken: {
       symbol: 'LAOS',
@@ -1031,7 +1031,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.LAOS_SIGMA_TESTNET}.webp`,
     blockExplorer: {
       name: 'LAOS Sigma Testnet Explorer',
-      rootUrl: 'https://sigma.explorer.laosnetwork.io/',
+      url: 'https://sigma.explorer.laosnetwork.io/',
     },
     nativeToken: {
       symbol: 'SIGMA',
@@ -1048,7 +1048,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBEAM}.webp`,
     blockExplorer: {
       name: 'Moonscan',
-      rootUrl: 'https://moonscan.io/',
+      url: 'https://moonscan.io/',
     },
     nativeToken: {
       symbol: 'GLMR',
@@ -1065,7 +1065,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MOONBASE_ALPHA}.webp`,
     blockExplorer: {
       name: 'Moonscan (Moonbase Alpha)',
-      rootUrl: 'https://moonbase.moonscan.io/',
+      url: 'https://moonbase.moonscan.io/',
     },
     nativeToken: {
       symbol: 'GLMR',
@@ -1082,7 +1082,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK}.webp`,
     blockExplorer: {
       name: 'Etherlink Explorer',
-      rootUrl: 'https://explorer.etherlink.com/',
+      url: 'https://explorer.etherlink.com/',
     },
     nativeToken: {
       symbol: 'XTZ',
@@ -1099,7 +1099,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.ETHERLINK_TESTNET}.webp`,
     blockExplorer: {
       name: 'Etherlink Testnet Explorer',
-      rootUrl: 'https://testnet.explorer.etherlink.com/',
+      url: 'https://testnet.explorer.etherlink.com/',
     },
     nativeToken: {
       symbol: 'XTZ',
@@ -1116,7 +1116,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.MONAD_TESTNET}.webp`,
     blockExplorer: {
       name: 'Monad Testnet Explorer',
-      rootUrl: 'https://testnet.monadexplorer.com/',
+      url: 'https://testnet.monadexplorer.com/',
     },
     nativeToken: {
       symbol: 'MON',
@@ -1134,7 +1134,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA_TESTNET}.webp`,
     blockExplorer: {
       name: 'Somnia Testnet Explorer',
-      rootUrl: 'https://somnia-testnet.socialscan.io/',
+      url: 'https://somnia-testnet.socialscan.io/',
     },
     nativeToken: {
       symbol: 'STT',
@@ -1152,7 +1152,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.INCENTIV_TESTNET}.webp`,
     blockExplorer: {
       name: 'Incentiv Testnet Explorer',
-      rootUrl: 'https://explorer.testnet.incentiv.net/',
+      url: 'https://explorer.testnet.incentiv.net/',
     },
     nativeToken: {
       symbol: 'CENT',
@@ -1170,7 +1170,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI}.webp`,
     blockExplorer: {
       name: 'SEI Explorer',
-      rootUrl: 'https://seitrace.com/?chain=pacific-1',
+      url: 'https://seitrace.com/?chain=pacific-1',
     },
     nativeToken: {
       symbol: 'SEI',
@@ -1188,7 +1188,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SEI_TESTNET}.webp`,
     blockExplorer: {
       name: 'Sei Testnet Explorer',
-      rootUrl: 'https://seitrace.com/?chain=atlantic-2',
+      url: 'https://seitrace.com/?chain=atlantic-2',
     },
     nativeToken: {
       symbol: 'SEI',
@@ -1206,7 +1206,7 @@ export const ALL: Network[] = [
     logoURI: `https://assets.sequence.info/images/networks/medium/${ChainId.SOMNIA}.webp`,
     blockExplorer: {
       name: 'Somnia Explorer',
-      rootUrl: 'https://mainnet.somnia.w3us.site/',
+      url: 'https://mainnet.somnia.w3us.site/',
     },
     nativeToken: {
       symbol: 'SOMI',

--- a/packages/wallet/primitives/src/payload.ts
+++ b/packages/wallet/primitives/src/payload.ts
@@ -1,7 +1,7 @@
 import { AbiFunction, AbiParameters, Address, Bytes, Hash, Hex } from 'ox'
 import { getSignPayload } from 'ox/TypedData'
 import { EXECUTE_USER_OP, RECOVER_SAPIENT_SIGNATURE } from './constants.js'
-import { Attestation } from './index.js'
+import { Attestation, Network } from './index.js'
 import { minBytesFor } from './utils.js'
 import { UserOperation } from 'ox/erc4337'
 

--- a/packages/wallet/primitives/src/signature.ts
+++ b/packages/wallet/primitives/src/signature.ts
@@ -22,7 +22,7 @@ import { RECOVER_SAPIENT_SIGNATURE, RECOVER_SAPIENT_SIGNATURE_COMPACT, IS_VALID_
 import { wrap, decode } from './erc-6492.js'
 import { fromConfigUpdate, hash, Parented } from './payload.js'
 import { minBytesFor, packRSY, unpackRSY } from './utils.js'
-import { Constants } from './index.js'
+import { Constants, Network } from './index.js'
 
 export const FLAG_SIGNATURE_HASH = 0
 export const FLAG_ADDRESS = 1

--- a/packages/wallet/wdk/package.json
+++ b/packages/wallet/wdk/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },
   "exports": {

--- a/packages/wallet/wdk/src/sequence/manager.ts
+++ b/packages/wallet/wdk/src/sequence/manager.ts
@@ -100,7 +100,7 @@ export const ManagerOptionsDefaults = {
   dbPruningInterval: 1000 * 60 * 60 * 24, // 24 hours
 
   stateProvider: new State.Sequence.Provider(),
-  networks: Network.All,
+  networks: Network.ALL,
   relayers: () => [Relayer.Standard.LocalRelayer.createFromWindow(window)].filter((r) => r !== undefined),
   bundlers: [],
 

--- a/packages/wallet/wdk/src/sequence/messages.ts
+++ b/packages/wallet/wdk/src/sequence/messages.ts
@@ -1,6 +1,6 @@
 import { Envelope, Wallet } from '@0xsequence/wallet-core'
-import { Payload } from '@0xsequence/wallet-primitives'
-import { Address, Bytes, Hex, Provider, RpcTransport } from 'ox'
+import { Network, Payload } from '@0xsequence/wallet-primitives'
+import { Address, Hex, Provider, RpcTransport } from 'ox'
 import { v7 as uuidv7 } from 'uuid'
 import { Shared } from './manager.js'
 import { Message, MessageRequest, MessageRequested, MessageSigned } from './types/message-request.js'
@@ -195,7 +195,7 @@ export class Messages implements MessagesInterface {
       if (!network) {
         throw new Error(`Network not found for ${message.envelope.chainId}`)
       }
-      const transport = RpcTransport.fromHttp(network.rpc)
+      const transport = RpcTransport.fromHttp(Network.getRpcUrl(network))
       provider = Provider.from(transport)
     }
 

--- a/packages/wallet/wdk/src/sequence/messages.ts
+++ b/packages/wallet/wdk/src/sequence/messages.ts
@@ -1,5 +1,5 @@
 import { Envelope, Wallet } from '@0xsequence/wallet-core'
-import { Network, Payload } from '@0xsequence/wallet-primitives'
+import { Payload } from '@0xsequence/wallet-primitives'
 import { Address, Hex, Provider, RpcTransport } from 'ox'
 import { v7 as uuidv7 } from 'uuid'
 import { Shared } from './manager.js'
@@ -195,7 +195,7 @@ export class Messages implements MessagesInterface {
       if (!network) {
         throw new Error(`Network not found for ${message.envelope.chainId}`)
       }
-      const transport = RpcTransport.fromHttp(Network.getRpcUrl(network))
+      const transport = RpcTransport.fromHttp(network.rpc)
       provider = Provider.from(transport)
     }
 

--- a/packages/wallet/wdk/src/sequence/messages.ts
+++ b/packages/wallet/wdk/src/sequence/messages.ts
@@ -195,7 +195,7 @@ export class Messages implements MessagesInterface {
       if (!network) {
         throw new Error(`Network not found for ${message.envelope.chainId}`)
       }
-      const transport = RpcTransport.fromHttp(network.rpc)
+      const transport = RpcTransport.fromHttp(network.rpcUrl)
       provider = Provider.from(transport)
     }
 

--- a/packages/wallet/wdk/src/sequence/recovery.ts
+++ b/packages/wallet/wdk/src/sequence/recovery.ts
@@ -1,4 +1,4 @@
-import { Config, Constants, Extensions, GenericTree, Payload } from '@0xsequence/wallet-primitives'
+import { Config, Constants, Extensions, GenericTree, Network, Payload } from '@0xsequence/wallet-primitives'
 import { Shared } from './manager.js'
 import { Address, Hex, Provider, RpcTransport } from 'ox'
 import { Kinds, RecoverySigner } from './types/signer.js'
@@ -468,7 +468,7 @@ export class Recovery implements RecoveryInterface {
     // Create providers for each network
     const providers = this.shared.sequence.networks.map((network) => ({
       chainId: network.chainId,
-      provider: Provider.from(RpcTransport.fromHttp(network.rpc)),
+      provider: Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network))),
     }))
 
     const seenInThisRun = new Set<string>()

--- a/packages/wallet/wdk/src/sequence/recovery.ts
+++ b/packages/wallet/wdk/src/sequence/recovery.ts
@@ -1,11 +1,11 @@
-import { Config, Constants, Extensions, GenericTree, Network, Payload } from '@0xsequence/wallet-primitives'
-import { Shared } from './manager.js'
-import { Address, Hex, Provider, RpcTransport } from 'ox'
-import { Kinds, RecoverySigner } from './types/signer.js'
 import { Envelope } from '@0xsequence/wallet-core'
-import { QueuedRecoveryPayload } from './types/recovery.js'
-import { Actions } from './types/index.js'
+import { Config, Constants, Extensions, GenericTree, Payload } from '@0xsequence/wallet-primitives'
+import { Address, Hex, Provider, RpcTransport } from 'ox'
 import { MnemonicHandler } from './handlers/mnemonic.js'
+import { Shared } from './manager.js'
+import { Actions } from './types/index.js'
+import { QueuedRecoveryPayload } from './types/recovery.js'
+import { Kinds, RecoverySigner } from './types/signer.js'
 
 export interface RecoveryInterface {
   /**
@@ -468,7 +468,7 @@ export class Recovery implements RecoveryInterface {
     // Create providers for each network
     const providers = this.shared.sequence.networks.map((network) => ({
       chainId: network.chainId,
-      provider: Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network))),
+      provider: Provider.from(RpcTransport.fromHttp(network.rpc)),
     }))
 
     const seenInThisRun = new Set<string>()

--- a/packages/wallet/wdk/src/sequence/recovery.ts
+++ b/packages/wallet/wdk/src/sequence/recovery.ts
@@ -468,7 +468,7 @@ export class Recovery implements RecoveryInterface {
     // Create providers for each network
     const providers = this.shared.sequence.networks.map((network) => ({
       chainId: network.chainId,
-      provider: Provider.from(RpcTransport.fromHttp(network.rpc)),
+      provider: Provider.from(RpcTransport.fromHttp(network.rpcUrl)),
     }))
 
     const seenInThisRun = new Set<string>()

--- a/packages/wallet/wdk/src/sequence/transactions.ts
+++ b/packages/wallet/wdk/src/sequence/transactions.ts
@@ -1,4 +1,4 @@
-import { Constants, Payload } from '@0xsequence/wallet-primitives'
+import { Constants, Network, Payload } from '@0xsequence/wallet-primitives'
 import { Envelope, Relayer, Wallet } from '@0xsequence/wallet-core'
 import { Abi, AbiFunction, Address, Hex, Provider, RpcTransport } from 'ox'
 import { v7 as uuidv7 } from 'uuid'
@@ -258,7 +258,7 @@ export class Transactions implements TransactionsInterface {
       throw new Error(`Network not found for ${chainId}`)
     }
 
-    const transport = RpcTransport.fromHttp(network.rpc)
+    const transport = RpcTransport.fromHttp(Network.getRpcUrl(network))
     const provider = Provider.from(transport)
     const wallet = new Wallet(from, { stateProvider: this.shared.sequence.stateProvider })
 
@@ -327,11 +327,11 @@ export class Transactions implements TransactionsInterface {
     }
 
     const wallet = new Wallet(tx.wallet, { stateProvider: this.shared.sequence.stateProvider })
-    const provider = Provider.from(
-      RpcTransport.fromHttp(
-        this.shared.sequence.networks.find((network) => network.chainId === tx.envelope.chainId)!.rpc,
-      ),
-    )
+    const network = this.shared.sequence.networks.find((network) => network.chainId === tx.envelope.chainId)
+    if (!network) {
+      throw new Error(`Network not found for ${tx.envelope.chainId}`)
+    }
+    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
 
     // Get relayer and relayer options
     const [allRelayerOptions, allBundlerOptions] = await Promise.all([
@@ -523,7 +523,7 @@ export class Transactions implements TransactionsInterface {
       throw new Error(`Network not found for ${tx.envelope.chainId}`)
     }
 
-    const transport = RpcTransport.fromHttp(network.rpc)
+    const transport = RpcTransport.fromHttp(Network.getRpcUrl(network))
     const provider = Provider.from(transport)
 
     const wallet = new Wallet(tx.wallet, { stateProvider: this.shared.sequence.stateProvider })

--- a/packages/wallet/wdk/src/sequence/transactions.ts
+++ b/packages/wallet/wdk/src/sequence/transactions.ts
@@ -258,7 +258,7 @@ export class Transactions implements TransactionsInterface {
       throw new Error(`Network not found for ${chainId}`)
     }
 
-    const transport = RpcTransport.fromHttp(network.rpc)
+    const transport = RpcTransport.fromHttp(network.rpcUrl)
     const provider = Provider.from(transport)
     const wallet = new Wallet(from, { stateProvider: this.shared.sequence.stateProvider })
 
@@ -331,7 +331,7 @@ export class Transactions implements TransactionsInterface {
     if (!network) {
       throw new Error(`Network not found for ${tx.envelope.chainId}`)
     }
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpcUrl))
 
     // Get relayer and relayer options
     const [allRelayerOptions, allBundlerOptions] = await Promise.all([
@@ -523,7 +523,7 @@ export class Transactions implements TransactionsInterface {
       throw new Error(`Network not found for ${tx.envelope.chainId}`)
     }
 
-    const transport = RpcTransport.fromHttp(network.rpc)
+    const transport = RpcTransport.fromHttp(network.rpcUrl)
     const provider = Provider.from(transport)
 
     const wallet = new Wallet(tx.wallet, { stateProvider: this.shared.sequence.stateProvider })

--- a/packages/wallet/wdk/src/sequence/transactions.ts
+++ b/packages/wallet/wdk/src/sequence/transactions.ts
@@ -1,5 +1,5 @@
-import { Constants, Network, Payload } from '@0xsequence/wallet-primitives'
 import { Envelope, Relayer, Wallet } from '@0xsequence/wallet-core'
+import { Constants, Payload } from '@0xsequence/wallet-primitives'
 import { Abi, AbiFunction, Address, Hex, Provider, RpcTransport } from 'ox'
 import { v7 as uuidv7 } from 'uuid'
 import { Shared } from './manager.js'
@@ -258,7 +258,7 @@ export class Transactions implements TransactionsInterface {
       throw new Error(`Network not found for ${chainId}`)
     }
 
-    const transport = RpcTransport.fromHttp(Network.getRpcUrl(network))
+    const transport = RpcTransport.fromHttp(network.rpc)
     const provider = Provider.from(transport)
     const wallet = new Wallet(from, { stateProvider: this.shared.sequence.stateProvider })
 
@@ -331,7 +331,7 @@ export class Transactions implements TransactionsInterface {
     if (!network) {
       throw new Error(`Network not found for ${tx.envelope.chainId}`)
     }
-    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
 
     // Get relayer and relayer options
     const [allRelayerOptions, allBundlerOptions] = await Promise.all([
@@ -523,7 +523,7 @@ export class Transactions implements TransactionsInterface {
       throw new Error(`Network not found for ${tx.envelope.chainId}`)
     }
 
-    const transport = RpcTransport.fromHttp(Network.getRpcUrl(network))
+    const transport = RpcTransport.fromHttp(network.rpc)
     const provider = Provider.from(transport)
 
     const wallet = new Wallet(tx.wallet, { stateProvider: this.shared.sequence.stateProvider })

--- a/packages/wallet/wdk/src/sequence/wallets.ts
+++ b/packages/wallet/wdk/src/sequence/wallets.ts
@@ -1114,7 +1114,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpcUrl))
     return wallet.getNonce(provider, space)
   }
 
@@ -1129,7 +1129,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpcUrl))
     const status = await walletObject.getStatus(provider)
 
     const onchainConfiguration = await this.shared.sequence.stateProvider.getConfiguration(status.onChainImageHash)
@@ -1174,7 +1174,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpcUrl))
     const onchainStatus = await walletObject.getStatus(provider)
     return onchainStatus.imageHash === onchainStatus.onChainImageHash
   }

--- a/packages/wallet/wdk/src/sequence/wallets.ts
+++ b/packages/wallet/wdk/src/sequence/wallets.ts
@@ -1,5 +1,5 @@
 import { Wallet as CoreWallet, Envelope, Signers, State } from '@0xsequence/wallet-core'
-import { Config, Constants, GenericTree, Payload, SessionConfig } from '@0xsequence/wallet-primitives'
+import { Config, Constants, GenericTree, Network, Payload, SessionConfig } from '@0xsequence/wallet-primitives'
 import { Address, Hex, Provider, RpcTransport } from 'ox'
 import { AuthCommitment } from '../dbs/auth-commitments.js'
 import { MnemonicHandler } from './handlers/mnemonic.js'
@@ -1114,7 +1114,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
     return wallet.getNonce(provider, space)
   }
 
@@ -1129,7 +1129,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
     const status = await walletObject.getStatus(provider)
 
     const onchainConfiguration = await this.shared.sequence.stateProvider.getConfiguration(status.onChainImageHash)
@@ -1174,7 +1174,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
+    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
     const onchainStatus = await walletObject.getStatus(provider)
     return onchainStatus.imageHash === onchainStatus.onChainImageHash
   }

--- a/packages/wallet/wdk/src/sequence/wallets.ts
+++ b/packages/wallet/wdk/src/sequence/wallets.ts
@@ -1,15 +1,15 @@
 import { Wallet as CoreWallet, Envelope, Signers, State } from '@0xsequence/wallet-core'
-import { Config, Constants, GenericTree, Network, Payload, SessionConfig } from '@0xsequence/wallet-primitives'
+import { Config, Constants, GenericTree, Payload, SessionConfig } from '@0xsequence/wallet-primitives'
 import { Address, Hex, Provider, RpcTransport } from 'ox'
 import { AuthCommitment } from '../dbs/auth-commitments.js'
+import { AuthCodeHandler } from './handlers/authcode.js'
 import { MnemonicHandler } from './handlers/mnemonic.js'
 import { OtpHandler } from './handlers/otp.js'
 import { ManagerOptionsDefaults, Shared } from './manager.js'
+import { Device } from './types/device.js'
 import { Action } from './types/index.js'
 import { Kinds, SignerWithKind, WitnessExtraSignerKind } from './types/signer.js'
 import { Wallet, WalletSelectionUiHandler } from './types/wallet.js'
-import { AuthCodeHandler } from './handlers/authcode.js'
-import { Device } from './types/device.js'
 
 export type StartSignUpWithRedirectArgs = {
   kind: 'google-pkce' | 'apple'
@@ -1114,7 +1114,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
     return wallet.getNonce(provider, space)
   }
 
@@ -1129,7 +1129,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
     const status = await walletObject.getStatus(provider)
 
     const onchainConfiguration = await this.shared.sequence.stateProvider.getConfiguration(status.onChainImageHash)
@@ -1174,7 +1174,7 @@ export class Wallets implements WalletsInterface {
       throw new Error('network-not-found')
     }
 
-    const provider = Provider.from(RpcTransport.fromHttp(Network.getRpcUrl(network)))
+    const provider = Provider.from(RpcTransport.fromHttp(network.rpc))
     const onchainStatus = await walletObject.getStatus(provider)
     return onchainStatus.imageHash === onchainStatus.onChainImageHash
   }

--- a/packages/wallet/wdk/test/constants.ts
+++ b/packages/wallet/wdk/test/constants.ts
@@ -4,6 +4,7 @@ import { Manager, ManagerOptions, ManagerOptionsDefaults } from '../src/sequence
 import { mockEthereum } from './setup'
 import { Signers as CoreSigners, State, Relayer } from '@0xsequence/wallet-core'
 import * as Db from '../src/dbs'
+import { Network } from '@0xsequence/wallet-primitives'
 
 const envFile = process.env.CI ? '.env.test' : '.env.test.local'
 dotenvConfig({ path: envFile })
@@ -37,10 +38,11 @@ export function newManager(options?: ManagerOptions, noEthereumMock?: boolean, t
     networks: [
       {
         name: 'Arbitrum (local fork)',
-        rpc: LOCAL_RPC_URL,
+        type: Network.NetworkType.MAINNET,
+        rpcUrl: LOCAL_RPC_URL,
         chainId: 42161n,
-        explorer: 'https://arbiscan.io/',
-        nativeCurrency: {
+        blockExplorer: { url: 'https://arbiscan.io/' },
+        nativeToken: {
           name: 'Ether',
           symbol: 'ETH',
           decimals: 18,
@@ -109,10 +111,11 @@ export function newRemoteManager(
     networks: [
       {
         name: 'Remote Test Network',
-        rpc: remoteManagerOptions.network.rpcUrl,
+        type: Network.NetworkType.MAINNET,
+        rpcUrl: remoteManagerOptions.network.rpcUrl,
         chainId: remoteManagerOptions.network.chainId,
-        explorer: 'https://undefined/',
-        nativeCurrency: {
+        blockExplorer: { url: 'https://undefined/' },
+        nativeToken: {
           name: 'Ether',
           symbol: 'ETH',
           decimals: 18,

--- a/packages/wallet/wdk/test/constants.ts
+++ b/packages/wallet/wdk/test/constants.ts
@@ -42,7 +42,7 @@ export function newManager(options?: ManagerOptions, noEthereumMock?: boolean, t
         rpcUrl: LOCAL_RPC_URL,
         chainId: 42161n,
         blockExplorer: { url: 'https://arbiscan.io/' },
-        nativeToken: {
+        nativeCurrency: {
           name: 'Ether',
           symbol: 'ETH',
           decimals: 18,
@@ -115,7 +115,7 @@ export function newRemoteManager(
         rpcUrl: remoteManagerOptions.network.rpcUrl,
         chainId: remoteManagerOptions.network.chainId,
         blockExplorer: { url: 'https://undefined/' },
-        nativeToken: {
+        nativeCurrency: {
           name: 'Ether',
           symbol: 'ETH',
           decimals: 18,

--- a/packages/wallet/wdk/test/identity-auth-dbs.test.ts
+++ b/packages/wallet/wdk/test/identity-auth-dbs.test.ts
@@ -5,6 +5,7 @@ import { IdentityInstrument } from '@0xsequence/identity-instrument'
 import * as Db from '../src/dbs'
 import { LOCAL_RPC_URL } from './constants'
 import { State } from '@0xsequence/wallet-core'
+import { Network } from '@0xsequence/wallet-primitives'
 
 describe('Identity Authentication Databases', () => {
   let manager: Manager | undefined
@@ -328,10 +329,11 @@ describe('Identity Authentication Databases', () => {
         networks: [
           {
             name: 'Test Network',
-            rpc: LOCAL_RPC_URL,
+            type: Network.NetworkType.MAINNET,
+            rpcUrl: LOCAL_RPC_URL,
             chainId: 42161n,
-            explorer: 'https://arbiscan.io',
-            nativeCurrency: {
+            blockExplorer: { url: 'https://arbiscan.io' },
+            nativeToken: {
               name: 'Ether',
               symbol: 'ETH',
               decimals: 18,
@@ -362,10 +364,11 @@ describe('Identity Authentication Databases', () => {
         networks: [
           {
             name: 'Test Network',
-            rpc: LOCAL_RPC_URL,
+            type: Network.NetworkType.MAINNET,
+            rpcUrl: LOCAL_RPC_URL,
             chainId: 42161n,
-            explorer: 'https://arbiscan.io',
-            nativeCurrency: {
+            blockExplorer: { url: 'https://arbiscan.io' },
+            nativeToken: {
               name: 'Ether',
               symbol: 'ETH',
               decimals: 18,
@@ -395,10 +398,11 @@ describe('Identity Authentication Databases', () => {
         networks: [
           {
             name: 'Test Network',
-            rpc: LOCAL_RPC_URL,
+            type: Network.NetworkType.MAINNET,
+            rpcUrl: LOCAL_RPC_URL,
             chainId: 42161n,
-            explorer: 'https://arbiscan.io',
-            nativeCurrency: {
+            blockExplorer: { url: 'https://arbiscan.io' },
+            nativeToken: {
               name: 'Ether',
               symbol: 'ETH',
               decimals: 18,

--- a/packages/wallet/wdk/test/identity-auth-dbs.test.ts
+++ b/packages/wallet/wdk/test/identity-auth-dbs.test.ts
@@ -333,7 +333,7 @@ describe('Identity Authentication Databases', () => {
             rpcUrl: LOCAL_RPC_URL,
             chainId: 42161n,
             blockExplorer: { url: 'https://arbiscan.io' },
-            nativeToken: {
+            nativeCurrency: {
               name: 'Ether',
               symbol: 'ETH',
               decimals: 18,
@@ -368,7 +368,7 @@ describe('Identity Authentication Databases', () => {
             rpcUrl: LOCAL_RPC_URL,
             chainId: 42161n,
             blockExplorer: { url: 'https://arbiscan.io' },
-            nativeToken: {
+            nativeCurrency: {
               name: 'Ether',
               symbol: 'ETH',
               decimals: 18,
@@ -402,7 +402,7 @@ describe('Identity Authentication Databases', () => {
             rpcUrl: LOCAL_RPC_URL,
             chainId: 42161n,
             blockExplorer: { url: 'https://arbiscan.io' },
-            nativeToken: {
+            nativeCurrency: {
               name: 'Ether',
               symbol: 'ETH',
               decimals: 18,

--- a/packages/wallet/wdk/test/sessions.test.ts
+++ b/packages/wallet/wdk/test/sessions.test.ts
@@ -1,7 +1,7 @@
 import { AbiFunction, Address, Bytes, Hex, Mnemonic, Provider, RpcTransport } from 'ox'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Signers as CoreSigners, Wallet as CoreWallet, Envelope, Relayer, State } from '../../core/src/index.js'
-import { Attestation, Constants, Extensions, Payload, Permission } from '../../primitives/src/index.js'
+import { Attestation, Constants, Extensions, Network, Payload, Permission } from '../../primitives/src/index.js'
 import { Sequence } from '../src/index.js'
 import { CAN_RUN_LIVE, EMITTER_ABI, EMITTER_ADDRESS, PRIVATE_KEY, RPC_URL } from './constants'
 
@@ -81,10 +81,11 @@ describe('Sessions (via Manager)', () => {
       networks: [
         {
           chainId,
-          rpc: RPC_URL ?? 'XXX',
+          type: Network.NetworkType.MAINNET,
+          rpcUrl: RPC_URL ?? 'XXX',
           name: 'XXX',
-          explorer: 'XXX',
-          nativeCurrency: {
+          blockExplorer: { url: 'XXX' },
+          nativeToken: {
             name: 'Ether',
             symbol: 'ETH',
             decimals: 18,

--- a/packages/wallet/wdk/test/sessions.test.ts
+++ b/packages/wallet/wdk/test/sessions.test.ts
@@ -85,7 +85,7 @@ describe('Sessions (via Manager)', () => {
           rpcUrl: RPC_URL ?? 'XXX',
           name: 'XXX',
           blockExplorer: { url: 'XXX' },
-          nativeToken: {
+          nativeCurrency: {
             name: 'Ether',
             symbol: 'ETH',
             decimals: 18,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,6 @@ importers:
 
   packages/wallet/dapp-client:
     dependencies:
-      '@0xsequence/network':
-        specifier: ^2.3.23
-        version: 2.3.23(ethers@6.15.0)
       '@0xsequence/wallet-core':
         specifier: workspace:^
         version: link:../core
@@ -475,37 +472,8 @@ importers:
 
 packages:
 
-  '@0xsequence/abi@2.3.23':
-    resolution: {integrity: sha512-N5bVeCAKaHQ6+M8lKVlPfNcbmp3s10BBLNiqM1XzIGuzl5BKxBj0S9h4Vb7cd//3ALxgqYjwRvxi760wIDnyCA==}
-
-  '@0xsequence/core@2.3.23':
-    resolution: {integrity: sha512-0y6TidFNJFYQF2yqGXScWYZTuGy651qwBH+9fQKRjzGSa0eXpe3zkccqiNuTtOXpR5QHBVGJ2U69SbK3ajzKEA==}
-    peerDependencies:
-      ethers: '>=6'
-
-  '@0xsequence/indexer@2.3.23':
-    resolution: {integrity: sha512-wYOPGDucEB+h4qujS4TqZ25pehdhByDLxsMLVDA4VFH0AFZlAt7Pq9hQznbQNnLwRPm+DHE/QB//qcPRvCiEFQ==}
-
-  '@0xsequence/network@2.3.23':
-    resolution: {integrity: sha512-7p0iTcFpkzQvh5saainlD95MZmUlMkZ+BiGzu/qT1gXYhUHEm5soq9wcII1JztgHaXgb+naS6PVTKB+z9eijYg==}
-    peerDependencies:
-      ethers: '>=6'
-
-  '@0xsequence/relayer@2.3.23':
-    resolution: {integrity: sha512-6b+ZjS2PWBM46awtPunfudCuvNUok7AUuuQiP5cukgTV949t5heoL9sY+FnJCVNEGayuqyghqMP4pyBmGgpo1w==}
-    peerDependencies:
-      ethers: '>=6'
-
   '@0xsequence/tee-verifier@0.1.2':
     resolution: {integrity: sha512-7sKr8/T4newknx6LAukjlRI3siGiGhBnZohz2Z3jX0zb0EBQdKUq0L//A7CPSckHFPxTg/QvQU2v8e9x9GfkDw==}
-
-  '@0xsequence/utils@2.3.23':
-    resolution: {integrity: sha512-Ak4/QuginegFw/tnpyb9u0aw8fA6XHdLH9JjM0jsRrPyM5v6KqKFQoCrCssQfXeBxuHaWs+ABxf5gL9TKpDBng==}
-    peerDependencies:
-      ethers: '>=6'
-
-  '@adraffy/ens-normalize@1.10.1':
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
@@ -1037,9 +1005,6 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@noble/curves@1.2.0':
-    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
-
   '@noble/curves@1.9.2':
     resolution: {integrity: sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==}
     engines: {node: ^14.21.3 || >=16}
@@ -1047,10 +1012,6 @@ packages:
   '@noble/curves@1.9.4':
     resolution: {integrity: sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==}
     engines: {node: ^14.21.3 || >=16}
-
-  '@noble/hashes@1.3.2':
-    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
-    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1238,9 +1199,6 @@ packages:
   '@types/node@22.16.5':
     resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
 
-  '@types/node@22.7.5':
-    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
-
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1389,9 +1347,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  aes-js@4.0.0-beta.5:
-    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1919,10 +1874,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  ethers@6.15.0:
-    resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
-    engines: {node: '>=14.0.0'}
-
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -2424,9 +2375,6 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
-
-  js-base64@3.7.7:
-    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3369,9 +3317,6 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3461,9 +3406,6 @@ packages:
 
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
-
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3642,18 +3584,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
     engines: {node: '>=10.0.0'}
@@ -3688,42 +3618,10 @@ packages:
 
 snapshots:
 
-  '@0xsequence/abi@2.3.23': {}
-
-  '@0xsequence/core@2.3.23(ethers@6.15.0)':
-    dependencies:
-      '@0xsequence/abi': 2.3.23
-      '@0xsequence/utils': 2.3.23(ethers@6.15.0)
-      ethers: 6.15.0
-
-  '@0xsequence/indexer@2.3.23': {}
-
-  '@0xsequence/network@2.3.23(ethers@6.15.0)':
-    dependencies:
-      '@0xsequence/core': 2.3.23(ethers@6.15.0)
-      '@0xsequence/indexer': 2.3.23
-      '@0xsequence/relayer': 2.3.23(ethers@6.15.0)
-      '@0xsequence/utils': 2.3.23(ethers@6.15.0)
-      ethers: 6.15.0
-
-  '@0xsequence/relayer@2.3.23(ethers@6.15.0)':
-    dependencies:
-      '@0xsequence/abi': 2.3.23
-      '@0xsequence/core': 2.3.23(ethers@6.15.0)
-      '@0xsequence/utils': 2.3.23(ethers@6.15.0)
-      ethers: 6.15.0
-
   '@0xsequence/tee-verifier@0.1.2':
     dependencies:
       cbor2: 1.12.0
       pkijs: 3.2.5
-
-  '@0xsequence/utils@2.3.23(ethers@6.15.0)':
-    dependencies:
-      ethers: 6.15.0
-      js-base64: 3.7.7
-
-  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.0': {}
 
@@ -4209,10 +4107,6 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
-  '@noble/curves@1.2.0':
-    dependencies:
-      '@noble/hashes': 1.3.2
-
   '@noble/curves@1.9.2':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -4220,8 +4114,6 @@ snapshots:
   '@noble/curves@1.9.4':
     dependencies:
       '@noble/hashes': 1.8.0
-
-  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -4395,10 +4287,6 @@ snapshots:
   '@types/node@22.16.5':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@22.7.5':
-    dependencies:
-      undici-types: 6.19.8
 
   '@types/prop-types@15.7.15': {}
 
@@ -4599,8 +4487,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  aes-js@4.0.0-beta.5: {}
 
   agent-base@7.1.4: {}
 
@@ -5306,19 +5192,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  ethers@6.15.0:
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   eventemitter3@5.0.1: {}
 
   execa@5.1.1:
@@ -5889,8 +5762,6 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
-
-  js-base64@3.7.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -6932,8 +6803,6 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tslib@2.7.0: {}
-
   tslib@2.8.1: {}
 
   turbo-darwin-64@2.5.5:
@@ -7028,8 +6897,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undefsafe@2.0.5: {}
-
-  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -7233,8 +7100,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  ws@8.17.1: {}
 
   ws@8.18.2: {}
 


### PR DESCRIPTION
* Networks leverages format used by devops, except:
  * `chain_id` is bigint
  * `rpc` added
  * `NetworkType.LOCAL` added
  * Deprecated `testnet` field removed (using type instead)
* Consistent usage of bigint for ChainId in dapp-client
* Removes 0xsequence/network

Note: Keeps deprecated chains and ids as these were available in devops. Should we remove these?