### PR TITLE
Parse tuple permission signatures

### DIFF
--- a/packages/wallet/core/src/utils/session/permission-builder.ts
+++ b/packages/wallet/core/src/utils/session/permission-builder.ts
@@ -12,7 +12,9 @@ function parseSignature(sig: string): { types: string[]; names: (string | undefi
   const inner = m[1]?.trim() ?? ''
   if (inner === '') return { types: [], names: [] }
 
-  const parts = inner.split(',').map((p) => p.trim())
+  const parts = AbiFunction.from(sig).inputs.map((input) =>
+    input.name ? `${input.type} ${input.name}` : input.type,
+  )
   const types = parts.map((p) => {
     const t = p.split(/\s+/)[0]
     if (!t) throw new Error(`Invalid parameter in signature: "${p}"`)

--- a/packages/wallet/core/test/utils/session/permission-builder.test.ts
+++ b/packages/wallet/core/test/utils/session/permission-builder.test.ts
@@ -509,6 +509,16 @@ describe('PermissionBuilder', () => {
     expect(permission.rules[1].offset).toEqual(4n + 32n) // Second parameter offset
   })
 
+
+  it('should parse tuple parameter signatures', () => {
+    const permission = PermissionBuilder.for(TARGET)
+      .forFunction('function test((address,uint256) pair, bool flag)')
+      .withBoolParam('flag', true)
+      .build()
+
+    expect(permission.rules[1].offset).toEqual(4n + 32n)
+  })
+
   it('should test AbiFunction input', () => {
     const abiFunc = AbiFunction.from('function transfer(address to, uint256 value)')
     const permission = PermissionBuilder.for(TARGET).forFunction(abiFunc).build()


### PR DESCRIPTION
`PermissionBuilder.forFunction()` parsed human-readable function signatures by splitting the parameter list on commas. Tuple parameters also contain commas, so a signature such as `function test((address,uint256) pair, bool flag)` was split incorrectly and named parameter rules could not find later parameters.

This change reuses `AbiFunction.from(sig).inputs` for the string path, so tuple parameters are parsed the same way as ABI inputs. It also adds a regression test for a tuple parameter followed by a named bool parameter.