### PR TITLE
Cleanup databases after logout

### DIFF
--- a/packages/wallet/wdk/src/sequence/wallets.ts
+++ b/packages/wallet/wdk/src/sequence/wallets.ts
@@ -1198,6 +1198,7 @@ export class Wallets implements WalletsInterface {
         this.shared.databases.manager.del(wallet),
         this.shared.modules.devices.remove(walletEntry.device),
       ])
+      await this._cleanupWalletData(wallet)
       return undefined as any
     }
 
@@ -1251,6 +1252,31 @@ export class Wallets implements WalletsInterface {
     await this.completeConfigurationUpdate(requestId)
     await this.shared.databases.manager.del(request.wallet)
     await this.shared.modules.devices.remove(walletEntry.device)
+    await this._cleanupWalletData(request.wallet)
+  }
+
+  private async _cleanupWalletData(wallet: Address.Address): Promise<void> {
+    const [sigs, txns, msgs, recovery] = await Promise.all([
+      this.shared.databases.signatures.list(),
+      this.shared.databases.transactions.list(),
+      this.shared.databases.messages.list(),
+      this.shared.databases.recovery.list(),
+    ])
+
+    await Promise.all([
+      ...sigs.filter((s) => Address.isEqual(s.wallet, wallet)).map((s) => this.shared.databases.signatures.del(s.id)),
+      ...txns.filter((t) => Address.isEqual(t.wallet, wallet)).map((t) => this.shared.databases.transactions.del(t.id)),
+      ...msgs.filter((m) => Address.isEqual(m.wallet, wallet)).map((m) => this.shared.databases.messages.del(m.id)),
+      ...recovery.filter((r) => Address.isEqual(r.wallet, wallet)).map((r) => this.shared.databases.recovery.del(r.id)),
+    ])
+
+    try {
+      const { loginTopology } = await this.getConfigurationParts(wallet)
+      const loginSigners = Config.getSigners(loginTopology)
+      await Promise.all(loginSigners.signers.map((s) => this.shared.databases.authKeys.delBySigner(s.toString())))
+    } catch {
+      // Don't fail logout if config lookup fails (e.g. offline)
+    }
   }
 
   async getConfiguration(wallet: Address.Address) {


### PR DESCRIPTION
  New `_cleanupWalletData(wallet)` method (lines 1258–1280):                                                                                                                              
  - Fetches all records from signatures, transactions, messages, and recovery databases in parallel                                                                                     
  - Deletes any records belonging to the logged-out wallet address (using Address.isEqual for case-insensitive comparison)                                                              
  - Best-effort cleanup of auth keys: fetches the wallet's loginTopology, extracts its signers, and deletes their corresponding AuthKey entries                                         
  - Auth key cleanup is wrapped in try/catch so an offline state won't block the logout                                                                                                 
                                                                                                                                                                                        
  Soft logout (skipRemoveDevice: true branch, line 1201): calls _cleanupWalletData after the manager entry and device are removed.

  Hard logout (completeLogout, line 1255): calls _cleanupWalletData after the configuration update is committed and the manager entry/device are removed.
