### PR TITLE
Fix fee options stub signature

### DIFF
--- a/packages/wallet/core/src/wallet.ts
+++ b/packages/wallet/core/src/wallet.ts
@@ -25,6 +25,51 @@ export const DefaultWalletOptions: WalletOptions = {
   guest: Constants.DefaultGuestAddress,
 }
 
+const FeeOptionsStubSignature: SequenceSignature.SignatureOfSignerLeaf = {
+  type: 'eth_sign',
+  r: 0x1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn,
+  s: 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n,
+  yParity: 0,
+}
+
+function stubFeeOptionsTopology(topology: Config.Topology): SequenceSignature.RawTopology {
+  if (Array.isArray(topology)) {
+    return [stubFeeOptionsTopology(topology[0]), stubFeeOptionsTopology(topology[1])]
+  }
+
+  if (Config.isSignerLeaf(topology)) {
+    return {
+      type: 'unrecovered-signer',
+      weight: topology.weight,
+      signature: FeeOptionsStubSignature,
+    }
+  }
+
+  if (Config.isNestedLeaf(topology)) {
+    return {
+      type: 'nested',
+      weight: topology.weight,
+      threshold: topology.threshold,
+      tree: stubFeeOptionsTopology(topology.tree),
+    }
+  }
+
+  return topology
+}
+
+function buildFeeOptionsStubSignature(status: WalletStatusWithOnchain): Hex.Hex {
+  return Bytes.toHex(
+    SequenceSignature.encodeSignature({
+      noChainId: status.chainId === 0,
+      configuration: {
+        ...status.configuration,
+        topology: stubFeeOptionsTopology(status.configuration.topology),
+      },
+      suffix: status.pendingUpdates.map(({ signature }) => signature),
+    }),
+  )
+}
+
 export type WalletStatus = {
   address: Address.Address
   isDeployed: boolean
@@ -499,7 +544,7 @@ export class Wallet {
     payload: Payload.Calls,
   ): Promise<{ to: Address.Address; data: Hex.Hex }> {
     const status = await this.getStatus(provider)
-    const signature = '0x0001' as Hex.Hex
+    const signature = buildFeeOptionsStubSignature(status)
 
     const executeData = AbiFunction.encodeData(Constants.EXECUTE, [Bytes.toHex(Payload.encode(payload)), signature])
 

--- a/packages/wallet/core/test/wallet-fee-options.test.ts
+++ b/packages/wallet/core/test/wallet-fee-options.test.ts
@@ -6,6 +6,8 @@ import { State, Wallet } from '../src/index.js'
 
 const SIGNER = '0x1234567890123456789012345678901234567890' as Address.Address
 const TARGET = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address.Address
+const FEE_OPTIONS_STUB_SIGNATURE =
+  '0x040001711fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0' as Hex.Hex
 
 const configuration: Config.Config = {
   threshold: 1n,
@@ -74,7 +76,10 @@ describe('Wallet.buildFeeOptionsTransaction', () => {
     const { wallet, imageHash } = await createWallet()
     const transaction = await wallet.buildFeeOptionsTransaction(providerFor({ deployed: true, imageHash }), payload)
 
-    const expectedData = AbiFunction.encodeData(Constants.EXECUTE, [Bytes.toHex(Payload.encode(payload)), '0x0001'])
+    const expectedData = AbiFunction.encodeData(Constants.EXECUTE, [
+      Bytes.toHex(Payload.encode(payload)),
+      FEE_OPTIONS_STUB_SIGNATURE,
+    ])
 
     expect(Address.isEqual(transaction.to, wallet.address)).toBe(true)
     expect(transaction.data).toBe(expectedData)
@@ -88,7 +93,7 @@ describe('Wallet.buildFeeOptionsTransaction', () => {
 
     const expectedExecuteData = AbiFunction.encodeData(Constants.EXECUTE, [
       Bytes.toHex(Payload.encode(payload)),
-      '0x0001',
+      FEE_OPTIONS_STUB_SIGNATURE,
     ])
 
     expect(Address.isEqual(transaction.to, Constants.DefaultGuestAddress)).toBe(true)


### PR DESCRIPTION
## Summary
- replace the fee-options placeholder signature with a Sequence raw unrecovered signer signature that satisfies the wallet config threshold during simulation
- reuse the wallet's pending update suffixes when building fee-options execute calldata
- update wallet-core fee-options transaction tests for deployed and undeployed wallets

## Verification
- pnpm --filter @0xsequence/wallet-core typecheck
- pnpm --filter @0xsequence/wallet-core exec vitest run test/wallet-fee-options.test.ts
- linked local sequence.js into wallet-webapp-v3 and confirmed the dev-polygon relayer fee-options request succeeds after Vite dependency cache refresh